### PR TITLE
Restores feature allowing count of specified tags that are not wanted…

### DIFF
--- a/AppInspector/AppMetaData.cs
+++ b/AppInspector/AppMetaData.cs
@@ -119,15 +119,8 @@ namespace Microsoft.AppInspector.Writers
                 }
             }
 
-
-            //TBD: Alternative to use here instead of AnalyzeCommand
-            //What is missed if called here instead of Analyze which may not add duplicates?
-            //allow each record to be tested for presence of customizable preferred tags
-            /*foreach (MatchRecord matchRecord in MatchList)
-            {
-                MetaData.AddStandardProperties(matchRecord);
-            }*/
-
+            MetaData.PrepareReport();
+            
         }
 
 
@@ -600,10 +593,9 @@ namespace Microsoft.AppInspector.Writers
         [JsonProperty(PropertyName = "uniqueMatchesCount")]
         public int UniqueMatchesCount { get { return UniqueTags.Count; } }
         [JsonIgnore]
-        public Dictionary<string, TagCounter> KeyedPropertyCounters { get; }
-        [JsonIgnore]
+        public List<TagCounterUI> TagCountersUI { get; set; }
+        [JsonProperty(PropertyName = "TagCounters")]
         public List<TagCounter> TagCounters { get; }
-        //predefined lists in KeyedPropertyLists for easy retrieval and loose coupling
         [JsonProperty(PropertyName = "packageTypes")]
         public HashSet<string> PackageTypes { get { return KeyedPropertyLists["strGrpPackageTypes"]; } }
         [JsonProperty(PropertyName = "appTypes")]
@@ -706,6 +698,25 @@ namespace Microsoft.AppInspector.Writers
                 AppTypes.Add(solutionType);
 
             return includeAsMatch;
+        }
+
+
+        /// <summary>
+        /// Opportunity for any final data prep before report gen
+        /// </summary>
+        public void PrepareReport()
+        {
+            //TagCountersUI is liquid compatible while TagCounters is not to support json serialization; the split prevents exception
+            //not fixable via json iteration disabling
+            TagCountersUI = new List<TagCounterUI>();
+            foreach (TagCounter counter in TagCounters)
+                TagCountersUI.Add(new TagCounterUI
+                {
+                    Tag = counter.Tag,
+                    ShortTag = counter.ShortTag,
+                    Count = counter.Count
+                });
+
         }
 
     }

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -144,8 +144,13 @@ namespace Microsoft.AppInspector.Commands
             {
                 if (Directory.Exists(rulePath))
                     rulesSet.AddDirectory(rulePath);
-                else
+                else if (File.Exists(rulePath))
                     rulesSet.AddFile(rulePath);
+                else
+                {
+                    WriteOnce.Error(String.Format("Not a valid rule file or directory {0}", rulePath));
+                    throw new Exception(String.Format("Not a valid rule file or directory {0}", rulePath));
+                }
             }
 
             //error check based on ruleset not path enumeration

--- a/AppInspector/Properties/Resources.Designer.cs
+++ b/AppInspector/Properties/Resources.Designer.cs
@@ -61,6 +61,114 @@ namespace ApplicationInspector.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No pattern matches were detected for files in source path.
+        /// </summary>
+        internal static string analyzecmd_nopatternmatches {
+            get {
+                return ResourceManager.GetString("analyzecmd-nopatternmatches", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No rules specified.
+        /// </summary>
+        internal static string analyzecmd_norules {
+            get {
+                return ResourceManager.GetString("analyzecmd-norules", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No file types found in source path that are supported.
+        /// </summary>
+        internal static string analyzecmd_nosupportedfiles {
+            get {
+                return ResourceManager.GetString("analyzecmd-nosupportedfiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to uncompressed.
+        /// </summary>
+        internal static string analyzecmd_notzipped {
+            get {
+                return ResourceManager.GetString("analyzecmd-notzipped", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Preparing report.
+        /// </summary>
+        internal static string analyzecmd_preparingrpt {
+            get {
+                return ResourceManager.GetString("analyzecmd-preparingrpt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}% source files processed.
+        /// </summary>
+        internal static string analyzecmd_processedpcnt {
+            get {
+                return ResourceManager.GetString("analyzecmd-processedpcnt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Analyze command running.
+        /// </summary>
+        internal static string analyzecmd_running {
+            get {
+                return ResourceManager.GetString("analyzecmd-running", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to compressed.
+        /// </summary>
+        internal static string analyzecmd_zipped {
+            get {
+                return ResourceManager.GetString("analyzecmd-zipped", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unsupported.
+        /// </summary>
+        internal static string analyzecmd_zippednospprt {
+            get {
+                return ResourceManager.GetString("analyzecmd-zippednospprt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid {0} argument value.
+        /// </summary>
+        internal static string cmd_invalidarg {
+            get {
+                return ResourceManager.GetString("cmd-invalidarg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid file or directory{0}.
+        /// </summary>
+        internal static string cmd_invalidfileordir {
+            get {
+                return ResourceManager.GetString("cmd-invalidfileordir", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} report completed.
+        /// </summary>
+        internal static string cmd_report {
+            get {
+                return ResourceManager.GetString("cmd-report", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
         internal static byte[] comments {
@@ -71,12 +179,156 @@ namespace ApplicationInspector.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Not a valid rule file or directory.
+        /// </summary>
+        internal static string exportcmd_invalidrule {
+            get {
+                return ResourceManager.GetString("exportcmd-invalidrule", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Export rule tags completed.
+        /// </summary>
+        internal static string exportcmd_report {
+            get {
+                return ResourceManager.GetString("exportcmd-report", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Export unique tags command running.
+        /// </summary>
+        internal static string exportcmd_running {
+            get {
+                return ResourceManager.GetString("exportcmd-running", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
         internal static byte[] languages {
             get {
                 object obj = ResourceManager.GetObject("languages", resourceCulture);
                 return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Critical error processing file {0}.
+        /// </summary>
+        internal static string tagdiffcmd_fileprocesserr {
+            get {
+                return ResourceManager.GetString("tagdiffcmd-fileprocesserr", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No tags found in one or both source paths.
+        /// </summary>
+        internal static string tagdiffcmd_notagfound {
+            get {
+                return ResourceManager.GetString("tagdiffcmd-notagfound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Required [path1] or [path2] argument missing.
+        /// </summary>
+        internal static string tagdiffcmd_requiredfile {
+            get {
+                return ResourceManager.GetString("tagdiffcmd-requiredfile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TagDiff command running.
+        /// </summary>
+        internal static string tagdiffcmd_running {
+            get {
+                return ResourceManager.GetString("tagdiffcmd-running", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Same file passed in for both sources. Test terminated.
+        /// </summary>
+        internal static string tagdiffcmd_samefile {
+            get {
+                return ResourceManager.GetString("tagdiffcmd-samefile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Files were {0} to contain differences.
+        /// </summary>
+        internal static string tagdiffcmd_tagdiffstatus {
+            get {
+                return ResourceManager.GetString("tagdiffcmd-tagdiffstatus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tags in {0} not detected in {1}.
+        /// </summary>
+        internal static string tagdiffcmd_tagsnotfound {
+            get {
+                return ResourceManager.GetString("tagdiffcmd-tagsnotfound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test for all [{0}] in source.
+        /// </summary>
+        internal static string tagdiffcmd_testtype {
+            get {
+                return ResourceManager.GetString("tagdiffcmd-testtype", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found {0} in source.
+        /// </summary>
+        internal static string tagtestcmd_found {
+            get {
+                return ResourceManager.GetString("tagtestcmd-found", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Missing {0} in source.
+        /// </summary>
+        internal static string tagtestcmd_missing {
+            get {
+                return ResourceManager.GetString("tagtestcmd-missing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to None.
+        /// </summary>
+        internal static string tagtestcmd_none {
+            get {
+                return ResourceManager.GetString("tagtestcmd-none", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tagtest for [{0}] in source: {1}.
+        /// </summary>
+        internal static string tagtestcmd_testtype {
+            get {
+                return ResourceManager.GetString("tagtestcmd-testtype", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rule parsing failed for file {0}.
+        /// </summary>
+        internal static string verifycmd_rulefail {
+            get {
+                return ResourceManager.GetString("verifycmd-rulefail", resourceCulture);
             }
         }
     }

--- a/AppInspector/Properties/Resources.resx
+++ b/AppInspector/Properties/Resources.resx
@@ -117,11 +117,95 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="analyzecmd-nopatternmatches" xml:space="preserve">
+    <value>No pattern matches were detected for files in source path</value>
+  </data>
+  <data name="analyzecmd-norules" xml:space="preserve">
+    <value>No rules specified</value>
+  </data>
+  <data name="analyzecmd-nosupportedfiles" xml:space="preserve">
+    <value>No file types found in source path that are supported</value>
+  </data>
+  <data name="analyzecmd-notzipped" xml:space="preserve">
+    <value>uncompressed</value>
+  </data>
+  <data name="analyzecmd-preparingrpt" xml:space="preserve">
+    <value>Preparing report</value>
+  </data>
+  <data name="analyzecmd-processedpcnt" xml:space="preserve">
+    <value>{0}% source files processed</value>
+  </data>
+  <data name="analyzecmd-running" xml:space="preserve">
+    <value>Analyze command running</value>
+  </data>
+  <data name="analyzecmd-zipped" xml:space="preserve">
+    <value>compressed</value>
+  </data>
+  <data name="analyzecmd-zippednospprt" xml:space="preserve">
+    <value>unsupported</value>
+  </data>
+  <data name="cmd-invalidarg" xml:space="preserve">
+    <value>Invalid {0} argument value</value>
+  </data>
+  <data name="cmd-invalidfileordir" xml:space="preserve">
+    <value>Invalid file or directory{0}</value>
+  </data>
+  <data name="cmd-report" xml:space="preserve">
+    <value>{0} report completed</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="comments" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\RulesEngine\Resources\comments.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="exportcmd-invalidrule" xml:space="preserve">
+    <value>Not a valid rule file or directory</value>
+  </data>
+  <data name="exportcmd-report" xml:space="preserve">
+    <value>Export rule tags completed</value>
+  </data>
+  <data name="exportcmd-running" xml:space="preserve">
+    <value>Export unique tags command running</value>
+  </data>
   <data name="languages" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\RulesEngine\Resources\languages.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="tagdiffcmd-fileprocesserr" xml:space="preserve">
+    <value>Critical error processing file {0}</value>
+  </data>
+  <data name="tagdiffcmd-notagfound" xml:space="preserve">
+    <value>No tags found in one or both source paths</value>
+  </data>
+  <data name="tagdiffcmd-requiredfile" xml:space="preserve">
+    <value>Required [path1] or [path2] argument missing</value>
+  </data>
+  <data name="tagdiffcmd-running" xml:space="preserve">
+    <value>TagDiff command running</value>
+  </data>
+  <data name="tagdiffcmd-samefile" xml:space="preserve">
+    <value>Same file passed in for both sources. Test terminated</value>
+  </data>
+  <data name="tagdiffcmd-tagdiffstatus" xml:space="preserve">
+    <value>Files were {0} to contain differences</value>
+  </data>
+  <data name="tagdiffcmd-tagsnotfound" xml:space="preserve">
+    <value>Tags in {0} not detected in {1}</value>
+  </data>
+  <data name="tagdiffcmd-testtype" xml:space="preserve">
+    <value>Test for all [{0}] in source</value>
+  </data>
+  <data name="tagtestcmd-found" xml:space="preserve">
+    <value>Found {0} in source</value>
+  </data>
+  <data name="tagtestcmd-missing" xml:space="preserve">
+    <value>Missing {0} in source</value>
+  </data>
+  <data name="tagtestcmd-none" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="tagtestcmd-testtype" xml:space="preserve">
+    <value>Tagtest for [{0}] in source: {1}</value>
+  </data>
+  <data name="verifycmd-rulefail" xml:space="preserve">
+    <value>Rule parsing failed for file {0}</value>
   </data>
 </root>

--- a/AppInspector/TagInfo.cs
+++ b/AppInspector/TagInfo.cs
@@ -116,7 +116,19 @@ namespace Microsoft.AppInspector.Writers
         }
     }
 
-    public class TagCounter : Drop
+    public class TagCounterUI : Drop
+    {
+        [JsonProperty(PropertyName = "tag")]
+        public string Tag { get; set; }
+        [JsonProperty(PropertyName = "displayName")]
+        public string ShortTag { get; set; }
+        [JsonProperty(PropertyName = "count")]
+        public int Count { get; set; }
+        [JsonProperty(PropertyName = "includeAsMatch")]
+        public bool IncludeAsMatch { get; set; }
+    }
+
+    public class TagCounter 
     {
         [JsonProperty(PropertyName = "tag")]
         public string Tag { get; set; }

--- a/AppInspector/Writers/LiquidWriter.cs
+++ b/AppInspector/Writers/LiquidWriter.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AppInspector.Writers
             hashData.Add("packagetypes", app.MetaData.PackageTypes);
             hashData.Add("ostargets", app.MetaData.OSTargets);
 
-            hashData["tagcounters"] = app.MetaData.TagCounters;
+            hashData["tagcounters"] = app.MetaData.TagCountersUI;
             //foreach (TagCounter counter in app.MetaData.TagCounters)
               //  hashData.Add(counter.Tag, counter.Count);
 

--- a/AppInspector/preferences/tagcounters.json
+++ b/AppInspector/preferences/tagcounters.json
@@ -14,7 +14,7 @@
   {
     "tag": "Metric.Exception.Caught",
     "displayName": "Exceptions",
-    "includeAsMatch": true
+    "includeAsMatch": false
   },
   {
     "tag": "Metric.HTMLForm.Defined",
@@ -24,16 +24,26 @@
   {
     "tag": "Dependency.SourceInclude",
     "displayName": "Dependencies",
+    "includeAsMatch": false
+  },
+  {
+    "tag": "Miscellaneous.CodeHygiene.Comment.Todo",
+    "displayName": "Comments",
+    "includeAsMatch": false
+  },
+  {
+    "tag": "Miscellaneous.CodeHygiene.Comment.Fix",
+    "displayName": "Fix-comments",
     "includeAsMatch": true
   },
   {
-    "tag": "Miscellaneous.CodeHygiene.Comment",
-    "displayName": "Comments",
+    "tag": "Miscellaneous.CodeHygiene.Comment.Suspicious",
+    "displayName": "Suspicious-comments",
     "includeAsMatch": true
   },
   {
     "tag": "Metric.Logging.Call",
     "displayName": "Logging Calls",
-    "includeAsMatch": true
+    "includeAsMatch": false
   }
 ]

--- a/AppInspector/preferences/tagreportgroups.json
+++ b/AppInspector/preferences/tagreportgroups.json
@@ -372,13 +372,13 @@
             "detectedIcon": "fas fa-meteor"
           },
           {
-            "searchPattern": "Comment.Todo",
-            "displayName": "Commment",
+            "searchPattern": "Comment.Fix",
+            "displayName": "Fix Comments",
             "detectedIcon": "far fa-clock"
           },
           {
             "searchPattern": "Comment.Suspicious",
-            "displayName": "Suspicious Comment",
+            "displayName": "Suspicious Comments",
             "detectedIcon": "fas fa-burn"
           }
         ]

--- a/AppInspector/rules/default/general/hygiene.json
+++ b/AppInspector/rules/default/general/hygiene.json
@@ -9,7 +9,24 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "fixme|todo|broke|broken",
+        "pattern": "todo",
+        "type": "regex",
+        "scopes": [ "comment" ],
+        "modifiers": [ "i" ]
+      }
+    ]
+  },
+  {
+    "name": "Hygiene: Fix Comment",
+    "id": "AI010511",
+    "description": "Hygiene: Fix Comment",
+    "tags": [
+      "Miscellaneous.CodeHygiene.Comment.Fix"
+    ],
+    "severity": "moderate",
+    "patterns": [
+      {
+        "pattern": "fixme|broke|broken",
         "type": "regex",
         "scopes": [ "comment" ],
         "modifiers": [ "i" ]
@@ -18,7 +35,7 @@
   },
   {
     "name": "Hygiene: Suspicious Comment",
-    "id": "AI010511",
+    "id": "AI010512",
     "description": "Hygiene: Suspicious Comment",
     "tags": [
       "Miscellaneous.CodeHygiene.Comment.Suspicious"


### PR DESCRIPTION
… in the match details output i.e. classes, functions, exceptions, html forms, comments...Also splits general comments from fix comments.