### PR TITLE
Several key rules/patterns added to address missing auth and auth pat…

### DIFF
--- a/AppInspector/rules/default/cryptography/certificate.json
+++ b/AppInspector/rules/default/cryptography/certificate.json
@@ -19,19 +19,11 @@
         "_comment": "do not include pfx or pem see rule below for x509 client auth"
       },
       {
-        "pattern": "PKCS|PaddingMode",
+        "pattern": "PKCS|PaddingMode|SubjectIdentifier",
         "type": "regex",
         "scopes": [ "code" ],
         "confidence": "high",
         "modifiers": [ "i" ],
-        "_comment": ""
-      },
-      {
-        "pattern": "SubjectIdentifier|CERT_CHAIN_",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
         "_comment": ""
       }
     ]
@@ -47,7 +39,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "WINHTTP.*CERT",
+        "pattern": "_CERT|CERT_",
         "type": "regex",
         "scopes": [
           "code"
@@ -58,7 +50,6 @@
       }
     ]
   },
-
   {
     "name": "Cryptography: x.509 ClientAuth",
     "id": "AI001500",

--- a/AppInspector/rules/default/cryptography/infrastructure-disabled.txt
+++ b/AppInspector/rules/default/cryptography/infrastructure-disabled.txt
@@ -12,22 +12,6 @@
     "rule_info": "",
     "patterns": [
       {
-        "pattern": "SSLCACertificateFile",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
-      {
-        "pattern": "SSLCACertificatePath",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
-      {
         "pattern": "SSLCADNRequestFile",
         "type": "regex",
         "scopes": [ "code" ],
@@ -68,38 +52,6 @@
         "_comment": ""
       },
       {
-        "pattern": "SSLCertificateChainFile",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
-      {
-        "pattern": "SSLCertificateFile",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
-      {
-        "pattern": "SSLCertificateKeyFile",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
-      {
-        "pattern": "SSLCipherSuite",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
-      {
         "pattern": "SSLCompression",
         "type": "regex",
         "scopes": [ "code" ],
@@ -107,14 +59,7 @@
         "modifiers": [ "" ],
         "_comment": ""
       },
-      {
-        "pattern": "SSLCryptoDevice",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
+  
       {
         "pattern": "SSLEngine",
         "type": "regex",
@@ -125,14 +70,6 @@
       },
       {
         "pattern": "SSLFIPS",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
-      {
-        "pattern": "SSLHonorCipherOrder",
         "type": "regex",
         "scopes": [ "code" ],
         "confidence": "high",
@@ -244,22 +181,6 @@
         "_comment": ""
       },
       {
-        "pattern": "SSLProxyCACertificateFile",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
-      {
-        "pattern": "SSLProxyCACertificatePath",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
-      {
         "pattern": "SSLProxyCARevocationCheck",
         "type": "regex",
         "scopes": [ "code" ],
@@ -317,30 +238,6 @@
       },
       {
         "pattern": "SSLProxyEngine",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
-      {
-        "pattern": "SSLProxyMachineCertificateChainFile",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
-      {
-        "pattern": "SSLProxyMachineCertificateFile",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "" ],
-        "_comment": ""
-      },
-      {
-        "pattern": "SSLProxyMachineCertificatePath",
         "type": "regex",
         "scopes": [ "code" ],
         "confidence": "high",

--- a/AppInspector/rules/default/data/processes_xml.json
+++ b/AppInspector/rules/default/data/processes_xml.json
@@ -69,7 +69,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "XslTransform|System.Xml.Xsl|XslCompiledTransform|transformNode",
+        "pattern": "XslTransform|System\\.Xml\\.Xsl|XslCompiledTransform|transformNode",
         "type": "regex",
         "confidence": "high",
         "scopes": [
@@ -89,7 +89,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "TransformerFactory|XSLDocument|javax.xml.transform",
+        "pattern": "TransformerFactory|XSLDocument|javax\\.xml\\.transform",
         "type": "regex",
         "confidence": "high",
         "scopes": [

--- a/AppInspector/rules/default/networkcomms/outbound_network.json
+++ b/AppInspector/rules/default/networkcomms/outbound_network.json
@@ -11,14 +11,14 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "tftp|ntp|imap|snmp|ldap|ldaps|ftps|sftp|ftp|nntp|smtp|telnet|ssh|pop3|gopher",
+        "pattern": "tftp|ntp|imap|snmp|ftps|sftp|ftp|nntp|smtp|telnet|ssh|pop3|gopher",
         "type": "regex",
         "scopes": [
           "code"
         ],
         "modifiers": [ "i" ],
         "confidence": "medium",
-        "_comment": ""
+        "_comment": "don't include auth api's to avoid duplicate reporting"
       }
     ]
   },
@@ -353,7 +353,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "RPC|RemotableTypeclass|System.Runtime.Remoting|RemotingConfiguration|TcpClient|TcpChannel",
+        "pattern": "RPC|RemotableTypeclass|System\\.Runtime\\.Remoting|RemotingConfiguration|TcpClient|TcpChannel",
         "type": "regex",
         "scopes": [
           "code"
@@ -375,7 +375,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "fastrpc|xmlrpc|SimpleXMLRPCServer|jsonrpc|rpc.server|client.rpc",
+        "pattern": "fastrpc|xmlrpc|SimpleXMLRPCServer|jsonrpc|rpc\\.server|client\\.rpc",
         "type": "regex",
         "scopes": [
           "code"
@@ -397,7 +397,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "capnp/ez-rpc.h|rpc/server.h",
+        "pattern": "capnp/ez-rpc\\.h|rpc/server\\.h",
         "type": "regex",
         "scopes": [
           "code"
@@ -419,7 +419,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "RmiServiceExporter|RmiProxyFactoryBean|remoting|jaxrpc|RemoteAccountService|io.grpc|RPCClient",
+        "pattern": "RmiServiceExporter|RmiProxyFactoryBean|remoting|jaxrpc|RemoteAccountService|io\\.grpc|RPCClient",
         "type": "regex",
         "scopes": [
           "code"
@@ -463,7 +463,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "NetworkInterfaceType.Wman|NetworkInterfaceType.Wwanpp|NetworkInterfaceType.Wwanpp2",
+        "pattern": "NetworkInterfaceType\\.Wman|NetworkInterfaceType\\Wwanpp|NetworkInterfaceType\\.Wwanpp2",
         "type": "regex",
         "scopes": [
           "code"

--- a/AppInspector/rules/default/security_feature/authentication.json
+++ b/AppInspector/rules/default/security_feature/authentication.json
@@ -1,64 +1,24 @@
 [
   {
-    "name": "Feature: Authentication",
+    "name": "Feature: Authentication (MicrosoftOnline)",
     "id": "AI034900",
-    "description": "Feature: Authentication",
+    "description": "Feature: Authentication (MicrosoftOnline)",
     "tags": [
-      "Feature.Authentication.General"
+      "Feature.Authentication.MicrosoftOnline"
     ],
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "identity|auth|authenticated|authentication|log(in|on)|log(off|out)|signin|sign-?in|signout|sign-?out",
-        "type": "regex-word",
-        "scopes": [
-          "code"
-        ],
-        "modifications": [ "i" ],
+        "pattern": "login\\.microsoftonline\\.com|SASToken|login\\.live.com|outlook\\.com|SAS Token|Shared Access Signature|AAD",
+        "type": "regex",
+        "scopes": [ "code", "comment" ],
+        "modifiers": [ "i" ],
         "confidence": "high",
         "_comment": ""
       },
       {
-        "pattern": "(username|password|credentials|acct)s?",
-        "type": "regex-word",
-        "scopes": [ "code" ],
-        "modifiers": [ "i" ],
-        "confidence": "high",
-        "_comment": ""
-      }
-    ]
-  },
-  {
-    "name": "Feature: Authentication",
-    "id": "AI035000",
-    "description": "Feature: Authentication",
-    "tags": [
-      "Feature.Authentication.Oauth"
-    ],
-    "severity": "moderate",
-    "patterns": [
-      {
-        "pattern": "oauth2",
-        "type": "regex-word",
-        "scopes": [ "code" ],
-        "modifiers": [ "i" ],
-        "confidence": "high",
-        "_comment": ""
-      }
-    ]
-  },
-  {
-    "name": "Feature: Authentication",
-    "id": "AI035100",
-    "description": "Feature: Authentication",
-    "tags": [
-      "Feature.Authentication.Microsoft"
-    ],
-    "severity": "moderate",
-    "patterns": [
-      {
-        "pattern": "adal|SASToken|login.live.com|outlook.com|SAS Token|Shared Access Signature",
-        "type": "regex",
+        "pattern": "adal",
+        "type": "string",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],
         "confidence": "high",
@@ -67,27 +27,140 @@
     ]
   },
   {
-    "name": "Feature: Authentication",
-    "id": "AI035200",
+    "name": "Feature: Authentication (Oauth)",
+    "id": "AI035000",
     "description": "Feature: Authentication",
     "tags": [
-      "Feature.Authentication.NTLM"
+      "Feature.Authentication.Oauth"
     ],
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "NTLM|WWW-Authenticate: NTLM|windowsAuthentication|CredentialCache.DefaultCredentials|HTTPNtlmAuthHandler|LogonUserA",
+        "pattern": "oauth",
         "type": "regex",
         "scopes": [ "code" ],
         "modifiers": [ "i" ],
         "confidence": "high",
+        "_comment": ""
+      },
+      {
+        "pattern": "auth_*token|access_*token|client_credentials|client_id|client_secret",
+        "type": "regex-word",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "high",
+        "_comment": ""
+      },
+      {
+        "pattern": "Authorization: Bearer",
+        "type": "string",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "high",
+        "_comment": ""
+      },
+      {
+        "pattern": "bearer",
+        "type": "string",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "medium",
+        "_comment": ""
+      }
+    ]
+  },
+  {
+    "name": "Feature: Authentication (Active Directory)",
+    "id": "AI035100",
+    "description": "Feature: Authentication",
+    "tags": [
+      "Feature.Authentication.Windows.AD"
+    ],
+    "severity": "moderate",
+    "patterns": [
+      {
+        "pattern": "active-directory|Active *Directory|ADFS|PrincipleContext|ValidateCredentials",
+        "type": "regex-word",
+        "scopes": [ "code", "comment" ],
+        "modifiers": [ "i" ],
+        "confidence": "high",
+        "_comment": ""
+      },
+      {
+        "pattern": "System.DirectoryServices",
+        "type": "string",
+        "scopes": [ "code", "comment" ],
+        "modifiers": [ "i" ],
+        "confidence": "medium",
+        "_comment": "potentially read only operations"
+      }
+    ]
+  },
+  {
+    "name": "Feature: Authentication (LDAP)",
+    "id": "AI035200",
+    "description": "Feature: Authentication (LDAP)",
+    "tags": [
+      "Feature.Authentication.LDAP"
+    ],
+    "severity": "moderate",
+    "patterns": [
+      {
+        "pattern": "LDAP|ldaps",
+        "type": "regex-word",
+        "scopes": [ "code", "comment" ],
+        "modifiers": [ "i" ],
+        "confidence": "high",
+        "_comment": ""
+      },
+      {
+        "pattern": "LDAP",
+        "type": "sub-string",
+        "scopes": [ "code", "comment" ],
+        "modifiers": [ "i" ],
+        "confidence": "medium",
+        "_comment": ""
+      }
+    ]
+  },
+  {
+    "name": "Feature: Authentication (NTML)",
+    "id": "AI035300",
+    "description": "Feature: Authentication (NTML)",
+    "tags": [
+      "Feature.Authentication.Windows.NTLM"
+    ],
+    "severity": "moderate",
+    "patterns": [
+      {
+        "pattern": "WWW-Authenticate: NTLM|windowsAuthentication|CredentialCache\\.DefaultCredentials|HTTPNtlmAuthHandler",
+        "type": "regex",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "high",
+        "_comment": ""
+      },
+      {
+        "pattern": "LogonUserA|LogonUserEx|LogonUserW",
+        "type": "regex",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "high",
+        "_comment": ""
+      },
+      {
+        "pattern": "NTLM",
+        "type": "string",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "medium",
         "_comment": ""
       }
     ]
   },
   {
     "name": "Feature: Authentication (JWT)",
-    "id": "AI035300",
+    "id": "AI035400",
     "description": "Feature: Authentication (JWT)",
     "tags": [
       "Feature.Authentication.JWT"
@@ -95,10 +168,11 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "jwt",
-        "type": "string",
+        "pattern": "jwt|RFC 7519",
+        "type": "regex-word",
         "scopes": [
-          "code"
+          "code",
+          "comment"
         ],
         "modifications": [ "i" ],
         "confidence": "high",
@@ -108,7 +182,7 @@
   },
   {
     "name": "Feature: Authentication (HTML Form)",
-    "id": "AI035400",
+    "id": "AI035410",
     "description": "Feature: Authentication (HTML Form)",
     "tags": [
       "Feature.Authentication.HTMLForm"
@@ -126,6 +200,77 @@
         "_comment": ""
       }
     ]
+  },
+  {
+    "name": "Feature: Authentication (SAML)",
+    "id": "AI035420",
+    "description": "Feature: Authentication (SAML)",
+    "tags": [
+      "Feature.Authentication.SAML"
+    ],
+    "severity": "moderate",
+    "patterns": [
+      {
+        "pattern": "SAML|saml2",
+        "type": "regex",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "high",
+        "_comment": ""
+      }
+    ]
+  },
+  {
+    "name": "Feature: Authentication (General)",
+    "id": "AI035430",
+    "description": "Feature: Authentication (General)",
+    "tags": [
+      "Feature.Authentication.General"
+    ],
+    "severity": "moderate",
+    "patterns": [
+      {
+        "pattern": "identity|auth|authenticated|authentication|log(in|on)|log(off|out)|signin|sign-?in|signout|sign-?out",
+        "type": "regex-word",
+        "scopes": [
+          "code"
+        ],
+        "modifications": [ "i" ],
+        "confidence": "high",
+        "_comment": ""
+      },
+      {
+        "pattern": "(username|userid|password|passphrase|multi-factor|credential|acct)s?",
+        "type": "regex-word",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "high",
+        "_comment": ""
+      },
+      {
+        "pattern": "Authorization: Basic|WWW-Authenticate",
+        "type": "regex",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "high",
+        "_comment": ""
+      },
+      {
+        "pattern": "connection_*string|conn_*string",
+        "type": "regex",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "medium",
+        "_comment": ""
+      },
+      {
+        "pattern": "federation|sso|networkcredential",
+        "type": "regex-word",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "medium",
+        "_comment": ""
+      }
+    ]
   }
-
 ]

--- a/AppInspector/rules/default/security_feature/authorization.json
+++ b/AppInspector/rules/default/security_feature/authorization.json
@@ -12,7 +12,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "authorize|permission|role|sharedAccessPolicy|storageAccessKey|sharedAccessAccountPolicy|storageAccountOrConnectionString",
+        "pattern": "authorize|authorized|authorization|permission|claim|sharedAccessPolicy|storageAccessKey|sharedAccessAccountPolicy|storageAccountOrConnectionString",
         "type": "regex-word",
         "scopes": [
           "code"
@@ -22,7 +22,16 @@
       },
       {
         "pattern": "SASToken",
-        "type": "regex",
+        "type": "string",
+        "scopes": [
+          "code"
+        ],
+        "modifications": [ "i" ],
+        "confidence": "high"
+      },
+      {
+        "pattern": "RBAC|role",
+        "type": "regex-word",
         "scopes": [
           "code"
         ],

--- a/AppInspector/rules/default/test_frameworks/python_testing.json
+++ b/AppInspector/rules/default/test_frameworks/python_testing.json
@@ -99,8 +99,8 @@
     ],
     "patterns": [
       {
-        "pattern": "import .*nose",
-        "type": "string",
+        "pattern": "import .*nose|nosetests|nose\\.run()",
+        "type": "regex",
         "scopes": [
           "code"
         ],


### PR DESCRIPTION
Several key rules/patterns added to address missing auth and auth patterns for SAML, Oauth, Basic Auth, a missing Microsoft login URL, active directory, LDAP, NTML, and more.  Also corrected few patterns with regex type with '.' but no literal markers.  Some work done on infra file.