### PR TITLE
Scope limit on what type of matches may be read from build files

### DIFF
--- a/AppInspector/ErrorMessage.cs
+++ b/AppInspector/ErrorMessage.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AppInspector
             ANALYZE_UNCOMPRESSED_FILETYPE,
             ANALYZE_UNSUPPORTED_COMPR_TYPE,
             ANALYZE_FILESIZE_SKIPPED,
+            ANALYZE_FILESIZE_HALT,
             ANALYZE_OUTPUT_FILE,
             CMD_PREPARING_REPORT,
             CMD_COMPLETED,

--- a/AppInspector/MatchRecord.cs
+++ b/AppInspector/MatchRecord.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AppInspector
 {
     public class MatchRecord
     {
-        public string Language { get; set; }
+        public LanguageInfo Language { get; set; }
         public string Filename { get; set; }
         public int Filesize { get; set; }
         public string TextSample { get; set; }

--- a/AppInspector/Program.cs
+++ b/AppInspector/Program.cs
@@ -253,7 +253,7 @@ namespace Microsoft.AppInspector
                 if (Logger != null)
                 {
                     WriteOnce.Error(ErrMsg.FormatString(ErrMsg.ID.RUNTIME_ERROR_UNNAMED));
-                    Logger.Error($"Runtime error: {e.StackTrace}");
+                    Logger.Error($"Runtime error: {e.Message} {e.StackTrace}");
                 }
                 else
                     WriteOnce.Error(ErrMsg.FormatString(ErrMsg.ID.RUNTIME_ERROR_PRELOG, e.Message));

--- a/AppInspector/Properties/Resources.Designer.cs
+++ b/AppInspector/Properties/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace ApplicationInspector.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to File size exceeded for {0}.  Analysis halted.  Try unzipping first..
+        /// </summary>
+        internal static string ANALYZE_FILESIZE_HALT {
+            get {
+                return ResourceManager.GetString("ANALYZE_FILESIZE_HALT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to File {0} is too large.  File skipped..
         /// </summary>
         internal static string ANALYZE_FILESIZE_SKIPPED {

--- a/AppInspector/Properties/Resources.resx
+++ b/AppInspector/Properties/Resources.resx
@@ -120,6 +120,9 @@
   <data name="ANALYZE_COMPRESSED_FILETYPE" xml:space="preserve">
     <value>compressed</value>
   </data>
+  <data name="ANALYZE_FILESIZE_HALT" xml:space="preserve">
+    <value>File size exceeded for {0}.  Analysis halted.  Try unzipping first.</value>
+  </data>
   <data name="ANALYZE_FILESIZE_SKIPPED" xml:space="preserve">
     <value>File {0} is too large.  File skipped.</value>
   </data>

--- a/AppInspector/Utils.cs
+++ b/AppInspector/Utils.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AppInspector
                                 result = "script";
                                 break;
                             default:
-                                switch (match.Language)
+                                switch (match.Language.Name)
                                 {
                                     case "ruby":
                                     case "perl":

--- a/AppInspector/Writers/JsonWriter.cs
+++ b/AppInspector/Writers/JsonWriter.cs
@@ -77,7 +77,8 @@ namespace Microsoft.AppInspector
         public MatchItems(MatchRecord matchRecord)
         {
             FileName = matchRecord.Filename;
-            SourceType = matchRecord.Language;
+            SourceLabel = matchRecord.Language.Name;
+            SourceType = matchRecord.Language.Type.ToString();
             StartLocationLine = matchRecord.Issue.StartLocation.Line;
             StartLocationColumn = matchRecord.Issue.StartLocation.Column;
             EndLocationLine = matchRecord.Issue.EndLocation.Line;
@@ -114,6 +115,8 @@ namespace Microsoft.AppInspector
         public string Severity { get; set; }
         [JsonProperty(PropertyName = "tags")]
         public string[] Tags { get; set; }
+        [JsonProperty(PropertyName = "sourceLabel")]
+        public string SourceLabel { get; set; }
         [JsonProperty(PropertyName = "sourceType")]
         public string SourceType { get; set; }
         [JsonProperty(PropertyName = "sample")]

--- a/AppInspector/Writers/SimpleTextWriter.cs
+++ b/AppInspector/Writers/SimpleTextWriter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AppInspector
         public SimpleTextWriter(string formatString)
         {
             if (string.IsNullOrEmpty(formatString))
-                _formatString = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m";
+                _formatString = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,SourceLabel:%l,SourceType:%tLine:%L,Sample:%m";
             else
                 _formatString = formatString;
         }
@@ -155,7 +155,8 @@ namespace Microsoft.AppInspector
         public void WriteMatch(MatchRecord match)
         {
             string output = _formatString.Replace("%F", match.Filename);
-            output = output.Replace("%t", match.Language);
+            output = output.Replace("%l", match.Language.Name);
+            output = output.Replace("%t", match.Language.Type.ToString());
             output = output.Replace("%L", match.Issue.StartLocation.Line.ToString());
             output = output.Replace("%C", match.Issue.StartLocation.Column.ToString());
             output = output.Replace("%l", match.Issue.EndLocation.Line.ToString());

--- a/AppInspector/html/partials/_report_profile.liquid
+++ b/AppInspector/html/partials/_report_profile.liquid
@@ -2,11 +2,11 @@
   <h2>Application Features</h2>
 
   <div>
-    This section reports the major characteristics of the application or its primary features
-    organized by customizable Feature Groups. Click any of the highlighted icons
-    below (indicating at least one match) to view additional details or expand a feature group 
-    for more information. To view where in source code a specific feature was found, click 
-    the Rule name link shown on the right.  A disabled icon indicates a not found status for that feature.
+    This section visually illustrates major characteristics of the application or its primary features
+    organized by Feature Groups. Click any active icon below (indicating at least one match)
+    to view additional details or expand a feature group for more information. Then, click a Rule name shown
+    on the right to view where in source code a specific feature was found.  A disabled icon indicates a not
+    found status for that feature.  The full set of identified tags or features can be found under the Summary menu.
   </div>
 </div>
 <br>

--- a/AppInspector/html/partials/_report_summary.liquid
+++ b/AppInspector/html/partials/_report_summary.liquid
@@ -113,8 +113,9 @@
             <div role="tabpanel" class="tab-pane" id="sorted_uniquetags">
               <h4>Tags List View</h4>
               <div>
-                A simple list view of the unique tags found and matching rule. Click a tag on the left then click
-                the rule name link shown on the right to view the source code location of the match.
+                A complete and simple list view of the unique tags found and matching rule. Click a tag on the left then click
+                the rule name link shown on the right to view the source code location of the match.  See the Features menu
+                for an alternative illustration of the major features detected.
               </div>
               <br>
               <br>

--- a/AppInspector/preferences/tagreportgroups.json
+++ b/AppInspector/preferences/tagreportgroups.json
@@ -89,12 +89,27 @@
       },
       {
         "title": "Development",
-        "dataRef": "Frameworks",
+        "dataRef": "Development",
         "patterns": [
           {
-            "searchPattern": "Development.Build",
+            "searchPattern": "Metadata.Development.Build",
             "displayName": "Build",
             "detectedIcon": "fas fa-building"
+          },
+          {
+            "searchPattern": "Metadata.Development.Repository",
+            "displayName": "Sourcecode Repository",
+            "detectedIcon": "fas fa-archive"
+          },
+          {
+            "searchPattern": "Metadata.Development.PackageManager",
+            "displayName": "Package Manager",
+            "detectedIcon": "fas fa-box-open"
+          },
+          {
+            "searchPattern": "Metadata.Development.CI",
+            "displayName": "Continuous Integration",
+            "detectedIcon": "fas fa-vials"
           },
           {
             "searchPattern": "Framework.Development",
@@ -110,11 +125,6 @@
             "searchPattern": "OpenSourceLicense",
             "displayName": "Open Source",
             "detectedIcon": "fab fa-github"
-          },
-          {
-            "searchPattern": "Dependency.SourceInclude",
-            "displayName": "Source Include",
-            "detectedIcon": "far fa-plus-square"
           },
           {
             "searchPattern": "Framework.CMS",
@@ -153,7 +163,7 @@
             "detectedIcon": "far fa-file-pdf"
           },
           {
-            "searchPattern": "Component.Browser.Messaging.Ajax",
+            "searchPattern": "OS.Network.Connection.Http.Ajax",
             "displayName": "Javascript Ajax",
             "detectedIcon": "fas fa-exchange-alt"
           }        
@@ -215,7 +225,7 @@
             "detectedIcon": "fas fa-user-secret"
           },
           {
-            "searchPattern": "Account",
+            "searchPattern": "Sensitive.UserAccount",
             "displayName": "Account or Membership",
             "detectedIcon": "fas fa-user-circle"
           },
@@ -223,11 +233,6 @@
             "searchPattern": "Sensitive.Financial",
             "displayName": "Financial",
             "detectedIcon": "fas fa-money-bill"
-          },
-          {
-            "searchPattern": "CloudServices.Finance.eCommerce",
-            "displayName": "eCommerce",
-            "detectedIcon": "fas fa-shopping-cart"
           }
         ]
       },
@@ -236,7 +241,7 @@
         "dataRef": "CloudServices",
         "patterns": [
           {
-            "searchPattern": "CloudServices.Hosting.General",
+            "searchPattern": "CloudServices.Hosting",
             "displayName": "Hosting",
             "detectedIcon": "fab fa-microsoft"
           },
@@ -251,21 +256,6 @@
             "detectedIcon": "fab fa-facebook-square"
           },
           {
-            "searchPattern": "CloudServices.Hosting.Repository",
-            "displayName": "Sourcecode Repository",
-            "detectedIcon": "fas fa-archive"
-          },
-          {
-            "searchPattern": "CloudServices.Hosting.PackageManager",
-            "displayName": "Package Manager",
-            "detectedIcon": "fas fa-box-open"
-          },
-          {
-            "searchPattern": "CloudServices.Hosting.CI",
-            "displayName": "Continuous Integration",
-            "detectedIcon": "fas fa-vials"
-          },
-          {
             "searchPattern": "CloudServices.DataStorage",
             "displayName": "Cloud Data Storage",
             "detectedIcon": "fas fa-cloud-download-alt"
@@ -274,6 +264,11 @@
             "searchPattern": "CloudServices.BigData",
             "displayName": "Big Data",
             "detectedIcon": "fas fa-warehouse"
+          },
+          {
+            "searchPattern": "CloudServices.Finance.eCommerce",
+            "displayName": "eCommerce",
+            "detectedIcon": "fas fa-shopping-cart"
           }
         ]
       },
@@ -282,7 +277,7 @@
         "dataRef": "OSIntegration",
         "patterns": [
           {
-            "searchPattern": "Platform.OS",
+            "searchPattern": "Metadata.Platform.OS",
             "displayName": "OS Identification",
             "detectedIcon": "fab fa-linux"
           },

--- a/AppInspector/rules/default/cloud_services/cloud_hosting.json
+++ b/AppInspector/rules/default/cloud_services/cloud_hosting.json
@@ -144,11 +144,11 @@
     ]
   },
   {
-    "name": "Cloud Service: GitHub",
+    "name": "Code Repo: GitHub",
     "id": "AI001200",
-    "description": "Cloud Service: GitHub",
+    "description": "Code Repo: GitHub",
     "tags": [
-      "CloudServices.Repository.GitHub"
+      "Metadata.Development.Repository.GitHub"
     ],
     "severity": "moderate",
     "patterns": [
@@ -162,11 +162,11 @@
     ]
   },
   {
-    "name": "Cloud Service: GitLab",
+    "name": "Code Repo: GitLab",
     "id": "AI001300",
-    "description": "Cloud Service: GitLab",
+    "description": "Code Repo: GitLab",
     "tags": [
-      "CloudServices.Repository.GitLab"
+      "Metadata.Development.Repository.GitLab"
     ],
     "severity": "moderate",
     "patterns": [
@@ -180,11 +180,11 @@
     ]
   },
   {
-    "name": "Cloud Service: BitBucket",
+    "name": "Code Repo: BitBucket",
     "id": "AI001400",
-    "description": "Cloud Service: BitBucket",
+    "description": "Code Repo: BitBucket",
     "tags": [
-      "CloudServices.Repository.BitBucket"
+      "Metadata.Development.Repository.BitBucket"
     ],
     "severity": "moderate",
     "patterns": [
@@ -198,11 +198,11 @@
     ]
   },
   {
-    "name": "Cloud Service: SourceForge",
+    "name": "Code Repo: SourceForge",
     "id": "AI001500",
-    "description": "Cloud Service: SourceForge",
+    "description": "Code Repo: SourceForge",
     "tags": [
-      "CloudServices.Repository.SourceForge"
+      "Metadata.Development.Repository.SourceForge"
     ],
     "severity": "moderate",
     "patterns": [
@@ -216,11 +216,11 @@
     ]
   },
   {
-    "name": "Cloud Service: Savannah",
+    "name": "Code Repo: Savannah",
     "id": "AI001600",
-    "description": "Cloud Service: Savannah",
+    "description": "Code Repo: Savannah",
     "tags": [
-      "CloudServices.Repository.Savannah"
+      "Metadata.Development.Repository.Savannah"
     ],
     "severity": "moderate",
     "patterns": [
@@ -234,11 +234,11 @@
     ]
   },
   {
-    "name": "Cloud Service: NuGet",
+    "name": "Component PackageManager: NuGet",
     "id": "AI001700",
-    "description": "Cloud Service: NuGet",
+    "description": "Component PackageManager: NuGet",
     "tags": [
-      "CloudServices.PackageManager.Microsoft.NuGet"
+      "Metadata.Development.PackageManager.Microsoft.NuGet"
     ],
     "severity": "moderate",
     "patterns": [
@@ -252,11 +252,11 @@
     ]
   },
   {
-    "name": "Cloud Service: NPM",
+    "name": "Component PackageManager: NPM",
     "id": "AI001800",
-    "description": "Cloud Service: NPM",
+    "description": "Component PackageManager: NPM",
     "tags": [
-      "CloudServices.PackageManager.NPM"
+      "Metadata.Development.PackageManager.NPM"
     ],
     "severity": "moderate",
     "patterns": [
@@ -270,11 +270,11 @@
     ]
   },
   {
-    "name": "Cloud Service: PyPI",
+    "name": "Component PackageManager: PyPI",
     "id": "AI001900",
-    "description": "Cloud Service: PyPI",
+    "description": "v: PyPI",
     "tags": [
-      "CloudServices.PackageManager.PyPI"
+      "Metadata.Development.PackageManager.PyPI"
     ],
     "severity": "moderate",
     "patterns": [
@@ -288,11 +288,11 @@
     ]
   },
   {
-    "name": "Cloud Service: LaunchPad",
+    "name": "Component PackageManager: LaunchPad",
     "id": "AI002000",
-    "description": "Cloud Service: LaunchPad",
+    "description": "Component PackageManager: LaunchPad",
     "tags": [
-      "CloudServices.PackageManager.LaunchPad"
+      "Metadata.Development.PackageManager.LaunchPad"
     ],
     "severity": "moderate",
     "patterns": [
@@ -306,14 +306,14 @@
     ]
   },
   {
-    "name": "Cloud Service: Travis.CI",
+    "name": "Development CI: Travis.CI",
     "id": "AI002100",
-    "description": "Cloud Service: Travis.CI",
+    "description": "Development CI: Travis.CI",
     "applies_to": [
       ".travis.yml"
     ],
     "tags": [
-      "CloudServices.CI.TravisCI"
+      "Metadata.Build.CI.TravisCI"
     ],
     "severity": "moderate",
     "patterns": [
@@ -327,14 +327,14 @@
     ]
   },
   {
-    "name": "Cloud Service: Circle CI",
+    "name": "Development CI: Circle CI",
     "id": "AI002200",
-    "description": "Cloud Service: Circle CI",
+    "description": "Development CI: Circle CI",
     "applies_to": [
       "config.yml"
     ],
     "tags": [
-      "CloudServices.CI.CircleCI"
+      "Metadata.Build.CI.CircleCI"
     ],
     "severity": "moderate",
     "patterns": [
@@ -348,14 +348,14 @@
     ]
   },
   {
-    "name": "Cloud Service: Azure Pipelines",
+    "name": "Development CI: Azure Pipelines",
     "id": "AI002300",
-    "description": "Cloud Service: Azure Pipelines",
+    "description": "Development CI: Azure Pipelines",
     "applies_to": [
       "yaml"
     ],
     "tags": [
-      "CloudServices.CI.Microsoft.AzurePipelines"
+      "Metadata.Build.Microsoft.AzurePipelines"
     ],
     "severity": "moderate",
     "patterns": [

--- a/AppInspector/rules/default/components/active_content.json
+++ b/AppInspector/rules/default/components/active_content.json
@@ -11,14 +11,34 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "\\.(swf|flv)|flash",
+        "pattern": "\\.(swf|flv)",
         "type": "regex",
         "scopes": [
           "code",
           "comment"
         ],
         "confidence": "high",
-        "modifiers": [ "i" ],
+        "modifiers": [ "i" ]
+      },
+      {
+        "pattern": "adobe flash",
+        "type": "string",
+        "scopes": [
+          "code",
+          "comment"
+        ],
+        "confidence": "medium",
+        "modifiers": [ "i" ]
+      },
+      {
+        "pattern": "flash",
+        "type": "regex-word",
+        "scopes": [
+          "code",
+          "comment"
+        ],
+        "confidence": "low",
+        "modifiers": [ "i" ]
       }
     ]
   },
@@ -30,8 +50,7 @@
       "c",
       "cpp",
       "csharp",
-      "html",
-      "javascript"
+      "vb"
     ],
     "tags": [
       "Component.Executable.Microsoft.ActiveX"
@@ -39,11 +58,44 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "active-?x|COleControlModule",
+        "pattern": "CoInitialize|CoCreateInstance|comClassInterface|CLSCTX_INPROC_SERVER|ProgId|COleControlModule|ComDefaultInterface|ComVisible|IOleInPlaceObject|IOleControl|IOleObjective",
+        "type": "regex-word",
+        "scopes": [
+          "code",
+          "comment"
+        ],
+        "modifiers": [ "i" ],
+        "confidence": "high"
+      },
+      {
+        "pattern": "active-?x|CreateObject",
         "type": "regex",
         "scopes": [
           "code",
           "comment"
+        ],
+        "modifiers": [ "i" ],
+        "confidence": "medium"
+      }
+    ]
+  },
+  {
+    "name": "Component: Active-X",
+    "id": "AI005010",
+    "description": "Component: Active-X",
+    "applies_to": [
+      "javascript", "typescript"
+    ],
+    "tags": [
+      "Component.Executable.Microsoft.ActiveX"
+    ],
+    "severity": "moderate",
+    "patterns": [
+      {
+        "pattern": "new ActiveXObject",
+        "type": "string",
+        "scopes": [
+          "code"
         ],
         "modifiers": [ "i" ],
         "confidence": "high"

--- a/AppInspector/rules/default/components/load_dll.json
+++ b/AppInspector/rules/default/components/load_dll.json
@@ -10,7 +10,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "ShellExecute|DllImport|Assembly\\.LoadFile|Assembly\\.LoadFrom",
+        "pattern": "DllImport|Assembly\\.LoadFile|Assembly\\.LoadFrom",
         "type": "regex",
         "modifiers": [ "i" ],
         "scopes": [

--- a/AppInspector/rules/default/cryptography/ciphers.json
+++ b/AppInspector/rules/default/cryptography/ciphers.json
@@ -17,7 +17,7 @@
         "confidence": "high"
       },
       {
-        "pattern": "AES-?(128|192|256)",
+        "pattern": "AES-?(128|192|256)|Rijndael",
         "type": "regex-word",
         "scopes": [
           "code"
@@ -94,7 +94,7 @@
     ]
   },
   {
-    "name": "Cryptography: Encryption",
+    "name": "Cryptography: Encryption (RSA)",
     "id": "AI007300",
     "description": "Cryptography: Encryption",
     "applies_to": [
@@ -132,7 +132,7 @@
     ]
   },
   {
-    "name": "Cryptography: Encryption",
+    "name": "Cryptography: Encryption (RSA)",
     "id": "AI007400",
     "description": "Cryptography: Encryption",
     "tags": [
@@ -141,7 +141,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "RSA.*encrypt|RSA.*decrypt|public.*key|private.*key",
+        "pattern": "RSA.*encrypt|RSA.*decrypt|public.?key|private.?key|privkey|pubkey",
         "type": "regex",
         "scopes": [
           "code", "comment"
@@ -154,12 +154,12 @@
         "scopes": [
           "code"
         ],
-        "confidence": "medium"
+        "confidence": "low"
       }
     ]
   },
   {
-    "name": "Cryptography: Encryption",
+    "name": "Cryptography: Encryption (RSA)",
     "id": "AI007500",
     "description": "Cryptography: Encryption",
     "tags": [
@@ -168,7 +168,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "asymmetric|rsa",
+        "pattern": "asymmetric",
         "type": "regex-word",
         "scopes": [
           "code",
@@ -179,11 +179,11 @@
     ]
   },
   {
-    "name": "Cryptography: Encryption",
+    "name": "Cryptography: Encryption (General)",
     "id": "AI007600",
     "description": "Cryptography: Encryption",
     "tags": [
-      "Cryptography.Encryption"
+      "Cryptography.Encryption.General"
     ],
     "severity": "moderate",
     "patterns": [
@@ -195,14 +195,6 @@
           "comment"
         ],
         "confidence": "high"
-      },
-      {
-        "pattern": "DiffieHellman|Rijndael|ECDsa",
-        "type": "regex",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": [ "i", "comment" ],
-        "_comment": ""
       }
     ]
   }

--- a/AppInspector/rules/default/cryptography/extended.json
+++ b/AppInspector/rules/default/cryptography/extended.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Detect Cryptography",
+    "name": "Cryptography: Encryption (General)",
     "id": "AI007900",
     "description": "Detect use of cryptography",
     "recommendation": "",
@@ -9,7 +9,7 @@
       "vb"
     ],
     "tags": [
-      "Cryptography.Encryption"
+      "Cryptography.Encryption.General"
     ],
     "severity": "critical",
     "_comment": "",

--- a/AppInspector/rules/default/cryptography/hash_algorithm.json
+++ b/AppInspector/rules/default/cryptography/hash_algorithm.json
@@ -22,7 +22,7 @@
   {
     "name": "Cryptography: Hash Algorithm (Legacy)",
     "id": "AI008800",
-    "description": "Cryptography: Hash Algorithm Usage (Legacy)",
+    "description": "Cryptography: Hash Algorithm (Legacy)",
     "tags": [
       "Cryptography.HashAlgorithm.Legacy"
     ],
@@ -63,7 +63,7 @@
   {
     "name": "Cryptography: Hash Algorithm (Misc)",
     "id": "AI009000",
-    "description": "Cryptography: Hash Algorithm Usage (Misc)",
+    "description": "Cryptography: Hash Algorithm (Misc)",
     "tags": [
       "Cryptography.HashAlgorithm.Misc"
     ],
@@ -102,11 +102,11 @@
     ]
   },
   {
-    "name": "Cryptography: Hash Algorithm (Misc)",
+    "name": "Cryptography: Hash Algorithm (General)",
     "id": "AI009200",
-    "description": "Cryptography: Hash Algorithm Usage (Misc)",
+    "description": "Cryptography: Hash Algorithm (General)",
     "tags": [
-      "Cryptography.HashAlgorithm.Other"
+      "Cryptography.HashAlgorithm.General"
     ],
     "severity": "moderate",
     "patterns": [

--- a/AppInspector/rules/default/cryptography/key_derivation.json
+++ b/AppInspector/rules/default/cryptography/key_derivation.json
@@ -4,10 +4,17 @@
     "id": "AI009300",
     "description": "Cryptography: Key Derivation",
     "tags": [
-      "Cryptography.KeyDerivation"
+      "Cryptography.KeyDerivation.General"
     ],
     "severity": "moderate",
     "patterns": [
+      {
+        "pattern": "KeyDerivationAlgorithmNames|SampleDeriveKeyMaterialPbkdf|RNGCryptoServiceProvider|Rfc2898DeriveBytes|KeyDerivation|DeriveKey|PasswordDeriveBytes",
+        "type": "regex",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "high"
+      }
     ]
   },
   {
@@ -15,12 +22,13 @@
     "id": "AI009400",
     "description": "Cryptography: Key Derivation (PBKDF1)",
     "tags": [
-      "Cryptography.KeyDerivation.PBKDF1"
+      "Cryptography.KeyDerivation.PBKDF1",
+      "Cryptography.HashAlgorithm.PBKDF1"
     ],
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "pbkdf1|PasswordDeriveBytes",
+        "pattern": "pbkdf1",
         "type": "regex",
         "scopes": [ "code" ],
         "modifiers": [ "i" ],
@@ -33,7 +41,8 @@
     "id": "AI009500",
     "description": "Cryptography: Key Derivation (PBKDF2)",
     "tags": [
-      "Cryptography.KeyDerivation.PBKDF2"
+      "Cryptography.KeyDerivation.PBKDF2",
+      "Cryptography.HashAlgorithm.PBKDF1"
     ],
     "severity": "moderate",
     "patterns": [

--- a/AppInspector/rules/default/cryptography/protocol.json
+++ b/AppInspector/rules/default/cryptography/protocol.json
@@ -167,5 +167,24 @@
         "confidence": "high"
       }
     ]
+  },
+  {
+    "name": "Cryptography: SSH Protocol",
+    "id": "AI009910",
+    "description": "Cryptography: SSH Protocol",
+    "tags": [
+      "Cryptography.Protocol.KeyExchange"
+    ],
+    "severity": "moderate",
+    "patterns": [
+      {
+        "pattern": "DiffieHellman|ECDsa",
+        "type": "regex",
+        "scopes": [ "code" ],
+        "confidence": "high",
+        "modifiers": [ "i", "comment" ],
+        "_comment": ""
+      }
+    ]
   }
 ]

--- a/AppInspector/rules/default/frameworks/build.json
+++ b/AppInspector/rules/default/frameworks/build.json
@@ -3,8 +3,8 @@
     "name": "Development: Build Tool (Maven)",
     "id": "AI016800",
     "description": "Development: Build Tool (Maven)",
-    "applies_to": [ "java" ],
-    "tags": [ "Development.Build.Maven" ],
+    "applies_to": [ "pom.xml" ],
+    "tags": [ "Metadata.Development.Build.Maven" ],
     "severity": "moderate",
     "patterns": [
       {
@@ -20,12 +20,12 @@
     "name": "Development: Build Tool (Ant)",
     "id": "AI016900",
     "description": "Development: Build Tool (Ant)",
-    "applies_to": [ "java" ],
-    "tags": [ "Development.Build.Ant" ],
+    "applies_to": [ "build.xml" ],
+    "tags": [ "Metadata.Development.Build.Ant" ],
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "Ant",
+        "pattern": "target",
         "type": "regex",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],
@@ -37,12 +37,12 @@
     "name": "Development: Build Tool (Gradle)",
     "id": "AI017000",
     "description": "Development: Build Tool (Gradle)",
-    "applies_to": [ "java" ],
-    "tags": [ "Development.Build.Gradle" ],
+    "applies_to": [ "build.gradle" ],
+    "tags": [ "Metadata.Development.Build.Gradle" ],
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "Gradle",
+        "pattern": "sourceSets",
         "type": "regex",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],
@@ -54,12 +54,12 @@
     "name": "Development: Build Tool (Jenkins)",
     "id": "AI017100",
     "description": "Development: Build Tool (Jenkins)",
-    "applies_to": [ "java" ],
-    "tags": [ "Development.Build.Jenkins" ],
+    "applies_to": [ "jenkins" ],
+    "tags": [ "Metadata.Development.Build.Jenkins" ],
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "jenkins",
+        "pattern": "pipeline",
         "type": "string",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],
@@ -71,12 +71,12 @@
     "name": "Development: Build Tool (SBT)",
     "id": "AI017200",
     "description": "Development: Build Tool (SBT)",
-    "applies_to": [ "java" ],
-    "tags": [ "Development.Build.SBT" ],
+    "applies_to": [ "sbt" ],
+    "tags": [ "Metadata.Development.Build.SBT" ],
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "sbt",
+        "pattern": "build",
         "type": "string",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],
@@ -88,12 +88,12 @@
     "name": "Development: Build Tool (Bamboo)",
     "id": "AI017300",
     "description": "Development: Build Tool (Bamboo)",
-    "applies_to": [ "java" ],
-    "tags": [ "Development.Build.Bamboo" ],
+    "applies_to": [ "yaml" ],
+    "tags": [ "Metadata.Development.Build.Bamboo" ],
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "atlassian bamboo",
+        "pattern": "bamboo",
         "type": "string",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],
@@ -106,8 +106,7 @@
     "id": "AI017400",
     "description": "Development: Build Tool (TeamCity)",
     "recommendation": "",
-    "applies_to": [ "java" ],
-    "tags": [ "Development.Build.TeamCity" ],
+    "tags": [ "Metadata.Development.Build.TeamCity" ],
     "severity": "moderate",
     "patterns": [
       {
@@ -124,7 +123,7 @@
     "id": "AI017500",
     "description": "Development: Build Tool (Grape)",
     "applies_to": [ "java" ],
-    "tags": [ "Development.Build.Grape" ],
+    "tags": [ "Metadata.Development.Build.Grape" ],
     "severity": "moderate",
     "patterns": [
       {
@@ -140,8 +139,8 @@
     "name": "Development: Build Tool (Ivy)",
     "id": "AI017600",
     "description": "Development: Build Tool (Ivy)",
-    "applies_to": [ "java" ],
-    "tags": [ "Development.Build.Ivy" ],
+    "applies_to": [ "build.xml" ],
+    "tags": [ "Metadata.Development.Build.Ivy" ],
     "severity": "moderate",
     "patterns": [
       {
@@ -157,13 +156,13 @@
     "name": "Development: Build Tool (Leiningen)",
     "id": "AI017700",
     "description": "Development: Build Tool (Leiningen)",
-    "applies_to": [ "java" ],
-    "tags": [ "Development.Build.Leiningen" ],
+    "applies_to": [ "project.clj" ],
+    "tags": [ "Metadata.Development.Build.Leiningen" ],
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "leiningen",
-        "type": "string",
+        "pattern": "plug-ins|repositories|build|java",
+        "type": "regex-word",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],
         "_comment": ""
@@ -175,7 +174,7 @@
     "id": "AI017800",
     "description": "Development: Build Tool (Studio)",
     "applies_to": [ "VSSolution", "VSProject" ],
-    "tags": [ "Development.Build.VisualStudio" ],
+    "tags": [ "Metadata.Development.Build.VisualStudio" ],
     "severity": "moderate",
     "patterns": [
       {

--- a/AppInspector/rules/default/frameworks/javascript.json
+++ b/AppInspector/rules/default/frameworks/javascript.json
@@ -302,5 +302,31 @@
         "confidence": "high"
       }
     ]
+  },
+  {
+    "name": "Development Framework: Node",
+    "id": "AI021610",
+    "description": "Development Framework: Node",
+    "applies_to": [ "javascript" ],
+    "tags": [
+      "Metadata.ApplicationType.Web.Service"
+    ],
+    "severity": "moderate",
+    "patterns": [
+      {
+        "pattern": "app\\.listen|server\\.listen",
+        "type": "regex",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "high"
+      },
+      {
+        "pattern": "\\.listen\\(",
+        "type": "regex",
+        "scopes": [ "code" ],
+        "modifiers": [ "i" ],
+        "confidence": "medium"
+      }
+    ]
   }
 ]

--- a/AppInspector/rules/default/general/platforms.json
+++ b/AppInspector/rules/default/general/platforms.json
@@ -4,7 +4,7 @@
     "id": "AI028500",
     "description": "Platform: .NET Core",
     "applies_to": [ "VSProject", "csharp" ],
-    "tags": [ "Platform.Microsoft.NETCore" ],
+    "tags": [ "Metadata.Platform.Microsoft.NETCore" ],
     "severity": "moderate",
     "patterns": [
       {
@@ -20,7 +20,7 @@
     "id": "AI028600",
     "description": "Platform: Microsoft .NET Standard",
     "applies_to": [ "VSProject", "csharp" ],
-    "tags": [ "Platform.Microsoft.NETStandard" ],
+    "tags": [ "Metadata.Platform.Microsoft.NETStandard" ],
     "severity": "moderate",
     "patterns": [
       {
@@ -36,7 +36,7 @@
     "id": "AI028700",
     "description": "Platform: Microsoft Mono",
     "applies_to": [ "VSProject", "csharp" ],
-    "tags": [ "Platform.Microsoft.Mono" ],
+    "tags": [ "Metadata.Platform.Microsoft.Mono" ],
     "severity": "moderate",
     "patterns": [
       {
@@ -52,7 +52,7 @@
     "id": "AI028800",
     "description": "Platform: Google Android",
     "tags": [
-      "Platform.OS.Google.Android"
+      "Metadata.Platform.OS.Google.Android"
     ],
     "severity": "moderate",
     "patterns": [
@@ -79,7 +79,7 @@
     "id": "AI028900",
     "description": "Platform: Apple iOS",
     "tags": [
-      "Platform.OS.Apple.iOS"
+      "Metadata.Platform.OS.Apple.iOS"
     ],
     "severity": "moderate",
     "patterns": [
@@ -98,7 +98,7 @@
     "id": "AI029000",
     "description": "Platform: Apple MacOS",
     "tags": [
-      "Platform.OS.Apple.MacOS"
+      "Metadata.Platform.OS.Apple.MacOS"
     ],
     "severity": "moderate",
     "patterns": [
@@ -117,7 +117,7 @@
     "id": "AI029100",
     "description": "Platform: Microsoft Windows Server",
     "tags": [
-      "Platform.OS.Microsoft.WindowsServer"
+      "Metadata.Platform.OS.Microsoft.WindowsServer"
     ],
     "severity": "moderate",
     "patterns": [
@@ -136,7 +136,7 @@
     "id": "AI029200",
     "description": "Platform: Microsoft Windows",
     "tags": [
-      "Platform.OS.Microsoft.WindowsStandard"
+      "Metadata.Platform.OS.Microsoft.WindowsStandard"
     ],
     "severity": "moderate",
     "patterns": [
@@ -156,7 +156,7 @@
     "id": "AI029300",
     "description": "Platform: Microsoft Windows",
     "tags": [
-      "Platform.OS.Microsoft.WindowsCE"
+      "Metadata.Platform.OS.Microsoft.WindowsCE"
     ],
     "severity": "moderate",
     "patterns": [
@@ -175,7 +175,7 @@
     "id": "AI029400",
     "description": "Development Framework: Windows Universal Platform",
     "tags": [
-      "Platform.OS.Microsoft.WindowsUniversalPlatform"
+      "Metadata.Platform.OS.Microsoft.WindowsUniversalPlatform"
     ],
     "severity": "moderate",
     "patterns": [
@@ -193,7 +193,7 @@
     "id": "AI029500",
     "description": "Platform: Linux",
     "tags": [
-      "Platform.OS.Linux.Distro"
+      "Metadata.Platform.OS.Linux.Distro"
     ],
     "severity": "moderate",
     "patterns": [
@@ -212,7 +212,7 @@
     "id": "AI029600",
     "description": "Platform: Microsoft XBox",
     "tags": [
-      "Platform.OS.Microsoft.XBox"
+      "Metadata.Platform.OS.Microsoft.XBox"
     ],
     "severity": "moderate",
     "patterns": [
@@ -231,7 +231,7 @@
     "id": "AI029700",
     "description": "Platform: Mobile Device",
     "tags": [
-      "Platform.Device.Mobile"
+      "Metadata.Platform.Device.Mobile"
     ],
     "severity": "moderate",
     "patterns": [
@@ -266,7 +266,7 @@
     "id": "AI029800",
     "description": "Platform: IOT",
     "tags": [
-      "Platform.Device.IOT"
+      "Metadata.Platform.Device.IOT"
     ],
     "severity": "moderate",
     "patterns": [

--- a/AppInspector/rules/default/os/dynamic_execution.json
+++ b/AppInspector/rules/default/os/dynamic_execution.json
@@ -161,7 +161,7 @@
         "confidence": "high"
       },
       {
-        "pattern": "createprocess|execl|execlp|execlp|execv|execve|execvp|execvpe|execle|fork",
+        "pattern": "shellexecute|createprocess|execl|execlp|execlp|execv|execve|execvp|execvpe|execle|fork",
         "type": "regex-word",
         "scopes": [
           "code"

--- a/AppInspector/rules/default/security_feature/authorization.json
+++ b/AppInspector/rules/default/security_feature/authorization.json
@@ -32,9 +32,9 @@
     ]
   },
   {
-    "name": "Authorization: RBAC",
+    "name": "Authorization: Roles Based Access (RBAC)",
     "id": "AI040300",
-    "description": "Authorization: RBAC",
+    "description": "Authorization: Roles Based Access (RBAC)",
     "applies_to": [
       "common_source_code"
     ],
@@ -55,14 +55,14 @@
     ]
   },
   {
-    "name": "Authorization: RBAC",
+    "name": "Authorization: Permissions",
     "id": "AI040400",
-    "description": "Authorization: RBAC",
+    "description": "Authorization: Permissions",
     "applies_to": [
       "common_source_code"
     ],
     "tags": [
-      "Authorization.RBAC"
+      "Authorization.Permissions"
     ],
     "severity": "critical",
     "patterns": [

--- a/RulesEngine/Language.cs
+++ b/RulesEngine/Language.cs
@@ -39,10 +39,12 @@ namespace RulesEngine
         /// </summary>
         /// <param name="fileName">File name</param>
         /// <returns>Language</returns>
-        public static string FromFileName(string fileName)
+        public static bool FromFileName(string fileName, ref LanguageInfo info)
         {
             if (fileName == null)
-                return string.Empty;
+                return false;
+
+            bool result = false;
 
             string file = Path.GetFileName(fileName).ToLower(CultureInfo.CurrentCulture);
             string ext = Path.GetExtension(file);
@@ -51,7 +53,11 @@ namespace RulesEngine
             foreach (LanguageInfo item in Instance.Languages)
             {
                 if (item.Name == file)
-                    return item.Name;
+                {
+                    info = item;
+                    result = true;
+                    break;
+                }
             }
 
             // Look for extension only ext is defined
@@ -60,11 +66,15 @@ namespace RulesEngine
                 foreach (LanguageInfo item in Instance.Languages)
                 {
                     if (Array.Exists(item.Extensions, x => x.EndsWith(ext)))
-                        return item.Name;
+                    {
+                        info = item;
+                        result = true;
+                        break;
+                    }
                 }
             }
 
-            return string.Empty;
+            return result;
         }
 
         /// <summary>

--- a/RulesEngine/LanguageInfo.cs
+++ b/RulesEngine/LanguageInfo.cs
@@ -8,12 +8,18 @@ namespace RulesEngine
     /// <summary>
     /// Content Type class
     /// </summary>
-    class LanguageInfo
+    public class LanguageInfo
     {
+        public enum LangFileType { Code, Build, Other };
+
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         [JsonProperty(PropertyName = "extensions")]
         public string[] Extensions { get; set; }
+        [JsonProperty(PropertyName = "type")]
+        public LangFileType Type { get; set; }
     }
+
+
 }

--- a/RulesEngine/Resources/languages.json
+++ b/RulesEngine/Resources/languages.json
@@ -1,162 +1,222 @@
 [
   {
     "name": "c",
-    "extensions": [ ".c", ".h" ]
+    "extensions": [ ".c", ".h" ],
+    "type": "code"
   },
   {
     "name": "cpp",
-    "extensions": [ ".cpp", ".hpp", ".cxx" ]
+    "extensions": [ ".cpp", ".hpp", ".cxx" ],
+    "type": "code"
   },
   {
     "name": "csharp",
-    "extensions": [ ".cs", "web.config", "app.config" ]
+    "extensions": [ ".cs" ],
+    "type": "code"
   },
   {
     "name": "fsharp",
-    "extensions": [ ".fs" ]
+    "extensions": [ ".fs" ],
+    "type": "code"
   },
   {
     "name": "vb",
-    "extensions": [ ".vb" ]
+    "extensions": [ ".vb" ],
+    "type": "code"
   },
   {
     "name": "python",
-    "extensions": [ ".py", ".py3", ".pyw" ]
+    "extensions": [ ".py", ".py3", ".pyw" ],
+    "type": "code"
   },
   {
     "name": "html",
-    "extensions": [ ".html", ".htm", ".cshtml", ".tmpl" ]
+    "extensions": [ ".html", ".htm", ".cshtml", ".tmpl" ],
+    "type": "code"
   },
   {
     "name": "javascript",
-    "extensions": [ ".js" ]
+    "extensions": [ ".js" ],
+    "type": "code"
   },
   {
     "name": "javascriptreact",
-    "extensions": [ ".jsx" ]
+    "extensions": [ ".jsx" ],
+    "type": "code"
   },
   {
     "name": "typescript",
-    "extensions": [ ".ts" ]
+    "extensions": [ ".ts" ],
+    "type": "code"
   },
   {
     "name": "typescriptreact",
-    "extensions": [ ".tsx" ]
+    "extensions": [ ".tsx" ],
+    "type": "code"
   },
   {
     "name": "coffeescript",
-    "extensions": [ ".coffee" ]
+    "extensions": [ ".coffee" ],
+    "type": "code"
   },
   {
     "name": "java",
-    "extensions": [ ".java" ]
-  },
-  {
-    "name": "build.gradle",
-    "extensions": [ "build.gradle" ]
-  },
-  {
-    "name": "build.make.xml",
-    "extensions": [ "build.make.xml" ]
-  },
-  {
-    "name": "build.py",
-    "extensions": [ "build.py" ]
+    "extensions": [ ".java" ],
+    "type": "code"
   },
   {
     "name": "objective-c",
-    "extensions": [ ".m", ".mm" ]
+    "extensions": [ ".m", ".mm" ],
+    "type": "code"
   },
   {
     "name": "swift",
-    "extensions": [ ".swift" ]
+    "extensions": [ ".swift" ],
+    "type": "code"
   },
   {
     "name": "perl",
-    "extensions": [ ".pl", ".pm", ".t", ".pod" ]
+    "extensions": [ ".pl", ".pm", ".t", ".pod" ],
+    "type": "code"
   },
   {
     "name": "perl6",
-    "extensions": [ ".pl6", ".p6", ".pm6" ]
+    "extensions": [ ".pl6", ".p6", ".pm6" ],
+    "type": "code"
   },
   {
     "name": "ruby",
-    "extensions": [ ".rb" ]
+    "extensions": [ ".rb" ],
+    "type": "code"
   },
   {
     "name": "lua",
-    "extensions": [ ".lua" ]
+    "extensions": [ ".lua" ],
+    "type": "code"
   },
   {
     "name": "groovy",
-    "extensions": [ ".groovy" ]
+    "extensions": [ ".groovy" ],
+    "type": "code"
   },
   {
     "name": "go",
-    "extensions": [ ".go" ]
+    "extensions": [ ".go" ],
+    "type": "code"
   },
   {
     "name": "rust",
-    "extensions": [ ".rs" ]
+    "extensions": [ ".rs" ],
+    "type": "code"
   },
   {
     "name": "jade",
-    "extensions": [ ".jade" ]
+    "extensions": [ ".jade" ],
+    "type": "code"
   },
   {
     "name": "clojure",
-    "extensions": [ ".clj", ".cljs", ".cljc", ".edn" ]
+    "extensions": [ ".clj", ".cljs", ".cljc", ".edn" ],
+    "type": "code"
   },
   {
     "name": "r",
-    "extensions": [ ".r" ]
-  },
-  {
-    "name": "yaml",
-    "extensions": [ ".yaml", ".yml" ]
+    "extensions": [ ".r" ],
+    "type": "code"
   },
   {
     "name": "php",
-    "extensions": [ ".php" ]
+    "extensions": [ ".php" ],
+    "type": "code"
   },
   {
     "name": "powershell",
-    "extensions": [ ".ps1", ".psm1", ".psd1" ]
+    "extensions": [ ".ps1", ".psm1", ".psd1" ],
+    "type": "code"
   },
   {
     "name": "shellscript",
-    "extensions": [ ".sh" ]
+    "extensions": [ ".sh" ],
+    "type": "code"
   },
   {
     "name": "wincmdscript",
-    "extensions": [ ".bat" ]
+    "extensions": [ ".bat" ],
+    "type": "code"
   },
   {
     "name": "sql",
-    "extensions": [ ".sql" ]
+    "extensions": [ ".sql" ],
+    "type": "code"
   },
   {
-    "name": ".config",
-    "extensions": [ ".config" ]
+    "name": "yaml",
+    "extensions": [ ".yaml", ".yml" ],
+    "type": "build"
   },
   {
     "name": "package.json",
-    "extensions": [ ".json" ]
+    "extensions": [ ".json" ],
+    "type": "build"
   },
   {
     "name": "packages.config",
-    "extensions": [ "packages.config" ]
+    "extensions": [ "packages.config" ],
+    "type": "build"
   },
   {
     "name": "VSSolution",
-    "extensions": [ ".sln" ]
+    "extensions": [ ".sln" ],
+    "type": "build"
   },
   {
     "name": "VSProject",
-    "extensions": [ ".vcxproj", ".ccproj", ".csproj", ".njsproj", ".vbproj" ]
+    "extensions": [ ".vcxproj", ".ccproj", ".csproj", ".njsproj", ".vbproj" ],
+    "type": "build"
   },
   {
     "name": "pom.xml",
-    "extensions": [ "pom.xml" ]
+    "extensions": [ "pom.xml" ],
+    "type": "build"
+  },
+  {
+    "name": "build.xml",
+    "extensions": [ "build.xml" ],
+    "type": "build"
+  },
+  {
+    "name": "build.gradle",
+    "extensions": [ "build.gradle" ],
+    "type": "build"
+  },
+  {
+    "name": "build.make.xml",
+    "extensions": [ "build.make.xml" ],
+    "type": "build"
+  },
+  {
+    "name": "jenkins",
+    "extensions": [ ".hpi" ],
+    "type": "build"
+  },
+  {
+    "name": "project.clj",
+    "extensions": [ ".clj" ],
+    "type": "build"
+  },
+  {
+    "name": "sbt",
+    "extensions": [ ".sbt" ],
+    "type": "build"
+  },
+  {
+    "name": "build.py",
+    "extensions": [ "build.py" ],
+    "type": "build"
+  },
+  {
+    "name": ".config",
+    "extensions": [ ".config" ],
+    "type": "build"
   }
 ]


### PR DESCRIPTION
Puts a scope limit on what type of matches may be read from build files to reduce the possibility of false positive feature matches further.  Features like crypto signing of source files may be found in yaml files but are not true features of the program which should only be accepted from executable code. Other data like target platforms are metadata that is found in build files.  This helps delineate the two better by identifying a type for the language file.  Some pattern improvement for categorizing metadata better and more.