### PR TITLE
Correct casing of PowerShell, JSON, and HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Microsoft Application Inspector is a software source code analysis tool that hel
 
 Application Inspector is different from traditional static analysis tools in that it doesn't attempt to identify "good" or "bad" patterns; it simply reports what it finds against a set of over 400 rule patterns for feature detection including features that impact security such as the use of cryptography and more.  This can be extremely helpful in reducing the time needed to determine what Open Source or other components do by examining the source directly rather than trusting to limited documentation or recommendations.  
 
-The tool supports scanning various programming languages including C, C++, C#, Java, JavaScript, HTML, Python, Objective-C, Go, Ruby, Powershell and [more](https://github.com/microsoft/ApplicationInspector/wiki/2.1-Field:-applies_to-(languages-support)) and includes html, json and text output formats with the default being an html report similar to the one shown here.
+The tool supports scanning various programming languages including C, C++, C#, Java, JavaScript, HTML, Python, Objective-C, Go, Ruby, PowerShell and [more](https://github.com/microsoft/ApplicationInspector/wiki/2.1-Field:-applies_to-(languages-support)) and includes HTML, JSON and text output formats with the default being an HTML report similar to the one shown here.
 
 ![AppInspector-Features](https://user-images.githubusercontent.com/47648296/72893326-9c82c700-3ccd-11ea-8944-9831ea17f3e0.png)
 


### PR DESCRIPTION
If possible, `json based` in the repository description should also be changed to `JSON-based`.