### PR TITLE
Handle space in path when opening output.html

### DIFF
--- a/AppInspector/Utils.cs
+++ b/AppInspector/Utils.cs
@@ -140,7 +140,7 @@ namespace Microsoft.AppInspector
                 {
                     try
                     {
-                        Process.Start("xdg-open", url);
+                        Process.Start("xdg-open", "\"" + url + "\"");
                         WriteOnce.General(ErrMsg.GetString(ErrMsg.ID.BROWSER_START_SUCCESS));
                     }
                     catch (Exception)
@@ -157,7 +157,7 @@ namespace Microsoft.AppInspector
             {
                 try
                 {
-                    Process.Start("open", url);
+                    Process.Start("open", "\"" + url + "\"");
                     WriteOnce.General(ErrMsg.GetString(ErrMsg.ID.BROWSER_START_SUCCESS));
                 }
                 catch (Exception)


### PR DESCRIPTION
When running the AppInspector from a directory with a space in the path, opening the resulting `output.html` fails as follows:

```
Opening default browser to output.html report
Analyze command completed
The files /Users/johnmccabe/workspace/github/microsoft/ApplicationInspector and /Users/johnmccabe/workspace/github/microsoft/ApplicationInspector 1/AppInspector/bin/Release/netcoreapp3.0/osx-x64/publish/1/AppInspector/bin/Release/netcoreapp3.0/osx-x64/publish/output.html do not exist.
```

This PR wraps the URL in quotes to handle the presence of spaces.