### PR TITLE
Package "rules" Folder with Library, Update Descriptions

### DIFF
--- a/AppInspector.CLI/AppInspector.CLI.csproj
+++ b/AppInspector.CLI/AppInspector.CLI.csproj
@@ -10,7 +10,7 @@
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Version>0.0.0-placeholder</Version>
-    <Description>Command line tool for GUI launch of Application Inspector</Description>
+    <Description>Microsoft Application Inspector is a software source code analysis tool that helps identify and surface well-known features and other interesting characteristics of source code to aid in determining what the software is or what it does. This is a dotnet tool package. For the library, see Microsoft.CST.ApplicationInspector.</Description>
     <FileVersion>0.0.0.0</FileVersion>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/AppInspector/AppInspector.Commands.csproj
+++ b/AppInspector/AppInspector.Commands.csproj
@@ -86,6 +86,7 @@
   <ItemGroup>
     <None Include="..\LICENSE.txt" Pack="true" PackagePath=""/>
     <None Include="..\icon-128.png" Pack="true" PackagePath=""/>
+    <None Update="rules\**" Pack="true" PackagePath="lib\$(TargetFramework)\"/>
   </ItemGroup>
 
 </Project>

--- a/AppInspector/AppInspector.Commands.csproj
+++ b/AppInspector/AppInspector.Commands.csproj
@@ -8,7 +8,7 @@
     <PackageProjectUrl>https://github.com/microsoft/ApplicationInspector</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/ApplicationInspector</RepositoryUrl>
     <PackageTags>Security Static Analyzer</PackageTags>
-    <Description>Characterizes software features.</Description>
+    <Description>Microsoft Application Inspector is a software source code analysis tool that helps identify and surface well-known features and other interesting characteristics of source code to aid in determining what the software is or what it does.</Description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright> 
     <HighEntropyVA>true</HighEntropyVA>
     <Product>Application Inspector</Product>


### PR DESCRIPTION
Updated AppInspector.Commands.csproj to include a copy of the "rules" folder when packaging for NuGet. Also taking this opportunity to update the package descriptions for clarity.

Fixes #157 