### PR TITLE
Nuget dll default args

### DIFF
--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ApplicationInspector.CLI
         static public Logger Logger { get; set; }
 
         /// <summary>
-        /// Program entry point which defines command verbs and options to running
+        /// CLI program entry point which defines command verbs and options to running
         /// </summary>
         /// <param name="args"></param>
         static int Main(string[] args)
@@ -26,7 +26,6 @@ namespace Microsoft.ApplicationInspector.CLI
             int finalResult = -1;
 
             WriteOnce.Verbosity = WriteOnce.ConsoleVerbosity.Medium;
-
             try
             {
                 WriteOnce.Info(Utils.GetVersionString());

--- a/AppInspector.CLI/Properties/launchSettings.json
+++ b/AppInspector.CLI/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "AppInspector.CLI": {
-      "commandName": "Project",
-      "commandLineArgs": "analyze -s c:\\temp\\main.cpp"
+      "commandName": "Project"
     }
   }
 }

--- a/AppInspector.CLI/preferences/tagreportgroups.json
+++ b/AppInspector.CLI/preferences/tagreportgroups.json
@@ -375,7 +375,7 @@
             "detectedIcon": "fas fa-play-circle"
           },
           {
-            "searchPattern": "Data.Compressed",
+            "searchPattern": "Data.Zipfile",
             "displayName": "Zip file processing",
             "detectedIcon": "far fa-file-archive"
           },

--- a/AppInspector/Commands/AllCommandOptions.cs
+++ b/AppInspector/Commands/AllCommandOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
         [Option('l', "log-file-path", Required = false, HelpText = "Log file path")]
         public string LogFilePath { get; set; }
-        [Option('v', "log-file-level", Required = false, HelpText = "Log file level [Debug|Info|Warn|Error|Fatal|Off]", Default = "Error")]
+        [Option('v', "log-file-level", Required = false, HelpText = "Log file level [Debug|Info|Warn|Error|Trace|Fatal|Off]", Default = "Error")]
         public string LogFileLevel { get; set; }
 
     }

--- a/AppInspector/rules/default/data_handling/compressed_files.json
+++ b/AppInspector/rules/default/data_handling/compressed_files.json
@@ -9,15 +9,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "\\.(zip|gz|gzip|gem|tar|tgz|tar.gz|xz|7z)",
-        "type": "regex",
-        "scopes": [ "code", "comment" ],
-        "modifiers": [ "i" ],
-        "confidence": "high",
-        "_comment": ""
-      },
-      {
-        "pattern": "zip|gz|gzip|gem|tar|tgz|tar\\.gz|xz|7z",
+        "pattern": "\\.(zip|gz|gzip|gem|tar|tgz|tar\\.gz|xz|7z)",
         "type": "regex-word",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],


### PR DESCRIPTION
Simplifies caller ability to use as DLL with new default arg support previously only set when used via CLI entry point.  Minor cleanup of file output for tagdiff command to remove analyze command output from file.