### PR TITLE
Update pipeline with latest version of netcore 3.1

### DIFF
--- a/Pipelines/core-pipeline.yml
+++ b/Pipelines/core-pipeline.yml
@@ -35,7 +35,7 @@ stages:
     - task: UseDotNet@2
       inputs:
         packageType: 'sdk'
-        version: '3.1.100'
+        version: '3.1.x'
     - script: 'dotnet tool install -g nbgv'
       displayName: 'Install GitVersioning'
     - task: PowerShell@2
@@ -91,7 +91,7 @@ stages:
     - task: UseDotNet@2
       inputs:
         packageType: 'sdk'
-        version: '3.1.100'
+        version: '3.1.x'
     - script: 'dotnet tool install -g nbgv'
       displayName: 'Install GitVersioning'
     - task: PowerShell@2
@@ -182,7 +182,7 @@ stages:
     - task: UseDotNet@2
       inputs:
         packageType: 'sdk'
-        version: '3.1.100'
+        version: '3.1.x'
     - script: 'dotnet tool install -g nbgv'
       displayName: 'Install GitVersioning'
     - task: PowerShell@2


### PR DESCRIPTION
Update pipeline to always use latest version of netcore 3.1 when building.

@guyacosta Feel free to squash and merge when ready.