### PR TITLE
Reviewed the rules. Removed some duplicates and fixed some typos.

### DIFF
--- a/AppInspector/rules/default/cryptography/algorithm_implementation.json
+++ b/AppInspector/rules/default/cryptography/algorithm_implementation.json
@@ -1,24 +1,5 @@
 [
   {
-    "name": "Cryptography: Algorithm Implementation",
-    "id": "AI005700",
-    "description": "Cryptography: Algorithm Implementation",
-    "tags": [
-      "Cryptography.Implementation"
-    ],
-    "severity": "important",
-    "_comment": "Implementing a standard cryptographic algorithm",
-    "patterns": [
-      {
-        "pattern": "5a827999",
-        "type": "regex-word",
-        "scopes": [ "code" ],
-        "confidence": "high",
-        "modifiers": []
-      }
-    ]
-  },
-  {
     "name": "Cryptography: Algorithm Implementation (SHA1)",
     "id": "AI005800",
     "description": "Cryptography: Algorithm Implementation (SHA1)",

--- a/AppInspector/rules/default/cryptography/crypto_currency.json
+++ b/AppInspector/rules/default/cryptography/crypto_currency.json
@@ -1,8 +1,8 @@
 [
   {
-    "name": "Cryptograpy: CryptoCurrency",
+    "name": "Cryptography: CryptoCurrency",
     "id": "AI007700",
-    "description": "Cryptograpy: CryptoCurrency",
+    "description": "Cryptography: CryptoCurrency",
     "tags": [
       "Cryptography.CryptoCurrency"
     ],
@@ -16,7 +16,7 @@
         "confidence": "high"
       },
       {
-        "pattern": "p2pool|miner|ripple|nxt|zcash|tether|ether|btc|monero|markleroot|xmr|eth",
+        "pattern": "p2pool|miner|ripple|nxt|zcash|tether|ether|btc|monero|merkleroot|xmr|eth",
         "type": "regex-word",
         "scopes": [ "code" ],
         "modifiers": [ "i" ],

--- a/AppInspector/rules/default/cryptography/external_libraries.json
+++ b/AppInspector/rules/default/cryptography/external_libraries.json
@@ -1,8 +1,8 @@
 [
   {
-    "name": "Crypographic Library: BouncyCastle",
+    "name": "Cryptographic Library: BouncyCastle",
     "id": "AI008000",
-    "description": "Crypographic Library: BouncyCastle",
+    "description": "Cryptographic Library: BouncyCastle",
     "applies_to": [
       "csharp",
       "java",
@@ -24,9 +24,9 @@
     ]
   },
   {
-    "name": "Crypographic Library: mbed TLS",
+    "name": "Cryptographic Library: mbed TLS",
     "id": "AI008100",
-    "description": "Crypographic Library: mbed TLS",
+    "description": "Cryptographic Library: mbed TLS",
     "applies_to": [
     ],
     "tags": [
@@ -44,9 +44,9 @@
     ]
   },
   {
-    "name": "Crypographic Library: OpenSSL",
+    "name": "Cryptographic Library: OpenSSL",
     "id": "AI008200",
-    "description": "Crypographic Library: OpenSSL",
+    "description": "Cryptographic Library: OpenSSL",
     "applies_to": [
     ],
     "tags": [
@@ -64,9 +64,9 @@
     ]
   },
   {
-    "name": "Crypographic Library: BoringSSL",
+    "name": "Cryptographic Library: BoringSSL",
     "id": "AI008300",
-    "description": "Crypographic Library: BoringSSL",
+    "description": "Cryptographic Library: BoringSSL",
     "applies_to": [
     ],
     "tags": [
@@ -84,9 +84,9 @@
     ]
   },
   {
-    "name": "Crypographic Library: LibreSSL",
+    "name": "Cryptographic Library: LibreSSL",
     "id": "AI008400",
-    "description": "Crypographic Library: LibreSSL",
+    "description": "Cryptographic Library: LibreSSL",
     "applies_to": [
     ],
     "tags": [
@@ -104,9 +104,9 @@
     ]
   },
   {
-    "name": "Crypographic Library: Win32",
+    "name": "Cryptographic Library: Win32",
     "id": "AI008500",
-    "description": "Crypographic Library: Win32",
+    "description": "Cryptographic Library: Win32",
     "applies_to": [
     ],
     "tags": [
@@ -124,9 +124,9 @@
     ]
   },
   {
-    "name": "Crypographic Library: .NET",
+    "name": "Cryptographic Library: .NET",
     "id": "AI008600",
-    "description": "Crypographic Library: .NET",
+    "description": "Cryptographic Library: .NET",
     "applies_to": [
       "c",
       "cpp",

--- a/AppInspector/rules/default/cryptography/random.json
+++ b/AppInspector/rules/default/cryptography/random.json
@@ -1,8 +1,8 @@
 [
   {
-    "name": "Crypgraphy: PRNG",
+    "name": "Cryptography: PRNG",
     "id": "AI010000",
-    "description": "Crypgraphy: PRNG",
+    "description": "Cryptography: PRNG",
     "tags": [
       "Cryptography.Randomness.PRNG"
     ],
@@ -42,9 +42,9 @@
     ]
   },
   {
-    "name": "Crypgraphy: PRNG",
+    "name": "Cryptography: PRNG",
     "id": "AI010100",
-    "description": "Crypgraphy: PRNG",
+    "description": "Cryptography: PRNG",
     "tags": [
       "Cryptography.Randomness.PRNG"
     ],
@@ -65,9 +65,9 @@
     ]
   },
   {
-    "name": "Crypgraphy: PRNG",
+    "name": "Cryptography: PRNG",
     "id": "AI010200",
-    "description": "Crypgraphy: PRNG",
+    "description": "Cryptography: PRNG",
     "tags": [
       "Cryptography.Randomness.PRNG"
     ],
@@ -87,9 +87,9 @@
     ]
   },
   {
-    "name": "Crypgraphy: PRNG",
+    "name": "Cryptography: PRNG",
     "id": "AI010300",
-    "description": "Crypgraphy: PRNG",
+    "description": "Cryptography: PRNG",
     "tags": [
       "Cryptography.Randomness.PRNG"
     ],
@@ -109,9 +109,9 @@
     ]
   },
   {
-    "name": "Crypgraphy: PRNG",
+    "name": "Cryptography: PRNG",
     "id": "AI010400",
-    "description": "Crypgraphy: PRNG",
+    "description": "Cryptography: PRNG",
     "tags": [
       "Cryptography.Randomness.PRNG"
     ],

--- a/AppInspector/rules/default/data_types/financial.json
+++ b/AppInspector/rules/default/data_types/financial.json
@@ -54,7 +54,7 @@
     ],
     "patterns": [
       {
-        "pattern": "currency|usd|money|dollar|coins|euro|peso|deuch-mark|dinar|franc|krone|pound|rupee|shekel|yen",
+        "pattern": "currency|usd|money|dollar|coins|euro|peso|deutsche-mark|dinar|franc|krone|pound|rupee|shekel|yen",
         "type": "regex-word",
         "scopes": [ "code" ],
         "modifiers": [ "i" ],

--- a/AppInspector/rules/default/data_types/secrets.json
+++ b/AppInspector/rules/default/data_types/secrets.json
@@ -9,7 +9,7 @@
     "severity": "critical",
     "patterns": [
       {
-        "pattern": "username|userid|passphrase|secret|password|credential|credentials|access_token",
+        "pattern": "username|userid|passphrase|secret|credential|credentials",
         "type": "regex-word",
         "scopes": [
           "code"

--- a/AppInspector/rules/default/data_types/sensitive.json
+++ b/AppInspector/rules/default/data_types/sensitive.json
@@ -16,7 +16,7 @@
         "confidence": "high"
       },
       {
-        "pattern": "birthdate|ethnicity|gender|citizenship|nationality|martial|marriage|married|spouce|mother|father",
+        "pattern": "birthdate|ethnicity|gender|citizenship|nationality|martial|marriage|married|spouse|mother|father",
         "type": "regex",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],

--- a/AppInspector/rules/default/frameworks/python.json
+++ b/AppInspector/rules/default/frameworks/python.json
@@ -19,11 +19,11 @@
     ]
   },
   {
-    "name": "Development Framework: Pryamid",
+    "name": "Development Framework: Pyramid",
     "id": "AI023900",
-    "description": "Development Framework: Pryamid",
+    "description": "Development Framework: Pyramid",
     "applies_to": [ "python" ],
-    "tags": [ "Framework.Development.Pryamid" ],
+    "tags": [ "Framework.Development.Pyramid" ],
     "severity": "moderate",
     "patterns": [
       {
@@ -31,7 +31,7 @@
         "type": "string",
         "scopes": [ "code" ],
         "modifiers": [ "i" ],
-        "confidence": "high",
+        "confidence": "high"
       }
     ]
   },

--- a/AppInspector/rules/default/general/code_metrics.json
+++ b/AppInspector/rules/default/general/code_metrics.json
@@ -7,7 +7,7 @@
       "Metric.Code.Class.Defined"
     ],
     "severity": "moderate",
-    "applies_to": [ "csharp", "cpp", "javascript", "pyton", "vb", "rust", "ruby", "groovy", "php" ],
+    "applies_to": [ "csharp", "cpp", "javascript", "python", "vb", "rust", "ruby", "groovy", "php" ],
     "patterns": [
       {
         "pattern": "class",


### PR DESCRIPTION
* `cryptography`
    * `algorithm_implementation.json`: First and second rules are the same. They both look for a SHA1 constant.
        * Removed the first rule.
    * `crypto_currency.json`: `markleroot` -> `merkleroot`
    * `external_libraries.json`: `Crypographic` -> `Cryptographic`.
    * `random.json`: `Crypgraphy` -> `Cryptography`.
    * `crypto_currency.json`: `Cryptograpy` to `Cryptography`.
* `data_types`
    * `secrets.json`: `password` and `access_token` are repeated in the patterns of the same rule on lines 12 and 30.
        * Removed `password` and `access_token` from line 12.
    * `sensitive.json`: `spouce` -> `spouse`.
    * `financial.json`: `deuch-mark` -> `deutsche-mark`
* `frameworks/python.json`:
    * `Pryamid` -> `Pyramid`.
    * Line 34 - remove trailing comma. `"confidence": "high",` -> `"confidence": "high"`.
* `general`
    * `code_metrics.json`: `pyton` to `python`.

-----

Verified the rules.

```
$ ApplicationInspector.CLI.exe verifyrules -i -r \removed\local\path\to\ApplicationInspector\AppInspector\rules\default
Microsoft Application Inspector 1.1.10+8d4d8e826d
Verify Rules command running
Verify rules succeeded
Verify Rules command completed
```