### PR TITLE
Improves rethrow exceptions from throw e; to just throw; to avoid los…

### DIFF
--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -115,7 +115,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     Utils.Logger = null;
                     WriteOnce.Log = null;
                 }
-                throw e;
+                throw;
             }
 
             _uniqueTagsControl = new HashSet<string>();
@@ -326,7 +326,7 @@ namespace Microsoft.ApplicationInspector.Commands
         public override int Run()
         {
             WriteOnce.SafeLog("AnalyzeCommand::Run", LogLevel.Trace);
-            WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_RUNNING, "Analyze"));
+            WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_RUNNING, "analyze"));
 
             try
             {
@@ -369,7 +369,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     WriteOnce.Error(ErrMsg.GetString(ErrMsg.ID.ANALYZE_NOPATTERNS));
                 else
                 {
-                    WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_COMPLETED, "Analyze"));
+                    WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_COMPLETED, "analyze"));
                     if (!_arg_autoBrowserOpen)
                         WriteOnce.Any(ErrMsg.FormatString(ErrMsg.ID.ANALYZE_OUTPUT_FILE, "output.html"), true, ConsoleColor.Gray, WriteOnce.ConsoleVerbosity.Low);
                 }
@@ -381,7 +381,7 @@ namespace Microsoft.ApplicationInspector.Commands
                 if (Utils.CLIExecutionContext)
                     return (int)ExitCode.CriticalError;
                 else
-                    throw e;
+                    throw;
             }
             finally
             {
@@ -609,7 +609,7 @@ namespace Microsoft.ApplicationInspector.Commands
              * space, so we'll find the smallest number of spaces at the beginning of
              * each line and use that.
              */
-            var n = (int)Math.Floor(Math.Log10(excerptEndLine) + 1);
+
             var minSpaces = -1;
             for (var i = excerptStartLine; i <= excerptEndLine; i++)
             {
@@ -650,7 +650,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     if (_arg_consoleVerbosityLevel.ToLower() != "none")
                     {
                         if (!String.IsNullOrEmpty(_arg_outputFile) && Utils.CLIExecutionContext)
-                            WriteOnce.Any(ErrMsg.FormatString(ErrMsg.ID.ANALYZE_OUTPUT_FILE, _arg_outputFile), true, ConsoleColor.Gray, WriteOnce.ConsoleVerbosity.Medium);
+                            WriteOnce.Info(ErrMsg.FormatString(ErrMsg.ID.ANALYZE_OUTPUT_FILE, _arg_outputFile), true, WriteOnce.ConsoleVerbosity.Medium, false);
                         else
                             WriteOnce.NewLine();
                     }
@@ -710,11 +710,11 @@ namespace Microsoft.ApplicationInspector.Commands
                 }
 
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 string errmsg = ErrMsg.FormatString(ErrMsg.ID.ANALYZE_COMPRESSED_ERROR, filename);
                 WriteOnce.Error(errmsg);
-                throw e;
+                throw;
             }
 
         }
@@ -763,10 +763,10 @@ namespace Microsoft.ApplicationInspector.Commands
                     return false;
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 WriteOnce.Error(ErrMsg.FormatString(ErrMsg.ID.CMD_INVALID_FILE_OR_DIR, filePath));
-                throw e;
+                throw;
             }
 
             return true;

--- a/AppInspector/Commands/PackRulesCommand.cs
+++ b/AppInspector/Commands/PackRulesCommand.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     Utils.Logger = null;
                     WriteOnce.Log = null;
                 }
-                throw e;
+                throw;
             }
         }
 
@@ -134,7 +134,7 @@ namespace Microsoft.ApplicationInspector.Commands
         public override int Run()
         {
             WriteOnce.SafeLog("PackRules::Run", LogLevel.Trace);
-            WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_RUNNING, "PackRules"));
+            WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_RUNNING, "packrules"));
 
             try
             {
@@ -154,7 +154,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     fs.Close();
                 }
 
-                WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_COMPLETED, "PackRules"));
+                WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_COMPLETED, "packrules"));
                 WriteOnce.Any(ErrMsg.FormatString(ErrMsg.ID.ANALYZE_OUTPUT_FILE, _arg_outputfile), true, ConsoleColor.Gray, WriteOnce.ConsoleVerbosity.Medium);
                 WriteOnce.FlushAll();
             }
@@ -165,7 +165,7 @@ namespace Microsoft.ApplicationInspector.Commands
                 if (Utils.CLIExecutionContext)
                     return (int)ExitCode.CriticalError;
                 else
-                    throw e;
+                    throw;
             }
             finally
             {

--- a/AppInspector/Commands/TagDiffCommand.cs
+++ b/AppInspector/Commands/TagDiffCommand.cs
@@ -70,7 +70,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     Utils.Logger = null;
                     WriteOnce.Log = null;
                 }
-                throw e;
+                throw;
             }
         }
 
@@ -161,7 +161,7 @@ namespace Microsoft.ApplicationInspector.Commands
         public override int Run()
         {
             WriteOnce.SafeLog("TagDiffCommand::Run", LogLevel.Trace);
-            WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_RUNNING, "Tagdiff"));
+            WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_RUNNING, "tagdiff"));
 
             ExitCode exitCode = ExitCode.CriticalError;
             //save to quiet analyze cmd and restore
@@ -264,9 +264,9 @@ namespace Microsoft.ApplicationInspector.Commands
 
                     WriteOnce.General(ErrMsg.FormatString(ErrMsg.ID.TAGDIFF_RESULTS_DIFFER), false);
                     WriteOnce.Result(resultsDiffer.ToString());
-                    WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_COMPLETED, "Tagdiff"));
+                    WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_COMPLETED, "tagdiff"));
                     if (!String.IsNullOrEmpty(_arg_outputFile) && Utils.CLIExecutionContext)
-                        WriteOnce.Any(ErrMsg.FormatString(ErrMsg.ID.ANALYZE_OUTPUT_FILE, _arg_outputFile), true, ConsoleColor.Gray, WriteOnce.ConsoleVerbosity.Low);
+                        WriteOnce.Info(ErrMsg.FormatString(ErrMsg.ID.ANALYZE_OUTPUT_FILE, _arg_outputFile), true, WriteOnce.ConsoleVerbosity.Low, false);
 
                     WriteOnce.FlushAll();
                 }
@@ -294,7 +294,7 @@ namespace Microsoft.ApplicationInspector.Commands
                 if (Utils.CLIExecutionContext)
                     return (int)ExitCode.CriticalError;
                 else
-                    throw e;
+                    throw;
             }
             finally
             {

--- a/AppInspector/Commands/TagTestCommand.cs
+++ b/AppInspector/Commands/TagTestCommand.cs
@@ -68,7 +68,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     Utils.Logger = null;
                     WriteOnce.Log = null;
                 }
-                throw e;
+                throw;
             }
         }
 
@@ -221,7 +221,6 @@ namespace Microsoft.ApplicationInspector.Commands
                 analyzeCmdResult = (AnalyzeCommand.ExitCode)cmd1.Run();
 
                 //must be done here to avoid losing our handle from analyze command overwriting WriteOnce.Writer
-                _arg_outputFile ??= "output.json";
                 ConfigureFileOutput();
 
                 //restore
@@ -239,7 +238,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     else
                         WriteOnce.Any(ErrMsg.GetString(ErrMsg.ID.TAGTEST_RESULTS_SUCCESS), true, ConsoleColor.Green, WriteOnce.ConsoleVerbosity.Low);
 
-                    WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_COMPLETED, "Tagtest"));
+                    WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_COMPLETED, "tagtest"));
 
                     exitCode = _arg_tagTestType == TagTestType.RulesPresent ? ExitCode.SomeTagsFailed : ExitCode.TagsTestSuccess;
                 }
@@ -287,7 +286,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
                     WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_COMPLETED, "Tagtest"));
                     if (!String.IsNullOrEmpty(_arg_outputFile) && Utils.CLIExecutionContext)
-                        WriteOnce.Any(ErrMsg.FormatString(ErrMsg.ID.ANALYZE_OUTPUT_FILE, _arg_outputFile), true, ConsoleColor.Gray, WriteOnce.ConsoleVerbosity.Low);
+                        WriteOnce.Info(ErrMsg.FormatString(ErrMsg.ID.ANALYZE_OUTPUT_FILE, _arg_outputFile), true, WriteOnce.ConsoleVerbosity.Low, false);
 
                     WriteOnce.FlushAll();
                 }
@@ -304,7 +303,7 @@ namespace Microsoft.ApplicationInspector.Commands
                 if (Utils.CLIExecutionContext)
                     return (int)ExitCode.CriticalError;
                 else
-                    throw e;
+                    throw;
             }
             finally
             {

--- a/AppInspector/Commands/VerifyRulesCommand.cs
+++ b/AppInspector/Commands/VerifyRulesCommand.cs
@@ -57,7 +57,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     Utils.Logger = null;
                     WriteOnce.Log = null;
                 }
-                throw e;
+                throw;
             }
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.ApplicationInspector.Commands
         public override int Run()
         {
             WriteOnce.SafeLog("VerifyRulesCommand::Run", LogLevel.Trace);
-            WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_RUNNING, "Verify Rules"));
+            WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_RUNNING, "verifyrules"));
 
             ExitCode exitCode = ExitCode.CriticalError;
 
@@ -159,7 +159,7 @@ namespace Microsoft.ApplicationInspector.Commands
                 }
 
                 WriteOnce.Any(ErrMsg.GetString(ErrMsg.ID.VERIFY_RULES_RESULTS_SUCCESS), true, ConsoleColor.Green, WriteOnce.ConsoleVerbosity.Low);
-                WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_COMPLETED, "Verify Rules"));
+                WriteOnce.Operation(ErrMsg.FormatString(ErrMsg.ID.CMD_COMPLETED, "verifyrules"));
                 if (!String.IsNullOrEmpty(_arg_outputFile) && Utils.CLIExecutionContext)
                     WriteOnce.Any(ErrMsg.FormatString(ErrMsg.ID.ANALYZE_OUTPUT_FILE, _arg_outputFile), true, ConsoleColor.Gray, WriteOnce.ConsoleVerbosity.Low);
                 WriteOnce.FlushAll();
@@ -169,9 +169,9 @@ namespace Microsoft.ApplicationInspector.Commands
                 WriteOnce.Error(e.Message);
                 //exit normaly for CLI callers and throw for DLL callers
                 if (Utils.CLIExecutionContext)
-                    return (int)ExitCode.CriticalError;//no way to distinguish from critical fail
+                    return (int)ExitCode.CriticalError;
                 else
-                    throw e;
+                    throw;
             }
             finally
             {

--- a/AppInspector/RulesVerifier.cs
+++ b/AppInspector/RulesVerifier.cs
@@ -24,40 +24,33 @@ namespace Microsoft.ApplicationInspector.Commands
         }
 
 
-        public bool Verify()
+        public void Verify()
         {
-            bool isCompiled = true;
-
             if (Directory.Exists(_rulesPath))
-                isCompiled = LoadDirectory(_rulesPath);
+                LoadDirectory(_rulesPath);
             else if (File.Exists(_rulesPath))
-                isCompiled = LoadFile(_rulesPath);
+                LoadFile(_rulesPath);
             else
             {
                 throw new Exception(ErrMsg.FormatString(ErrMsg.ID.CMD_INVALID_RULE_PATH, _rulesPath));
             }
 
-            return isCompiled;
         }
 
 
 
-        private bool LoadDirectory(string path)
+        private void LoadDirectory(string path)
         {
-            bool result = true;
             foreach (string filename in Directory.EnumerateFileSystemEntries(path, "*.json", SearchOption.AllDirectories))
             {
-                if (!LoadFile(filename))
-                    result = false;
+                LoadFile(filename);
             }
-
-            return result;
         }
 
-        private bool LoadFile(string file)
+        private void LoadFile(string file)
         {
             RuleSet rules = new RuleSet();
-            bool noProblem = true;
+
             try
             {
                 rules.AddFile(file, null);
@@ -69,10 +62,7 @@ namespace Microsoft.ApplicationInspector.Commands
                 throw new Exception(ErrMsg.FormatString(ErrMsg.ID.VERIFY_RULE_FAILED, file));
             }
 
-            if (noProblem)
-                _rules.AddRange(rules.AsEnumerable());
-
-            return noProblem;
+            _rules.AddRange(rules.AsEnumerable());
         }
 
 

--- a/AppInspector/Utils.cs
+++ b/AppInspector/Utils.cs
@@ -93,7 +93,6 @@ namespace Microsoft.ApplicationInspector.Commands
         {
             RuleSet ruleSet = new RuleSet(logger);
             Assembly assembly = Assembly.GetExecutingAssembly();
-            string[] resourceName = assembly.GetManifestResourceNames();
             string filePath = "Microsoft.ApplicationInspector.Commands.defaultRulesPkd.json";
             Stream resource = assembly.GetManifestResourceStream(filePath);
             using (StreamReader file = new StreamReader(resource))
@@ -296,7 +295,6 @@ namespace Microsoft.ApplicationInspector.Commands
             LogManager.Configuration = config;
             Logger = LogManager.GetLogger("CST.ApplicationInspector");
             return Logger;
-
         }
 
     }

--- a/AppInspector/Writers/SimpleTextWriter.cs
+++ b/AppInspector/Writers/SimpleTextWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Text;
 
 namespace Microsoft.ApplicationInspector.Commands
 {
@@ -50,34 +51,40 @@ namespace Microsoft.ApplicationInspector.Commands
 
         private string StringList(HashSet<string> data)
         {
-            string results = "";
+            StringBuilder build = new StringBuilder();
 
             foreach (string s in data)
-                results += s + " ";
+                build.Append(" ");
 
-            return results;
+            return build.ToString();
         }
 
 
         private string StringList(Dictionary<string, int> data)
         {
-            string results = "";
+            StringBuilder build = new StringBuilder();
 
             foreach (string s in data.Keys)
-                results += s + " ";
+            {
+                build.Append(s);
+                build.Append(" ");
+            }
 
-            return results;
+            return build.ToString();
         }
 
 
         private string StringList(SortedDictionary<string, string> data)
         {
-            string results = "";
+            StringBuilder build = new StringBuilder();
 
             foreach (string s in data.Values)
-                results += s + " ";
+            {
+                build.Append(s);
+                build.Append(" ");
+            }
 
-            return results;
+            return build.ToString();
         }
 
 
@@ -88,11 +95,12 @@ namespace Microsoft.ApplicationInspector.Commands
         /// <returns></returns>
         private string MakeHeading(string header)
         {
-            string result = string.Format("[{0}]", header);
+            StringBuilder build = new StringBuilder();
+            build.Append(string.Format("[{0}]", header));
             for (int i = header.Length; i < COLUMN_MAX; i++)
-                result += "-";
+                build.Append("-");
 
-            return result;
+            return build.ToString();
         }
 
 

--- a/MultiExtractor/Extractor.cs
+++ b/MultiExtractor/Extractor.cs
@@ -1,22 +1,19 @@
-﻿using System;
+﻿using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
 using ICSharpCode.SharpZipLib.Zip;
-using ICSharpCode.SharpZipLib.Core;
-using System.IO;
-using System.Collections.Generic;
 using SharpCompress.Archives.Rar;
-using SharpCompress.Compressors.Xz;
 using SharpCompress.Compressors.BZip2;
-using ICSharpCode.SharpZipLib;
-using System.Dynamic;
+using SharpCompress.Compressors.Xz;
+using System.Collections.Generic;
+using System.IO;
 
 namespace MultiExtractor
 {
     public static class Extractor
     {
         private const int BUFFER_SIZE = 4096;
-        
+
         public static bool IsSupportedFormat(string filename)
         {
             ArchiveFileType archiveFileType = MiniMagic.DetectFileType(filename);
@@ -138,7 +135,7 @@ namespace MultiExtractor
             }
 
             var newFileEntry = new FileEntry(newFilename, fileEntry.FullPath, memoryStream);
-            
+
             foreach (var extractedFile in ExtractFile(newFileEntry))
             {
                 files.Add(extractedFile);
@@ -212,7 +209,7 @@ namespace MultiExtractor
         {
             List<FileEntry> files = new List<FileEntry>();
             using var rarArchive = RarArchive.Open(fileEntry.Content);
-            using var memoryStream = new MemoryStream();
+
             foreach (var entry in rarArchive.Entries)
             {
                 if (entry.IsDirectory)
@@ -233,7 +230,7 @@ namespace MultiExtractor
         {
             List<FileEntry> files = new List<FileEntry>();
             using var rarArchive = RarArchive.Open(fileEntry.Content);
-            using var memoryStream = new MemoryStream();
+
             foreach (var entry in rarArchive.Entries)
             {
                 if (entry.IsDirectory)

--- a/RulesEngine/Issue.cs
+++ b/RulesEngine/Issue.cs
@@ -9,6 +9,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
     /// </summary>
     public class Issue
     {
+        Confidence _confidence;
         /// <summary>
         /// Creates new instance of Issue
         /// </summary>
@@ -18,9 +19,25 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             Boundary = new Boundary();
             StartLocation = new Location();
             IsSuppressionInfo = false;
+            Confidence = Confidence.Medium;
         }
 
-        public Confidence Confidence { get; set; }
+        public Confidence Confidence
+        {
+            get
+            {
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+                if (_confidence == null)//possible from serialiation
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+                    _confidence = Confidence.Medium;
+
+                return _confidence;
+            }
+            set
+            {
+                _confidence = value;
+            }
+        }
 
         /// <summary>
         /// Boundary of issue (index, length)

--- a/RulesEngine/SearchPattern.cs
+++ b/RulesEngine/SearchPattern.cs
@@ -10,6 +10,8 @@ namespace Microsoft.ApplicationInspector.RulesEngine
     /// </summary>
     public class SearchPattern
     {
+        Confidence _confidence;
+
         [JsonProperty(PropertyName = "pattern")]
         public string Pattern { get; set; }
 
@@ -20,17 +22,32 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         [JsonProperty(PropertyName = "modifiers")]
         public string[] Modifiers { get; set; }
 
-        [JsonProperty(PropertyName = "scopes")]        
+        [JsonProperty(PropertyName = "scopes")]
         public PatternScope[] Scopes { get; set; }
 
         [JsonProperty(PropertyName = "confidence")]
-        public Confidence Confidence { get; set; }
+        public Confidence Confidence
+        {
+            get
+            {
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+                if (_confidence == null)//possible from serialiation
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+                    _confidence = Confidence.Medium;
+
+                return _confidence;
+            }
+            set
+            {
+                _confidence = value;
+            }
+        }
 
         public SearchPattern()
         {
-           Confidence = Confidence.Medium;
+            Confidence = Confidence.Medium;
         }
     }
 
-    
+
 }


### PR DESCRIPTION
…s of stack data info and removes unused lines of code for cleanliness identified by LGTM/Semmle. Fixes loss of confidence data in some cases from serialization where not specified. Fixes one hardcoded output filename for tagtest and prevents msg for console winding up in log.