### PR TITLE
Potential fix for #200.

### DIFF
--- a/MultiExtractor/Extractor.cs
+++ b/MultiExtractor/Extractor.cs
@@ -22,12 +22,38 @@ namespace MultiExtractor
 
         public static IEnumerable<FileEntry> ExtractFile(string filename)
         {
+            try
+            {
+                if (!File.OpenRead(filename).CanRead)
+                {
+                    throw new IOException("ExtractFile called, but {0} cannot be read.", filename);
+                }
+            }
+            catch (Exception)
+            {
+                Logger.Trace("File {0} cannot be read, ignoring.", filename);
+                return Array.Empty<FileEntry>();
+            }
+            
             using var memoryStream = new MemoryStream(File.ReadAllBytes(filename));
             return ExtractFile(new FileEntry(filename, "", memoryStream));
         }
 
         public static IEnumerable<FileEntry> ExtractFile(string filename, ArchiveFileType archiveFileType)
         {
+            try
+            {
+                if (!File.OpenRead(filename).CanRead)
+                {
+                    throw new IOException("ExtractFile called, but {0} cannot be read.", filename);
+                }
+            }
+            catch (Exception)
+            {
+                Logger.Trace("File {0} cannot be read, ignoring.", filename);
+                return Array.Empty<FileEntry>();
+            }
+            
             using var memoryStream = new MemoryStream(File.ReadAllBytes(filename));
             return ExtractFile(new FileEntry(filename, "", memoryStream), archiveFileType);
         }

--- a/MultiExtractor/Extractor.cs
+++ b/MultiExtractor/Extractor.cs
@@ -26,7 +26,7 @@ namespace MultiExtractor
             {
                 if (!File.OpenRead(filename).CanRead)
                 {
-                    throw new IOException("ExtractFile called, but {0} cannot be read.", filename);
+                    throw new IOException($"ExtractFile called, but {filename} cannot be read.");
                 }
             }
             catch (Exception)
@@ -45,7 +45,7 @@ namespace MultiExtractor
             {
                 if (!File.OpenRead(filename).CanRead)
                 {
-                    throw new IOException("ExtractFile called, but {0} cannot be read.", filename);
+                    throw new IOException($"ExtractFile called, but {filename} cannot be read.");
                 }
             }
             catch (Exception)

--- a/MultiExtractor/Extractor.cs
+++ b/MultiExtractor/Extractor.cs
@@ -7,6 +7,7 @@ using SharpCompress.Compressors.BZip2;
 using SharpCompress.Compressors.Xz;
 using System.Collections.Generic;
 using System.IO;
+using System;
 
 namespace MultiExtractor
 {
@@ -31,7 +32,7 @@ namespace MultiExtractor
             }
             catch (Exception)
             {
-                Logger.Trace("File {0} cannot be read, ignoring.", filename);
+                //Logger.Trace("File {0} cannot be read, ignoring.", filename);
                 return Array.Empty<FileEntry>();
             }
             
@@ -50,7 +51,7 @@ namespace MultiExtractor
             }
             catch (Exception)
             {
-                Logger.Trace("File {0} cannot be read, ignoring.", filename);
+                //Logger.Trace("File {0} cannot be read, ignoring.", filename);
                 return Array.Empty<FileEntry>();
             }
             


### PR DESCRIPTION
Before calling File.ReadAllBytes(), check to see if we actually can. This isn't awesome (we'll have this functionality improved when we publish MultiExtractor as a separate package), but should work. (Please test, though.)