### PR TITLE
Zero length files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,4 @@ __pycache__/
 /AppInspector/Resources/defaultRulesPkd.json
 /UnitTest.Commands/output
 /RulesPacker/log.txt
+/AppInspector/ApplicationInspector.Commands.xml

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('c', "confidence-filters", Required = false, HelpText = "Output only matches with specified confidence <value>,<value> [high|medium|low]", Default = "high,medium")]
         public string ConfidenceFilters { get; set; } = "high,medium";
 
-        [Option('k', "file-path-exclusions", Required = false, HelpText = "Exclude source files (none|default: sample,example,test,docs,.vs,.git)", Default = "sample,example,test,docs,.vs,.git")]
+        [Option('k', "file-path-exclusions", Required = false, HelpText = "Exclude source files (none|default: sample,example,test,docs,lib,.vs,.git)", Default = "sample,example,test,docs,lib,.vs,.git")]
         public string FilePathExclusions { get; set; } = "sample,example,test,docs,.vs,.git";
 
         [Option('f', "output-file-format", Required = false, HelpText = "Output format [html|json|text]", Default = "html")]

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -317,7 +317,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     }
                     else
                     {
-                        UnZipAndProcess(filename, archiveFileType);
+                        UnZipAndProcess(filename, archiveFileType, _srcfileList.Count() == 1);
                     }
                 }
 
@@ -595,7 +595,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
         #endregion ProcessingAssist
 
-        private void UnZipAndProcess(string filename, ArchiveFileType archiveFileType)
+        private void UnZipAndProcess(string filename, ArchiveFileType archiveFileType, bool topLevel = true)
         {
             // zip itself may be in excluded list i.e. sample, test or similar unless ignore filter requested
             if (_fileExclusionList != null && _fileExclusionList.Any(v => filename.ToLower().Contains(v)))
@@ -608,11 +608,25 @@ namespace Microsoft.ApplicationInspector.Commands
             //zip itself may be too huge for timely processing
             if (new FileInfo(filename).Length > WARN_ZIP_FILE_SIZE)
             {
-                WriteOnce.General(MsgHelp.FormatString(MsgHelp.ID.ANALYZE_COMPRESSED_FILESIZE_WARN));
+                if (topLevel)
+                {
+                    WriteOnce.General(MsgHelp.GetString(MsgHelp.ID.ANALYZE_COMPRESSED_FILESIZE_WARN));
+                }
+                else
+                {
+                    WriteOnce.SafeLog("Decompressing large file " + filename, LogLevel.Warn);
+                }
             }
             else
             {
-                WriteOnce.General(MsgHelp.FormatString(MsgHelp.ID.ANALYZE_COMPRESSED_PROCESSING));
+                if (topLevel)
+                {
+                    WriteOnce.General(MsgHelp.GetString(MsgHelp.ID.ANALYZE_COMPRESSED_PROCESSING));
+                }
+                else
+                {
+                    WriteOnce.SafeLog("Decompressing file " + filename, LogLevel.Warn);
+                }
             }
 
             LastUpdated = File.GetLastWriteTime(filename);

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -299,6 +299,13 @@ namespace Microsoft.ApplicationInspector.Commands
                 // Iterate through all files and process against rules
                 foreach (string filename in _srcfileList)
                 {
+                    if (new FileInfo(filename).Length == 0)
+                    {
+                        WriteOnce.SafeLog(MsgHelp.FormatString(MsgHelp.ID.ANALYZE_EXCLUDED_TYPE_SKIPPED, filename), LogLevel.Warn);
+                        _metaDataHelper.Metadata.FilesSkipped++;
+                        continue;
+                    }
+
                     ArchiveFileType archiveFileType = ArchiveFileType.UNKNOWN;
                     try //fix for #146
                     {

--- a/AppInspector/MetaDataHelper.cs
+++ b/AppInspector/MetaDataHelper.cs
@@ -21,6 +21,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
         public MetaDataHelper(string sourcePath, bool uniqueMatchesOnly)
         {
+            sourcePath = Path.GetFullPath(sourcePath);//normalize for .\ and similar
             Metadata = new MetaData(GetDefaultProjectName(sourcePath), sourcePath);
 
             _propertyTagSearchPatterns = new Dictionary<string, string>();
@@ -163,9 +164,14 @@ namespace Microsoft.ApplicationInspector.Commands
 
             if (Directory.Exists(sourcePath))
             {
+                if (sourcePath[sourcePath.Length - 1] == Path.DirectorySeparatorChar) //in case path ends with dir separator; remove
+                {
+                    applicationName = sourcePath.Substring(0, sourcePath.Length - 1);
+                }
+
                 try
                 {
-                    applicationName = sourcePath.Substring(sourcePath.LastIndexOf(Path.DirectorySeparatorChar)).Replace(Path.DirectorySeparatorChar, ' ').Trim();
+                    applicationName = applicationName.Substring(applicationName.LastIndexOf(Path.DirectorySeparatorChar)).Replace(Path.DirectorySeparatorChar, ' ').Trim();
                 }
                 catch (Exception)
                 {

--- a/AppInspector/Resources/defaultRulesPkd.json
+++ b/AppInspector/Resources/defaultRulesPkd.json
@@ -11156,7 +11156,7 @@
     "overrides": null,
     "patterns": [
       {
-        "pattern": "\\b(WindowsImpersonationContext|WindowsIdentity\\.Impersonate|WindowsIdentity\\.RunImpersonated||ImpersonateIdentity)\\b",
+        "pattern": "\\b(WindowsImpersonationContext|WindowsIdentity\\.Impersonate|WindowsIdentity\\.RunImpersonated|ImpersonateIdentity)\\b",
         "type": "regex",
         "modifiers": null,
         "scopes": [
@@ -14003,9 +14003,9 @@
     "conditions": []
   },
   {
-    "name": "Testing Framework: ",
+    "name": "Testing Framework: JSUnit",
     "id": "AI042000",
-    "description": "Testing Framework: ",
+    "description": "Testing Framework: JSUnit",
     "applies_to": [
       "javascript"
     ],

--- a/AppInspector/Utils.cs
+++ b/AppInspector/Utils.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     break;
 
                 case AppPath.defaultLog:
-                    result = Path.Combine(GetBaseAppPath(), "log.txt");
+                    result = Path.Combine(GetBaseAppPath(), "appinspector.log.txt");
                     break;
 
                 case AppPath.defaultRulesSrc://Packrules source use
@@ -178,7 +178,11 @@ namespace Microsoft.ApplicationInspector.Commands
                 return Logger;
             }
 
-            var config = new NLog.Config.LoggingConfiguration();
+            LoggingConfiguration config = LogManager.Configuration;
+            if (config == null)//fix #179 to prevent overwrite of caller config...i.e. just add ours
+            {
+                config = new LoggingConfiguration();
+            }
 
             if (String.IsNullOrEmpty(opts.LogFilePath))
             {
@@ -256,13 +260,13 @@ namespace Microsoft.ApplicationInspector.Commands
             })
             {
                 config.AddTarget(fileTarget);
-                config.LoggingRules.Add(new LoggingRule("CST.ApplicationInspector", log_level, fileTarget));
+                config.LoggingRules.Add(new LoggingRule("Microsoft.CST.ApplicationInspector", log_level, fileTarget));
             }
 
             LogFilePath = opts.LogFilePath;//preserve for console path msg
 
             LogManager.Configuration = config;
-            Logger = LogManager.GetLogger("CST.ApplicationInspector");
+            Logger = LogManager.GetLogger("Microsoft.CST.ApplicationInspector");
             return Logger;
         }
     }

--- a/AppInspector/rules/default/os/acl.json
+++ b/AppInspector/rules/default/os/acl.json
@@ -178,7 +178,7 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "WindowsImpersonationContext|WindowsIdentity\\.Impersonate|WindowsIdentity\\.RunImpersonated||ImpersonateIdentity",
+        "pattern": "WindowsImpersonationContext|WindowsIdentity\\.Impersonate|WindowsIdentity\\.RunImpersonated|ImpersonateIdentity",
         "type": "regex-word",
         "scopes": [
           "code"

--- a/MultiExtractor/Extractor.cs
+++ b/MultiExtractor/Extractor.cs
@@ -5,6 +5,7 @@ using ICSharpCode.SharpZipLib.Zip;
 using SharpCompress.Archives.Rar;
 using SharpCompress.Compressors.BZip2;
 using SharpCompress.Compressors.Xz;
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -22,12 +23,38 @@ namespace MultiExtractor
 
         public static IEnumerable<FileEntry> ExtractFile(string filename)
         {
+            try
+            {
+                if (!File.OpenRead(filename).CanRead)
+                {
+                    throw new IOException($"ExtractFile called, but {filename} cannot be read.");
+                }
+            }
+            catch (Exception)
+            {
+                //Logger.Trace("File {0} cannot be read, ignoring.", filename);
+                return Array.Empty<FileEntry>();
+            }
+
             using var memoryStream = new MemoryStream(File.ReadAllBytes(filename));
             return ExtractFile(new FileEntry(filename, "", memoryStream));
         }
 
         public static IEnumerable<FileEntry> ExtractFile(string filename, ArchiveFileType archiveFileType)
         {
+            try
+            {
+                if (!File.OpenRead(filename).CanRead)
+                {
+                    throw new IOException($"ExtractFile called, but {filename} cannot be read.");
+                }
+            }
+            catch (Exception)
+            {
+                //Logger.Trace("File {0} cannot be read, ignoring.", filename);
+                return Array.Empty<FileEntry>();
+            }
+
             using var memoryStream = new MemoryStream(File.ReadAllBytes(filename));
             return ExtractFile(new FileEntry(filename, "", memoryStream), archiveFileType);
         }

--- a/RulesEngine/TextContainer.cs
+++ b/RulesEngine/TextContainer.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
     /// </summary>
     internal class TextContainer
     {
+        private static readonly int MAX_PATTERN_MATCHES = 10;
         /// <summary>
         /// Creates new instance
         /// </summary>
@@ -161,6 +162,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             MatchCollection matches = patRegx.Matches(text);
             if (matches.Count > 0)
             {
+                int matchCount = 0;
                 foreach (Match m in matches)
                 {
                     Boundary bound = new Boundary() { Index = m.Index, Length = m.Length };
@@ -173,7 +175,15 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                     {
                         break;
                     }
+
+                    //firewall in case the pattern match count is exceedingly high
+                    if (matchCount++ > MAX_PATTERN_MATCHES)
+                    {
+                        break;
+                    }
                 }
+
+
             }
 
             return matchList;


### PR DESCRIPTION
Detects zero length files that can cause exceptions when scanning due to file read for bytes fail.  Logs the skipped file.  Related to #200.