### PR TITLE
Change the namespace for multiextractor

### DIFF
--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 using Microsoft.ApplicationInspector.RulesEngine;
-using Microsoft.CST.OpenSource.MultiExtractor;
+using Microsoft.ApplicationInspector.MultiExtractor;
 using Newtonsoft.Json;
 using NLog;
 using System;

--- a/MultiExtractor/ArFile.cs
+++ b/MultiExtractor/ArFile.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
-namespace Microsoft.CST.OpenSource.MultiExtractor
+namespace Microsoft.ApplicationInspector.MultiExtractor
 {
     /**
      * Gnu Ar file parser.  Supports SystemV style lookup tables in both 32 and 64 bit mode as well as BSD and GNU formatted .ars.

--- a/MultiExtractor/DebArchiveFile.cs
+++ b/MultiExtractor/DebArchiveFile.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Text;
 
-namespace Microsoft.CST.OpenSource.MultiExtractor
+namespace Microsoft.ApplicationInspector.MultiExtractor
 {
     /**
      * Very simple implementation of an .Deb format parser, needed for Debian .deb archives.

--- a/MultiExtractor/Extractor.cs
+++ b/MultiExtractor/Extractor.cs
@@ -26,7 +26,7 @@ using SharpCompress.Compressors.BZip2;
 using SharpCompress.Compressors.Xz;
 using System.Collections.Concurrent;
 
-namespace Microsoft.CST.OpenSource.MultiExtractor
+namespace Microsoft.ApplicationInspector.MultiExtractor
 {
     public class Extractor
     {

--- a/MultiExtractor/FileEntry.cs
+++ b/MultiExtractor/FileEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 
-namespace Microsoft.CST.OpenSource.MultiExtractor
+namespace Microsoft.ApplicationInspector.MultiExtractor
 {
     public class FileEntry
     {

--- a/MultiExtractor/MiniMagic.cs
+++ b/MultiExtractor/MiniMagic.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
-namespace Microsoft.CST.OpenSource.MultiExtractor
+namespace Microsoft.ApplicationInspector.MultiExtractor
 {
     /// <summary>
     /// ArchiveTypes are the kinds of archive files that this module can process.


### PR DESCRIPTION
 Change the namespace for multiextractor to be in the `Microsoft.ApplicationInspector.Multiextractor` namespace.

Currently it conflicts if you try to include the latest `ApplicationInspector.Commands` nupkg and the latest OSS Gadget `MultiExtractor`.  This allows them to co-exist.