### PR TITLE
Bump NBGV to Fix CodeQL Workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-name: "Code Scanning - Application Inspector"
+name: "CodeQL"
 
 on:
   push:

--- a/AppInspector.CLI/AppInspector.CLI.csproj
+++ b/AppInspector.CLI/AppInspector.CLI.csproj
@@ -69,7 +69,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.2.31" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
   </ItemGroup>
   
 </Project>

--- a/AppInspector/AppInspector.Commands.csproj
+++ b/AppInspector/AppInspector.Commands.csproj
@@ -93,7 +93,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.2.31" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="BeforeCompile">

--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -19,6 +19,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.2.31" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.0.50</Version>
+      <Version>3.3.37</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/RulesEngine/AppInspector.RulesEngine.csproj
+++ b/RulesEngine/AppInspector.RulesEngine.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.2.31" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
   </ItemGroup>
 
 </Project>

--- a/UnitTest.Commands/UnitTest.Commands.csproj
+++ b/UnitTest.Commands/UnitTest.Commands.csproj
@@ -152,7 +152,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.2.31" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
   </ItemGroup>
 
  </Project>

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
-  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.2",
   "publicReleaseRefSpec": [
-    "^refs/heads/main",
+    "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"
   ],
   "cloudBuild": {


### PR DESCRIPTION
Bump nbgv to fix codeql workflow. Update is required due to changes to GitHub Actions set-env deprecation:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/