### PR TITLE
Rewrite Analyze Command

### DIFF
--- a/AppInspector.CLI/AppInspector.CLI.csproj
+++ b/AppInspector.CLI/AppInspector.CLI.csproj
@@ -65,8 +65,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="DotLiquid" Version="2.0.361" />
-    <PackageReference Include="NLog" Version="4.7.5" />
+    <PackageReference Include="DotLiquid" Version="2.1.418" />
+    <PackageReference Include="NLog" Version="4.7.9" />
   </ItemGroup>
   
   <ItemGroup>

--- a/AppInspector.CLI/AppInspector.CLI.csproj
+++ b/AppInspector.CLI/AppInspector.CLI.csproj
@@ -67,6 +67,7 @@
   <ItemGroup>
     <PackageReference Include="DotLiquid" Version="2.1.418" />
     <PackageReference Include="NLog" Version="4.7.9" />
+    <PackageReference Include="ShellProgressBar" Version="5.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -22,6 +22,37 @@ namespace Microsoft.ApplicationInspector.CLI
     /// <summary>
     /// CLI command distinct arguments
     /// </summary>
+    [Verb("get-tags", HelpText = "Inspect source directory/file/compressed file (.tgz|zip) against defined characteristics for unique tags")]
+    public class CLIGetTagsCommandOptions : CLICommandOptions
+    {
+        [Option('s', "source-path", Required = true, HelpText = "Source file or directory to inspect")]
+        public string? SourcePath { get; set; }
+
+        [Option('r', "custom-rules-path", Required = false, HelpText = "Custom rules file or directory path")]
+        public string? CustomRulesPath { get; set; }
+
+        [Option('i', "ignore-default-rules", Required = false, HelpText = "Exclude default rules bundled with application", Default = false)]
+        public bool IgnoreDefaultRules { get; set; }
+
+        [Option('c', "confidence-filters", Required = false, HelpText = "Output only matches with specified confidence <value>,<value> [high|medium|low]", Default = "high,medium")]
+        public string ConfidenceFilters { get; set; } = "high,medium";
+
+        [Option('k', "file-path-exclusions", Required = false, HelpText = "Exclude source files (none|default: sample,example,test,docs,lib,.vs,.git)", Default = "sample,example,test,docs,lib,.vs,.git")]
+        public string FilePathExclusions { get; set; } = "sample,example,test,docs,.vs,.git";
+
+        [Option('e', "text-format", Required = false, HelpText = "Match text format specifiers", Default = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m")]
+        public string TextOutputFormat { get; set; } = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m";
+
+        [Option("single-threaded", Required = false, HelpText = "Disables parallel processing.")]
+        public bool SingleThread { get; set; }
+
+        [Option("no-show-progress", Required = false, HelpText = "Disable progress information.")]
+        public bool NoShowProgressBar { get; set; }
+    }
+
+    /// <summary>
+    /// CLI command distinct arguments
+    /// </summary>
     [Verb("analyze", HelpText = "Inspect source directory/file/compressed file (.tgz|zip) against defined characteristics")]
     public class CLIAnalyzeCmdOptions : CLICommandOptions
     {
@@ -36,9 +67,6 @@ namespace Microsoft.ApplicationInspector.CLI
 
         [Option('i', "ignore-default-rules", Required = false, HelpText = "Exclude default rules bundled with application", Default = false)]
         public bool IgnoreDefaultRules { get; set; }
-
-        [Option('d', "allow-dup-tags", Required = false, HelpText = "Output contains unique and non-unique tag matches", Default = false)]
-        public bool AllowDupTags { get; set; }
 
         [Option('b', "suppress-browser-open", Required = false, HelpText = "Suppress automatically opening HTML output using default browser", Default = false)]
         public bool SuppressBrowserOpen { get; set; }

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -41,8 +41,11 @@ namespace Microsoft.ApplicationInspector.CLI
         public string FilePathExclusions { get; set; } = "sample,example,test,docs,.vs,.git";
 
         [Option('e', "text-format", Required = false, HelpText = "Match text format specifiers", Default = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m")]
-        public string TextOutputFormat { get; set; } = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m";
+        public string TextOutputFormat { get; set; } = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m";\
 
+        [Option("file-timeout", Required = false, HelpText = "Maximum amount of time in seconds to allow for processing each file.", Default = 0)]
+        public int FileTimeOut { get; set; } = 0;
+        
         [Option("single-threaded", Required = false, HelpText = "Disables parallel processing.")]
         public bool SingleThread { get; set; }
 

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -40,9 +40,6 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('k', "file-path-exclusions", Required = false, HelpText = "Exclude source files (none|default: sample,example,test,docs,lib,.vs,.git)", Default = "sample,example,test,docs,lib,.vs,.git")]
         public string FilePathExclusions { get; set; } = "sample,example,test,docs,.vs,.git";
 
-        [Option('e', "text-format", Required = false, HelpText = "Match text format specifiers", Default = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m")]
-        public string TextOutputFormat { get; set; } = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m";\
-
         [Option("file-timeout", Required = false, HelpText = "Maximum amount of time in seconds to allow for processing each file.", Default = 0)]
         public int FileTimeOut { get; set; } = 0;
         

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -83,6 +83,9 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('t', "tag-output-only", Required = false, HelpText = "Output only identified tags", Default = false)]
         public bool SimpleTagsOnly { get; set; }
 
+        [Option("file-timeout", Required = false, HelpText = "Maximum amount of time in seconds to allow for processing each file.", Default = 0)]
+        public int FileTimeOut { get; set; } = 0;
+
         [Option("single-threaded", Required = false, HelpText = "Disables parallel processing.")]
         public bool SingleThread { get; set; }
 

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -60,6 +60,9 @@ namespace Microsoft.ApplicationInspector.CLI
 
         [Option("single-threaded", Required = false, HelpText = "Disables parallel processing.")]
         public bool SingleThread { get; set; }
+
+        [Option("no-show-progress", Required = false, HelpText = "Disable progress information.")]
+        public bool NoShowProgressBar { get; set; }
     }
 
     [Verb("tagdiff", HelpText = "Compares unique tag values between two source paths")]

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -62,9 +62,6 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('r', "custom-rules-path", Required = false, HelpText = "Custom rules file or directory path")]
         public string? CustomRulesPath { get; set; }
 
-        [Option('h', "match-depth", Required = false, HelpText = "First match or best match based on confidence level (first|best)", Default = "best")]
-        public string MatchDepth { get; set; } = "best";
-
         [Option('i', "ignore-default-rules", Required = false, HelpText = "Exclude default rules bundled with application", Default = false)]
         public bool IgnoreDefaultRules { get; set; }
 

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -278,7 +278,8 @@ namespace Microsoft.ApplicationInspector.CLI
                 FilePathExclusions = cliOptions.FilePathExclusions,
                 ConsoleVerbosityLevel = cliOptions.ConsoleVerbosityLevel,
                 Log = cliOptions.Log,
-                SingleThread = cliOptions.SingleThread
+                SingleThread = cliOptions.SingleThread,
+                NoShowProgress = cliOptions.NoShowProgressBar
             });
 
             AnalyzeResult analyzeResult = command.GetResult();

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -279,7 +279,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 ConsoleVerbosityLevel = cliOptions.ConsoleVerbosityLevel,
                 Log = cliOptions.Log,
                 SingleThread = cliOptions.SingleThread
-            }); ;
+            });
 
             AnalyzeResult analyzeResult = command.GetResult();
             exitCode = analyzeResult.ResultCode;

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -307,7 +307,8 @@ namespace Microsoft.ApplicationInspector.CLI
                 ConsoleVerbosityLevel = cliOptions.ConsoleVerbosityLevel,
                 Log = cliOptions.Log,
                 SingleThread = cliOptions.SingleThread,
-                NoShowProgress = cliOptions.NoShowProgressBar
+                NoShowProgress = cliOptions.NoShowProgressBar,
+                FileTimeOut = cliOptions.FileTimeOut
             });
 
             AnalyzeResult analyzeResult = command.GetResult();

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -283,7 +283,8 @@ namespace Microsoft.ApplicationInspector.CLI
                 ConsoleVerbosityLevel = cliOptions.ConsoleVerbosityLevel,
                 Log = cliOptions.Log,
                 SingleThread = cliOptions.SingleThread,
-                NoShowProgress = cliOptions.NoShowProgressBar
+                NoShowProgress = cliOptions.NoShowProgressBar,
+                FileTimeOut = cliOptions.FileTimeOut
             });
 
             GetTagsResult getTagsResult = command.GetResult();

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -166,12 +166,6 @@ namespace Microsoft.ApplicationInspector.CLI
                     WriteOnce.Info(MsgHelp.GetString(MsgHelp.ID.ANALYZE_HTML_EXTENSION));
                 }
 
-                if (options.AllowDupTags) //fix #183; duplicates results for html format is not supported which causes filedialog issues
-                {
-                    WriteOnce.Error(MsgHelp.GetString(MsgHelp.ID.ANALYZE_NODUPLICATES_HTML_FORMAT));
-                    throw new OpException(MsgHelp.GetString(MsgHelp.ID.ANALYZE_NODUPLICATES_HTML_FORMAT));
-                }
-
                 if (options.SimpleTagsOnly) //won't work for html that expects full data for UI
                 {
                     WriteOnce.Error(MsgHelp.GetString(MsgHelp.ID.ANALYZE_SIMPLETAGS_HTML_FORMAT));
@@ -263,6 +257,30 @@ namespace Microsoft.ApplicationInspector.CLI
 
         #region RunCmdsWriteResults
 
+        private static int RunGetTagsCommand(CLIGetTagsCommandOptions cliOptions)
+        {
+            GetTagsResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
+
+            GetTagsCommand command = new GetTagsCommand(new GetTagsCommandOptions()
+            {
+                SourcePath = cliOptions.SourcePath ?? "",
+                CustomRulesPath = cliOptions.CustomRulesPath ?? "",
+                IgnoreDefaultRules = cliOptions.IgnoreDefaultRules,
+                ConfidenceFilters = cliOptions.ConfidenceFilters,
+                FilePathExclusions = cliOptions.FilePathExclusions,
+                ConsoleVerbosityLevel = cliOptions.ConsoleVerbosityLevel,
+                Log = cliOptions.Log,
+                SingleThread = cliOptions.SingleThread,
+                NoShowProgress = cliOptions.NoShowProgressBar
+            });
+
+            GetTagsResult getTagsResult = command.GetResult();
+            exitCode = getTagsResult.ResultCode;
+            ResultsWriter.Write(getTagsResult, cliOptions);
+
+            return (int)exitCode;
+        }
+
         private static int RunAnalyzeCommand(CLIAnalyzeCmdOptions cliOptions)
         {
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
@@ -272,7 +290,6 @@ namespace Microsoft.ApplicationInspector.CLI
                 SourcePath = cliOptions.SourcePath ?? "",
                 CustomRulesPath = cliOptions.CustomRulesPath ?? "",
                 IgnoreDefaultRules = cliOptions.IgnoreDefaultRules,
-                AllowDupTags = cliOptions.AllowDupTags,
                 ConfidenceFilters = cliOptions.ConfidenceFilters,
                 MatchDepth = cliOptions.MatchDepth,
                 FilePathExclusions = cliOptions.FilePathExclusions,

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -30,7 +30,8 @@ namespace Microsoft.ApplicationInspector.CLI
                     CLITagTestCmdOptions,
                     CLIExportTagsCmdOptions,
                     CLIVerifyRulesCmdOptions,
-                    CLIPackRulesCmdOptions>(args)
+                    CLIPackRulesCmdOptions, 
+                    CLIGetTagsCommandOptions>(args)
                   .MapResult(
                     (CLIAnalyzeCmdOptions cliOptions) => VerifyOutputArgsRun(cliOptions),
                     (CLITagDiffCmdOptions cliOptions) => VerifyOutputArgsRun(cliOptions),
@@ -38,7 +39,8 @@ namespace Microsoft.ApplicationInspector.CLI
                     (CLIExportTagsCmdOptions cliOptions) => VerifyOutputArgsRun(cliOptions),
                     (CLIVerifyRulesCmdOptions cliOptions) => VerifyOutputArgsRun(cliOptions),
                     (CLIPackRulesCmdOptions cliOptions) => VerifyOutputArgsRun(cliOptions),
-                    errs => 1
+                    (CLIGetTagsCommandOptions cliOptions) => VerifyOutputArgsRun(cliOptions),
+                    errs => 2
                   );
 
                 finalResult = argsResult;
@@ -148,6 +150,16 @@ namespace Microsoft.ApplicationInspector.CLI
             }
 
             return RunPackRulesCommand(options);
+        }
+
+        private static int VerifyOutputArgsRun(CLIGetTagsCommandOptions options)
+        {
+            Logger logger = Utils.SetupLogging(options, true);
+            WriteOnce.Log = logger;
+            options.Log = logger;
+
+            CommonOutputChecks((CLICommandOptions)options);
+            return RunGetTagsCommand(options);
         }
 
         private static int VerifyOutputArgsRun(CLIAnalyzeCmdOptions options)

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -259,7 +259,7 @@ namespace Microsoft.ApplicationInspector.CLI
 
         private static int RunGetTagsCommand(CLIGetTagsCommandOptions cliOptions)
         {
-            GetTagsResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
 
             GetTagsCommand command = new GetTagsCommand(new GetTagsCommandOptions()
             {
@@ -291,7 +291,6 @@ namespace Microsoft.ApplicationInspector.CLI
                 CustomRulesPath = cliOptions.CustomRulesPath ?? "",
                 IgnoreDefaultRules = cliOptions.IgnoreDefaultRules,
                 ConfidenceFilters = cliOptions.ConfidenceFilters,
-                MatchDepth = cliOptions.MatchDepth,
                 FilePathExclusions = cliOptions.FilePathExclusions,
                 ConsoleVerbosityLevel = cliOptions.ConsoleVerbosityLevel,
                 Log = cliOptions.Log,

--- a/AppInspector.CLI/ResultsWriter.cs
+++ b/AppInspector.CLI/ResultsWriter.cs
@@ -72,6 +72,10 @@ namespace Microsoft.ApplicationInspector.CLI
                     return;
                 }
             }
+            else if (result is GetTagsResult gtr && options is CLIGetTagsCommandOptions gtco)
+            {
+                commandCompletedMsg = "Get Tags";
+            }
             else
             {
                 throw new Exception("Unrecognized object types for write results");

--- a/AppInspector.CLI/ResultsWriter.cs
+++ b/AppInspector.CLI/ResultsWriter.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ApplicationInspector.CLI
                     writer?.WriteResults(analyzeResult, cLIAnalyzeCmdOptions);
 
                     //post checks
-                    if (File.Exists(options.OutputFilePath) && new FileInfo(options.OutputFilePath).Length > MAX_HTML_REPORT_FILE_SIZE)
+                    if (options.OutputFilePath is not null && File.Exists(options.OutputFilePath) && new FileInfo(options.OutputFilePath).Length > MAX_HTML_REPORT_FILE_SIZE)
                     {
                         WriteOnce.Info(MsgHelp.GetString(MsgHelp.ID.ANALYZE_REPORTSIZE_WARN));
                     }

--- a/AppInspector.CLI/Writers/AnalyzeHtmlWriter.cs
+++ b/AppInspector.CLI/Writers/AnalyzeHtmlWriter.cs
@@ -192,7 +192,7 @@ namespace Microsoft.ApplicationInspector.CLI
             SafeList(_appMetaData?.CPUTargets);
 
             //safeguard displayable fields in match records
-            foreach (MatchRecord matchRecord in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
+            foreach (MatchRecord matchRecord in _appMetaData?.Matches ?? new List<MatchRecord>())
             {
                 //safeguard sample output now that we've matched properties for blocking browser xss
                 matchRecord.Sample = System.Net.WebUtility.HtmlEncode(matchRecord.Sample);
@@ -312,7 +312,7 @@ namespace Microsoft.ApplicationInspector.CLI
         {
             HashSet<string> results = new HashSet<string>();
 
-            foreach (MatchRecord match in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
+            foreach (MatchRecord match in _appMetaData?.Matches ?? new List<MatchRecord>())
             {
                 foreach (string tag in match.Tags ?? new string[] { })
                 {
@@ -341,7 +341,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 {
                     var tagPatternRegex = pattern.Expression;
 
-                    foreach (var match in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
+                    foreach (var match in _appMetaData?.Matches ?? new List<MatchRecord>())
                     {
                         foreach (var tagItem in match.Tags ?? new string[] { })
                         {
@@ -432,7 +432,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 {
                     var tagPatternRegex = pattern.Expression;
 
-                    foreach (var match in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
+                    foreach (var match in _appMetaData?.Matches ?? new List<MatchRecord>())
                     {
                         foreach (var tagItem in match.Tags ?? new string[] { })
                         {
@@ -498,7 +498,7 @@ namespace Microsoft.ApplicationInspector.CLI
 
             foreach (string tag in _appMetaData?.UniqueTags ?? new List<string>())
             {
-                foreach (var match in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
+                foreach (var match in _appMetaData?.Matches ?? new List<MatchRecord>())
                 {
                     foreach (string testTag in match.Tags ?? new string[] { })
                     {
@@ -539,7 +539,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 var searchPattern = new Regex(tag, RegexOptions.IgnoreCase);
                 foreach (Confidence confidence in confidences)
                 {
-                    foreach (var match in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
+                    foreach (var match in _appMetaData?.Matches ?? new List<MatchRecord>())
                     {
                         foreach (string testTag in match.Tags ?? new string[] { })
                         {
@@ -578,7 +578,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 var searchPattern = new Regex(tag, RegexOptions.IgnoreCase);
                 foreach (Severity severity in severities)
                 {
-                    foreach (var match in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
+                    foreach (var match in _appMetaData?.Matches ?? new List<MatchRecord>())
                     {
                         foreach (string testTag in match.Tags ?? new string[] { })
                         {

--- a/AppInspector.CLI/Writers/AnalyzeHtmlWriter.cs
+++ b/AppInspector.CLI/Writers/AnalyzeHtmlWriter.cs
@@ -235,7 +235,7 @@ namespace Microsoft.ApplicationInspector.CLI
             string[] unSupportedGroupsOrPatterns = new string[] { "metric", "dependency" };
 
             //for each preferred group of tag patterns determine if at least one instance was detected
-            foreach (TagCategory tagCategory in TagGroupPreferences)
+            foreach (TagCategory tagCategory in TagGroupPreferences ?? new List<TagCategory>())
             {
                 foreach (TagGroup tagGroup in tagCategory.Groups ?? new List<TagGroup>())
                 {

--- a/AppInspector.CLI/Writers/AnalyzeHtmlWriter.cs
+++ b/AppInspector.CLI/Writers/AnalyzeHtmlWriter.cs
@@ -7,6 +7,7 @@ using Microsoft.ApplicationInspector.Commands;
 using Microsoft.ApplicationInspector.RulesEngine;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -191,7 +192,7 @@ namespace Microsoft.ApplicationInspector.CLI
             SafeList(_appMetaData?.CPUTargets);
 
             //safeguard displayable fields in match records
-            foreach (MatchRecord matchRecord in _appMetaData?.Matches ?? new List<MatchRecord>())
+            foreach (MatchRecord matchRecord in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
             {
                 //safeguard sample output now that we've matched properties for blocking browser xss
                 matchRecord.Sample = System.Net.WebUtility.HtmlEncode(matchRecord.Sample);
@@ -311,7 +312,7 @@ namespace Microsoft.ApplicationInspector.CLI
         {
             HashSet<string> results = new HashSet<string>();
 
-            foreach (MatchRecord match in _appMetaData?.Matches ?? new List<MatchRecord>())
+            foreach (MatchRecord match in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
             {
                 foreach (string tag in match.Tags ?? new string[] { })
                 {
@@ -340,7 +341,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 {
                     var tagPatternRegex = pattern.Expression;
 
-                    foreach (var match in _appMetaData?.Matches ?? new List<MatchRecord>())
+                    foreach (var match in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
                     {
                         foreach (var tagItem in match.Tags ?? new string[] { })
                         {
@@ -431,7 +432,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 {
                     var tagPatternRegex = pattern.Expression;
 
-                    foreach (var match in _appMetaData?.Matches ?? new List<MatchRecord>())
+                    foreach (var match in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
                     {
                         foreach (var tagItem in match.Tags ?? new string[] { })
                         {
@@ -497,7 +498,7 @@ namespace Microsoft.ApplicationInspector.CLI
 
             foreach (string tag in _appMetaData?.UniqueTags ?? new List<string>())
             {
-                foreach (var match in _appMetaData?.Matches ?? new List<MatchRecord>())
+                foreach (var match in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
                 {
                     foreach (string testTag in match.Tags ?? new string[] { })
                     {
@@ -538,7 +539,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 var searchPattern = new Regex(tag, RegexOptions.IgnoreCase);
                 foreach (Confidence confidence in confidences)
                 {
-                    foreach (var match in _appMetaData?.Matches ?? new List<MatchRecord>())
+                    foreach (var match in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
                     {
                         foreach (string testTag in match.Tags ?? new string[] { })
                         {
@@ -577,7 +578,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 var searchPattern = new Regex(tag, RegexOptions.IgnoreCase);
                 foreach (Severity severity in severities)
                 {
-                    foreach (var match in _appMetaData?.Matches ?? new List<MatchRecord>())
+                    foreach (var match in _appMetaData?.Matches ?? new ConcurrentBag<MatchRecord>())
                     {
                         foreach (string testTag in match.Tags ?? new string[] { })
                         {

--- a/AppInspector.CLI/Writers/AnalyzeTextWriter.cs
+++ b/AppInspector.CLI/Writers/AnalyzeTextWriter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 WriteDependencies(analyzeResult.Metadata);
                 WriteOnce.General(MakeHeading("Match Details"));
 
-                foreach (MatchRecord match in analyzeResult.Metadata.Matches ?? new List<MatchRecord>())
+                foreach (MatchRecord match in analyzeResult.Metadata.Matches ?? new ConcurrentBag<MatchRecord>())
                 {
                     WriteMatch(match);
                 }

--- a/AppInspector.CLI/Writers/AnalyzeTextWriter.cs
+++ b/AppInspector.CLI/Writers/AnalyzeTextWriter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 WriteDependencies(analyzeResult.Metadata);
                 WriteOnce.General(MakeHeading("Match Details"));
 
-                foreach (MatchRecord match in analyzeResult.Metadata.Matches ?? new ConcurrentBag<MatchRecord>())
+                foreach (MatchRecord match in analyzeResult.Metadata.Matches ?? new List<MatchRecord>())
                 {
                     WriteMatch(match);
                 }

--- a/AppInspector.CLI/Writers/GetTagsTextWriter.cs
+++ b/AppInspector.CLI/Writers/GetTagsTextWriter.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+using Microsoft.ApplicationInspector.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.ApplicationInspector.CLI
+{
+    public class GetTagsTextWriter : CommandResultsWriter
+    {
+        public override void WriteResults(Result result, CLICommandOptions commandOptions, bool autoClose = true)
+        {
+            GetTagsResult getTagsResult = (GetTagsResult)result;
+            CLIGetTagsCommandOptions cliGetTagsCommandOptions = (CLIGetTagsCommandOptions)commandOptions;
+
+            //For console output, update write once for same results to console or file
+            WriteOnce.TextWriter = TextWriter;
+
+            if (string.IsNullOrEmpty(commandOptions.OutputFilePath))
+            {
+                WriteOnce.Result("Results");
+            }
+
+            foreach(var tag in getTagsResult.Metadata.UniqueTags ?? new List<string>())
+            {
+                WriteOnce.Result(tag);
+            }
+
+            if (autoClose)
+            {
+                FlushAndClose();
+            }
+        }
+    }
+}

--- a/AppInspector.CLI/Writers/JsonWriter.cs
+++ b/AppInspector.CLI/Writers/JsonWriter.cs
@@ -42,6 +42,10 @@ namespace Microsoft.ApplicationInspector.CLI.Writers
                 {
                     jsonSerializer.Serialize(TextWriter, packRulesResult.Rules);//write rules array only to disk
                 }
+                else if (result is GetTagsResult getTagsResults)
+                {
+                    jsonSerializer.Serialize(TextWriter, getTagsResults);
+                }
                 else
                 {
                     throw new System.Exception("Unexpected object type for json writer");

--- a/AppInspector.CLI/Writers/JsonWriter.cs
+++ b/AppInspector.CLI/Writers/JsonWriter.cs
@@ -9,6 +9,8 @@ namespace Microsoft.ApplicationInspector.CLI.Writers
         {
             JsonSerializer jsonSerializer = new JsonSerializer();
             jsonSerializer.Formatting = Formatting.Indented;
+            jsonSerializer.NullValueHandling = NullValueHandling.Ignore;
+            jsonSerializer.DefaultValueHandling = DefaultValueHandling.Ignore;
 
             //For console output, update write once for same results to console or file
             WriteOnce.TextWriter = TextWriter;

--- a/AppInspector.CLI/Writers/WriterFactory.cs
+++ b/AppInspector.CLI/Writers/WriterFactory.cs
@@ -25,29 +25,33 @@ namespace Microsoft.ApplicationInspector.CLI
             CommandResultsWriter? writer;
 
             //allocate the right writer by cmd (options) type
-            if (options is CLIAnalyzeCmdOptions cLIAnalyzeCmdOptions)
+            if (options is CLIAnalyzeCmdOptions cliAnalyzeCmdOptions)
             {
-                writer = GetAnalyzeWriter(cLIAnalyzeCmdOptions);
+                writer = GetAnalyzeWriter(cliAnalyzeCmdOptions);
             }
-            else if (options is CLITagTestCmdOptions cLITagTestCmdOptions)
+            else if (options is CLITagTestCmdOptions cliTagTestCmdOptions)
             {
-                writer = GetTagTestWriter(cLITagTestCmdOptions);
+                writer = GetTagTestWriter(cliTagTestCmdOptions);
             }
-            else if (options is CLITagDiffCmdOptions cLITagDiffCmdOptions)
+            else if (options is CLITagDiffCmdOptions cliTagDiffCmdOptions)
             {
-                writer = GetTagDiffWriter(cLITagDiffCmdOptions);
+                writer = GetTagDiffWriter(cliTagDiffCmdOptions);
             }
-            else if (options is CLIExportTagsCmdOptions cLIExportTagsCmdOptions)
+            else if (options is CLIExportTagsCmdOptions cliExportTagsCmdOptions)
             {
-                writer = GetExportWriter(cLIExportTagsCmdOptions);
+                writer = GetExportWriter(cliExportTagsCmdOptions);
             }
-            else if (options is CLIVerifyRulesCmdOptions cLIVerifyRulesCmdOptions)
+            else if (options is CLIVerifyRulesCmdOptions cliVerifyRulesCmdOptions)
             {
-                writer = GetVerifyRulesWriter(cLIVerifyRulesCmdOptions);
+                writer = GetVerifyRulesWriter(cliVerifyRulesCmdOptions);
             }
-            else if (options is CLIPackRulesCmdOptions cLIPackRulesCmdOptions)
+            else if (options is CLIPackRulesCmdOptions cliPackRulesCmdOptions)
             {
-                writer = GetPackRulesWriter(cLIPackRulesCmdOptions);
+                writer = GetPackRulesWriter(cliPackRulesCmdOptions);
+            }
+            else if (options is CLIGetTagsCommandOptions cliGetTagsCmdOptions)
+            {
+                writer = GetGetTagsWriter(cliGetTagsCmdOptions);
             }
             else
             {
@@ -56,6 +60,8 @@ namespace Microsoft.ApplicationInspector.CLI
 
             return writer;
         }
+
+
 
         /// <summary>
         /// Only AnalyzeResultsWriter supports an html option
@@ -112,6 +118,36 @@ namespace Microsoft.ApplicationInspector.CLI
 
                 case "text":
                     writer = new ExportTextWriter();
+                    break;
+
+                default:
+                    WriteOnce.Error(MsgHelp.FormatString(MsgHelp.ID.CMD_INVALID_ARG_VALUE, "-f"));
+                    throw new OpException((MsgHelp.FormatString(MsgHelp.ID.CMD_INVALID_ARG_VALUE, "-f")));
+            }
+
+            //assign the stream as a file or console
+            writer.OutputFileName = options.OutputFilePath;
+            writer.TextWriter = GetTextWriter(writer.OutputFileName);
+
+            return writer;
+        }
+
+        private static CommandResultsWriter GetGetTagsWriter(CLIGetTagsCommandOptions options)
+        {
+            CommandResultsWriter? writer;
+
+            switch (options.OutputFileFormat.ToLower())
+            {
+                case "_dummy":
+                    writer = new TagTestDummyWriter();
+                    break;
+
+                case "json":
+                    writer = new JsonWriter();
+                    break;
+
+                case "text":
+                    writer = new GetTagsTextWriter();
                     break;
 
                 default:

--- a/AppInspector.CLI/html/partials/_report_overview.liquid
+++ b/AppInspector.CLI/html/partials/_report_overview.liquid
@@ -1,6 +1,6 @@
 ﻿<div class="section">
     <h2>Application Inspector Report</h2>
-  <br>
+  <br/>
   <h4>Overview</h4>
     Welcome to the <strong>Microsoft Application Inspector Report.</strong>
     This report represents the analysis results for the specified source code. It contains

--- a/AppInspector/AppInspector.Commands.csproj
+++ b/AppInspector/AppInspector.Commands.csproj
@@ -62,6 +62,7 @@
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.0.58" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog" Version="4.7.9" />
+    <PackageReference Include="ShellProgressBar" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AppInspector/AppInspector.Commands.csproj
+++ b/AppInspector/AppInspector.Commands.csproj
@@ -57,11 +57,11 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="DotLiquid" Version="2.0.361" />
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.0.74" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.0.36" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NLog" Version="4.7.5" />
+    <PackageReference Include="DotLiquid" Version="2.1.418" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.0.83" />
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.0.58" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NLog" Version="4.7.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -350,8 +350,6 @@ namespace Microsoft.ApplicationInspector.Commands
                         languageInfo = new LanguageInfo() { Extensions = new string[] { Path.GetExtension(file.FullPath) }, Name = "Unknown" };
                     }
 
-                    _metaDataHelper?.Metadata.IncrementFilesAnalyzed();
-
                     List<MatchRecord> results = new List<MatchRecord>();
                     
                     if (opts.FileTimeOut > 0)
@@ -362,10 +360,15 @@ namespace Microsoft.ApplicationInspector.Commands
                             WriteOnce.Error($"{file.FullPath} analysis timed out.");
                             _metaDataHelper?.Metadata.IncrementFilesSkipped();
                         }
+                        else
+                        {
+                            _metaDataHelper?.Metadata.IncrementFilesAnalyzed();
+                        }
                     }
                     else
                     {
                         results = _rulesProcessor.AnalyzeFile(file, languageInfo, null);
+                        _metaDataHelper?.Metadata.IncrementFilesAnalyzed();
                     }
 
                     if (results.Any())

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -405,7 +405,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
             foreach (var srcFile in _srcfileList ?? Array.Empty<string>())
             {
-                foreach (var file in extractor.Extract(srcFile))
+                foreach (var file in extractor.Extract(srcFile, new ExtractorOptions() { Parallel = false }))
                 {
                     yield return file;
                 }   

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -297,7 +297,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
         #endregion configureMethods
 
-        public void PopulateRecords(CancellationToken cancellationToken, AnalyzeOptions opts)
+        public void PopulateRecords(CancellationToken cancellationToken, AnalyzeOptions opts, IEnumerable<FileEntry>? populatedEntries = null)
         {
             WriteOnce.SafeLog("AnalyzeCommand::EnumerateRecords", LogLevel.Trace);
 
@@ -308,25 +308,43 @@ namespace Microsoft.ApplicationInspector.Commands
                 return;
             }
 
-            Extractor extractor = new();
-
-            foreach (var srcFile in _srcfileList ?? Array.Empty<string>())
+            if (populatedEntries is not null)
             {
-                if (cancellationToken.IsCancellationRequested) { break; }
-                else if (opts.SingleThread)
+                if (opts.SingleThread)
                 {
-                    foreach (var file in extractor.Extract(srcFile))
+                    foreach (var entry in populatedEntries)
                     {
                         if (cancellationToken.IsCancellationRequested) { break; }
-                        ProcessAndAddToMetadata(file);
+                        ProcessAndAddToMetadata(entry);
                     }
                 }
                 else
                 {
-                    Parallel.ForEach(extractor.Extract(srcFile), new ParallelOptions() { CancellationToken = cancellationToken }, file =>
+                    Parallel.ForEach(populatedEntries, new ParallelOptions() { CancellationToken = cancellationToken }, entry => ProcessAndAddToMetadata(entry));
+                }
+            }
+            else
+            {
+                Extractor extractor = new();
+
+                foreach (var srcFile in _srcfileList ?? Array.Empty<string>())
+                {
+                    if (cancellationToken.IsCancellationRequested) { break; }
+                    else if (opts.SingleThread)
                     {
-                        ProcessAndAddToMetadata(file);
-                    });
+                        foreach (var file in extractor.Extract(srcFile))
+                        {
+                            if (cancellationToken.IsCancellationRequested) { break; }
+                            ProcessAndAddToMetadata(file);
+                        }
+                    }
+                    else
+                    {
+                        Parallel.ForEach(extractor.Extract(srcFile), new ParallelOptions() { CancellationToken = cancellationToken }, file =>
+                        {
+                            ProcessAndAddToMetadata(file);
+                        });
+                    }
                 }
             }
 
@@ -387,7 +405,37 @@ namespace Microsoft.ApplicationInspector.Commands
             }
         }
 
-    
+        public ConcurrentQueue<FileEntry> GetFileEntries(CancellationToken cancellationToken, AnalyzeOptions opts)
+        {
+            WriteOnce.SafeLog("GetTagsCommand::GetFileEntries", LogLevel.Trace);
+
+            Extractor extractor = new();
+
+            var output = new ConcurrentQueue<FileEntry>();
+
+            foreach (var srcFile in _srcfileList ?? Array.Empty<string>())
+            {
+                if (cancellationToken.IsCancellationRequested) { break; }
+                else if (opts.SingleThread)
+                {
+                    foreach (var file in extractor.Extract(srcFile))
+                    {
+                        if (cancellationToken.IsCancellationRequested) { break; }
+                        output.Enqueue(file);
+                    }
+                }
+                else
+                {
+                    Parallel.ForEach(extractor.Extract(srcFile), new ParallelOptions() { CancellationToken = cancellationToken }, file =>
+                    {
+                        output.Enqueue(file);
+                    });
+                }
+            }
+
+            return output;
+        }
+
 
         /// <summary>
         /// Main entry point to start analysis from CLI; handles setting up rules, directory enumeration
@@ -409,11 +457,14 @@ namespace Microsoft.ApplicationInspector.Commands
             if (!_options.NoShowProgress)
             {
                 var done = false;
+                ConcurrentQueue<FileEntry> fileQueue = new();
+
                 _ = Task.Factory.StartNew(() =>
                 {
-                    PopulateRecords(new CancellationToken(), _options);
+                    fileQueue = GetFileEntries(new CancellationToken(), _options);
                     done = true;
                 });
+
                 var options = new ProgressBarOptions
                 {
                     ForegroundColor = ConsoleColor.Yellow,
@@ -423,15 +474,32 @@ namespace Microsoft.ApplicationInspector.Commands
                 };
 
                 using var pbar = new IndeterminateProgressBar("Indeterminate", options);
-                pbar.Message = $"Analyzing Records";
+                pbar.Message = $"Enumerating Files.";
 
                 while (!done)
                 {
-                    pbar.Message = $"Enumerating and Analyzing Files. {_metaDataHelper?.Metadata.TotalMatchesCount} findings in {_metaDataHelper?.Metadata.FilesAnalyzed} files.";
                     Thread.Sleep(10);
                 }
 
                 pbar.Finished();
+
+                done = false;
+
+                float totFilesNum = fileQueue.Count;
+
+                using ProgressBar progressBar = new ProgressBar(10000, $"Analyzing {totFilesNum - _metaDataHelper?.Metadata.TotalFiles} files.");
+                IProgress<float> progress = progressBar.AsProgress<float>();
+                _ = Task.Factory.StartNew(() =>
+                {
+                    PopulateRecords(new CancellationToken(), _options, fileQueue);
+                    done = true;
+                });
+
+                while (!done)
+                {
+                    progressBar.Message = $"Analyzing {totFilesNum - _metaDataHelper?.Metadata.TotalFiles} files.";
+                    progress.Report(_metaDataHelper?.Metadata.TotalFiles / totFilesNum ?? 0);
+                }
             }
             else
             {

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -308,16 +308,13 @@ namespace Microsoft.ApplicationInspector.Commands
                     }
                     
                     LanguageInfo languageInfo = new LanguageInfo();
+
                     if (FileChecksPassed(file, ref languageInfo))
                     {
-                        var streamByteArray = new byte[file.Content.Length];
-                        file.Content.Read(streamByteArray);
-                        ProcessInMemory(file.FullPath, Encoding.UTF8.GetString(streamByteArray), languageInfo);
-                    }
-
-                    foreach (var matchRecord in await _rulesProcessor.AnalyzeFileAsync(file, languageInfo))
-                    {
-                        yield return matchRecord;
+                        foreach (var matchRecord in await _rulesProcessor.AnalyzeFileAsync(file, languageInfo))
+                        {
+                            yield return matchRecord;
+                        }
                     }
                 }
             }

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -492,7 +492,9 @@ namespace Microsoft.ApplicationInspector.Commands
                     while (!done)
                     {
                         Thread.Sleep(10);
+                        pbar.Message = $"Enumerating Files. {fileQueue.Count} Discovered.";
                     }
+                    pbar.Message = $"Enumerating Files. {fileQueue.Count} Discovered.";
 
                     pbar.Finished();
                 }
@@ -518,9 +520,12 @@ namespace Microsoft.ApplicationInspector.Commands
 
                     while (!done)
                     {
-                        progressBar.Tick(_metaDataHelper?.Files.Count ?? 0);
                         Thread.Sleep(10);
+                        progressBar.Message = $"Analyzing Files. {_metaDataHelper?.Matches.Count} Matches.";
+                        progressBar.Tick(_metaDataHelper?.Files.Count ?? 0);
+
                     }
+                    progressBar.Message = $"Analyzing Files. {_metaDataHelper?.Matches.Count} Matches.";
                     progressBar.Tick(progressBar.MaxTicks);
                 }
             }

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -323,8 +323,6 @@ namespace Microsoft.ApplicationInspector.Commands
                 }
             }
 
-            Console.WriteLine("Yo");
-
             void ProcessAndAddToMetadata(FileEntry file)
             {
                 _metaDataHelper?.Metadata.IncrementTotalFiles();

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -414,7 +414,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
                 record.ScanTime = sw.Elapsed;
 
-                _metaDataHelper?.Metadata.Files.Add(record);
+                _metaDataHelper?.Files.Add(record);
             }
         }
 
@@ -520,7 +520,7 @@ namespace Microsoft.ApplicationInspector.Commands
             }
 
             //wrapup result status
-            if (_metaDataHelper?.TotalFiles == _metaDataHelper?.FilesSkipped)
+            if (_metaDataHelper?.Files.All(x => x.Status == ScanState.Skipped) ?? false)
             {
                 WriteOnce.Error(MsgHelp.GetString(MsgHelp.ID.ANALYZE_NOSUPPORTED_FILETYPES));
                 analyzeResult.ResultCode = AnalyzeResult.ExitCode.NoMatches;

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -355,7 +355,6 @@ namespace Microsoft.ApplicationInspector.Commands
 
                 var sw = new Stopwatch();
                 sw.Start();
-                _metaDataHelper?.Metadata.IncrementTotalFiles();
 
                 LanguageInfo languageInfo = new LanguageInfo();
 
@@ -408,7 +407,6 @@ namespace Microsoft.ApplicationInspector.Commands
                 }
                 else
                 {
-                    _metaDataHelper?.Metadata.IncrementFilesSkipped();
                     record.Status = ScanState.Skipped;
                 }
 
@@ -502,7 +500,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
                 float totFilesNum = fileQueue.Count;
 
-                using ProgressBar progressBar = new ProgressBar(10000, $"Analyzing {totFilesNum - _metaDataHelper?.Metadata.TotalFiles} files.");
+                using ProgressBar progressBar = new ProgressBar(10000, $"Analyzing {totFilesNum - _metaDataHelper?.Files.Count} files.");
                 IProgress<float> progress = progressBar.AsProgress<float>();
                 _ = Task.Factory.StartNew(() =>
                 {
@@ -512,8 +510,8 @@ namespace Microsoft.ApplicationInspector.Commands
 
                 while (!done)
                 {
-                    progressBar.Message = $"Analyzing {totFilesNum - _metaDataHelper?.Metadata.TotalFiles} files.";
-                    progress.Report(_metaDataHelper?.Metadata.TotalFiles / totFilesNum ?? 0);
+                    progressBar.Message = $"Analyzing {totFilesNum - _metaDataHelper?.Files.Count} files.";
+                    progress.Report(_metaDataHelper?.Files.Count / totFilesNum ?? 0);
                 }
             }
             else

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -306,14 +306,11 @@ namespace Microsoft.ApplicationInspector.Commands
             foreach (var srcFile in _srcfileList ?? Array.Empty<string>())
             {
                 if (cancellationToken.IsCancellationRequested) { break; }
-                if (opts.SingleThread)
+                else if (opts.SingleThread)
                 {
                     foreach (var file in extractor.Extract(srcFile))
                     {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            return;
-                        }
+                        if (cancellationToken.IsCancellationRequested) { break; }
                         ProcessAndAddToMetadata(file);
                     }
                 }
@@ -326,8 +323,12 @@ namespace Microsoft.ApplicationInspector.Commands
                 }
             }
 
+            Console.WriteLine("Yo");
+
             void ProcessAndAddToMetadata(FileEntry file)
             {
+                _metaDataHelper?.Metadata.IncrementTotalFiles();
+
                 LanguageInfo languageInfo = new LanguageInfo();
 
                 if (FileChecksPassed(file, ref languageInfo))

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -489,7 +489,8 @@ namespace Microsoft.ApplicationInspector.Commands
                     ForegroundColorDone = ConsoleColor.DarkGreen,
                     BackgroundColor = ConsoleColor.DarkGray,
                     BackgroundCharacter = '\u2593',
-                    DisableBottomPercentage = false
+                    DisableBottomPercentage = false,
+                    ShowEstimatedDuration = true
                 };
 
                 using (var progressBar = new ProgressBar(fileQueue.Count, $"Analyzing Files.", options2))
@@ -509,7 +510,7 @@ namespace Microsoft.ApplicationInspector.Commands
                         var timePerRecord = sw.Elapsed.TotalMilliseconds / current;
                         var millisExpected = (int)(timePerRecord * (fileQueue.Count - (int)current));
                         var timeExpected = new TimeSpan(0,0,0,0,millisExpected);
-                        progressBar.Tick(_metaDataHelper?.Files.Count ?? 0, timeExpected, $"Analyzing Files. {_metaDataHelper?.Matches.Count} Matches. ETA {timeExpected.ToString("hh\\:mm\\:ss")}.");
+                        progressBar.Tick(_metaDataHelper?.Files.Count ?? 0, timeExpected, $"Analyzing Files. {_metaDataHelper?.Matches.Count} Matches.");
                     }
                     progressBar.Message = $"Analyzing Files. {_metaDataHelper?.Matches.Count} Matches.";
                     progressBar.Tick(progressBar.MaxTicks);

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -483,35 +483,45 @@ namespace Microsoft.ApplicationInspector.Commands
                     ForegroundColor = ConsoleColor.Yellow,
                     ForegroundColorDone = ConsoleColor.DarkGreen,
                     BackgroundColor = ConsoleColor.DarkGray,
-                    BackgroundCharacter = '\u2593'
+                    BackgroundCharacter = '\u2593',
+                    DisableBottomPercentage = true
                 };
 
-                using var pbar = new IndeterminateProgressBar("Indeterminate", options);
-                pbar.Message = $"Enumerating Files.";
-
-                while (!done)
+                using (var pbar = new IndeterminateProgressBar("Enumerating Files.", options))
                 {
-                    Thread.Sleep(10);
-                }
+                    while (!done)
+                    {
+                        Thread.Sleep(10);
+                    }
 
-                pbar.Finished();
+                    pbar.Finished();
+                }
 
                 done = false;
 
-                float totFilesNum = fileQueue.Count;
-
-                using ProgressBar progressBar = new ProgressBar(10000, $"Analyzing {totFilesNum - _metaDataHelper?.Files.Count} files.");
-                IProgress<float> progress = progressBar.AsProgress<float>();
-                _ = Task.Factory.StartNew(() =>
+                var options2 = new ProgressBarOptions
                 {
-                    PopulateRecords(new CancellationToken(), _options, fileQueue);
-                    done = true;
-                });
+                    ForegroundColor = ConsoleColor.Yellow,
+                    ForegroundColorDone = ConsoleColor.DarkGreen,
+                    BackgroundColor = ConsoleColor.DarkGray,
+                    BackgroundCharacter = '\u2593',
+                    DisableBottomPercentage = false
+                };
 
-                while (!done)
+                using (var progressBar = new ProgressBar(fileQueue.Count, $"Analyzing Files.", options2))
                 {
-                    progressBar.Message = $"Analyzing {totFilesNum - _metaDataHelper?.Files.Count} files.";
-                    progress.Report(_metaDataHelper?.Files.Count / totFilesNum ?? 0);
+                    _ = Task.Factory.StartNew(() =>
+                    {
+                        PopulateRecords(new CancellationToken(), _options, fileQueue);
+                        done = true;
+                    });
+
+                    while (!done)
+                    {
+                        progressBar.Tick(_metaDataHelper?.Files.Count ?? 0);
+                        Thread.Sleep(10);
+                    }
+                    progressBar.Tick(progressBar.MaxTicks);
                 }
             }
             else

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -68,7 +68,6 @@ namespace Microsoft.ApplicationInspector.Commands
     /// </summary>
     public class AnalyzeCommand
     {
-        private readonly int WARN_ZIP_FILE_SIZE = 1024 * 1000 * 10;  // warning for large zip files
         private readonly int MAX_FILESIZE = 1024 * 1000 * 5;  // Skip source files larger than 5 MB and log
 
         private IEnumerable<string>? _srcfileList;
@@ -79,7 +78,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
         private DateTime _lastUpdated;
 
-        public MetaData MetaData { get { return _metaDataHelper.Metadata; } }
+        public MetaData? MetaData { get { return _metaDataHelper?.Metadata; } }
 
         /// <summary>
         /// Updated dynamically to more recent file in source

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -382,26 +382,23 @@ namespace Microsoft.ApplicationInspector.Commands
                         if (!t.Wait(new TimeSpan(0, 0, opts.FileTimeOut)))
                         {
                             WriteOnce.Error($"{file.FullPath} analysis timed out.");
-                            _metaDataHelper?.Metadata.IncrementFilesTimedOut();
                             record.Status = ScanState.TimedOut;
                             cts.Cancel();
                         }
                         else
                         {
-                            _metaDataHelper?.Metadata.IncrementFilesAnalyzed();
                             record.Status = ScanState.Analyzed;
                         }
                     }
                     else
                     {
                         results = _rulesProcessor.AnalyzeFile(file, languageInfo, null);
-                        _metaDataHelper?.Metadata.IncrementFilesAnalyzed();
                         record.Status = ScanState.Analyzed;
                     }
 
                     if (results.Any())
                     {
-                        _metaDataHelper?.Metadata.IncrementFilesAffected();
+                        record.Status = ScanState.Affected;
                         record.NumFindings = results.Count;
                     }
                     foreach (var matchRecord in results)
@@ -525,12 +522,12 @@ namespace Microsoft.ApplicationInspector.Commands
             }
 
             //wrapup result status
-            if (_metaDataHelper?.Metadata.TotalFiles == _metaDataHelper?.Metadata.FilesSkipped)
+            if (_metaDataHelper?.TotalFiles == _metaDataHelper?.FilesSkipped)
             {
                 WriteOnce.Error(MsgHelp.GetString(MsgHelp.ID.ANALYZE_NOSUPPORTED_FILETYPES));
                 analyzeResult.ResultCode = AnalyzeResult.ExitCode.NoMatches;
             }
-            else if (_metaDataHelper?.Metadata?.Matches?.Count == 0)
+            else if (_metaDataHelper?.Matches.Count == 0)
             {
                 WriteOnce.Error(MsgHelp.GetString(MsgHelp.ID.ANALYZE_NOPATTERNS));
                 analyzeResult.ResultCode = AnalyzeResult.ExitCode.NoMatches;

--- a/AppInspector/Commands/GetTagsCommand.cs
+++ b/AppInspector/Commands/GetTagsCommand.cs
@@ -64,7 +64,6 @@ namespace Microsoft.ApplicationInspector.Commands
     /// </summary>
     public class GetTagsCommand
     {
-        private readonly int WARN_ZIP_FILE_SIZE = 1024 * 1000 * 10;  // warning for large zip files
         private readonly int MAX_FILESIZE = 1024 * 1000 * 5;  // Skip source files larger than 5 MB and log
 
         private IEnumerable<string>? _srcfileList;

--- a/AppInspector/Commands/GetTagsCommand.cs
+++ b/AppInspector/Commands/GetTagsCommand.cs
@@ -486,7 +486,6 @@ namespace Microsoft.ApplicationInspector.Commands
                     while (!done)
                     {
                         Thread.Sleep(10);
-                        pbar.Message = $"Enumerating Files. {fileQueue.Count} Discovered.";
                     }
                     pbar.Message = $"Enumerating Files. {fileQueue.Count} Discovered.";
                     pbar.Finished();
@@ -514,8 +513,11 @@ namespace Microsoft.ApplicationInspector.Commands
                     while (!done)
                     {
                         Thread.Sleep(10);
-                        progressBar.Tick(_metaDataHelper?.Files.Count ?? 0);
-                        progressBar.Message = $"Analyzing Files. {_metaDataHelper?.UniqueTagsCount} Tags Found.";
+                        var current = (double)(_metaDataHelper?.Files.Count ?? 0);
+                        var timePerRecord = sw.Elapsed.TotalMilliseconds / current;
+                        var millisExpected = (int)(timePerRecord * (fileQueue.Count - (int)current));
+                        var timeExpected = new TimeSpan(0, 0, 0, 0, millisExpected);
+                        progressBar.Tick(_metaDataHelper?.Files.Count ?? 0, timeExpected, $"Analyzing Files. {_metaDataHelper?.UniqueTagsCount} Tags Found. ETA {timeExpected.ToString("hh\\:mm\\:ss")}.");
                     }
                     progressBar.Message = $"Analyzing Files. {_metaDataHelper?.UniqueTagsCount} Tags Found.";
                     progressBar.Tick(progressBar.MaxTicks);

--- a/AppInspector/Commands/GetTagsCommand.cs
+++ b/AppInspector/Commands/GetTagsCommand.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
         private DateTime _lastUpdated;
 
-        public MetaData MetaData { get { return _metaDataHelper.Metadata; } }
+        public MetaData? MetaData { get { return _metaDataHelper?.Metadata; } }
 
         /// <summary>
         /// Updated dynamically to more recent file in source
@@ -372,7 +372,7 @@ namespace Microsoft.ApplicationInspector.Commands
         {
             WriteOnce.SafeLog("GetTagsCommand::Run", LogLevel.Trace);
             WriteOnce.Operation(MsgHelp.FormatString(MsgHelp.ID.CMD_RUNNING, "GetTags"));
-            GetTagsResult analyzeResult = new GetTagsResult()
+            GetTagsResult getTagsResult = new GetTagsResult()
             {
                 AppVersion = Utils.GetVersionString()
             };
@@ -398,7 +398,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
                 while (!done)
                 {
-                    pbar.Message = $"Enumerating and Analyzing Files. {_metaDataHelper?.Metadata.TotalMatchesCount} findings in {_metaDataHelper?.Metadata.FilesAnalyzed} files.";
+                    pbar.Message = $"Enumerating and Analyzing Files. {_metaDataHelper?.UniqueTagsCount} tags in {_metaDataHelper?.Metadata.FilesAnalyzed} files.";
                     Thread.Sleep(10);
                 }
 
@@ -413,23 +413,23 @@ namespace Microsoft.ApplicationInspector.Commands
             if (_metaDataHelper?.Metadata.TotalFiles == _metaDataHelper?.Metadata.FilesSkipped)
             {
                 WriteOnce.Error(MsgHelp.GetString(MsgHelp.ID.ANALYZE_NOSUPPORTED_FILETYPES));
-                analyzeResult.ResultCode = GetTagsResult.ExitCode.NoMatches;
+                getTagsResult.ResultCode = GetTagsResult.ExitCode.NoMatches;
             }
-            else if (_metaDataHelper?.Metadata?.Matches?.Count == 0)
+            else if (_metaDataHelper?.UniqueTagsCount == 0)
             {
                 WriteOnce.Error(MsgHelp.GetString(MsgHelp.ID.ANALYZE_NOPATTERNS));
-                analyzeResult.ResultCode = GetTagsResult.ExitCode.NoMatches;
+                getTagsResult.ResultCode = GetTagsResult.ExitCode.NoMatches;
             }
             else if (_metaDataHelper != null && _metaDataHelper.Metadata != null)
             {
                 _metaDataHelper.Metadata.LastUpdated = LastUpdated.ToString();
                 _metaDataHelper.Metadata.DateScanned = DateScanned.ToString();
                 _metaDataHelper.PrepareReport();
-                analyzeResult.Metadata = _metaDataHelper.Metadata; //replace instance with metadatahelper processed one
-                analyzeResult.ResultCode = GetTagsResult.ExitCode.Success;
+                getTagsResult.Metadata = _metaDataHelper.Metadata; //replace instance with metadatahelper processed one
+                getTagsResult.ResultCode = GetTagsResult.ExitCode.Success;
             }
 
-            return analyzeResult;
+            return getTagsResult;
         }
 
         /// <summary>

--- a/AppInspector/Commands/GetTagsCommand.cs
+++ b/AppInspector/Commands/GetTagsCommand.cs
@@ -494,7 +494,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
                 float totFilesNum = fileQueue.Count;
 
-                using ProgressBar progressBar = new ProgressBar(10000, $"Analyzing {totFilesNum - _metaDataHelper?.Metadata.TotalFiles} files.");
+                using ProgressBar progressBar = new ProgressBar(10000, $"Analyzing {totFilesNum - _metaDataHelper?.Files.Count} files.");
                 IProgress<float> progress = progressBar.AsProgress<float>();
                 _ = Task.Factory.StartNew(() =>
                 {
@@ -504,8 +504,8 @@ namespace Microsoft.ApplicationInspector.Commands
 
                 while (!done)
                 {
-                    progressBar.Message = $"Analyzing {totFilesNum - _metaDataHelper?.Metadata.TotalFiles} files.";
-                    progress.Report(_metaDataHelper?.Metadata.TotalFiles/totFilesNum ?? 0);
+                    progressBar.Message = $"Analyzing {totFilesNum - _metaDataHelper?.Files.Count} files.";
+                    progress.Report(_metaDataHelper?.Files.Count/totFilesNum ?? 0);
                 }
             }
             else

--- a/AppInspector/Commands/GetTagsCommand.cs
+++ b/AppInspector/Commands/GetTagsCommand.cs
@@ -486,7 +486,8 @@ namespace Microsoft.ApplicationInspector.Commands
                     ForegroundColorDone = ConsoleColor.DarkGreen,
                     BackgroundColor = ConsoleColor.DarkGray,
                     BackgroundCharacter = '\u2593',
-                    DisableBottomPercentage = false
+                    DisableBottomPercentage = false,
+                    ShowEstimatedDuration = true
                 };
 
                 using (var progressBar = new ProgressBar(fileQueue.Count, $"Analyzing Files.", options2))
@@ -506,7 +507,7 @@ namespace Microsoft.ApplicationInspector.Commands
                         var timePerRecord = sw.Elapsed.TotalMilliseconds / current;
                         var millisExpected = (int)(timePerRecord * (fileQueue.Count - (int)current));
                         var timeExpected = new TimeSpan(0, 0, 0, 0, millisExpected);
-                        progressBar.Tick(_metaDataHelper?.Files.Count ?? 0, timeExpected, $"Analyzing Files. {_metaDataHelper?.UniqueTagsCount} Tags Found. ETA {timeExpected.ToString("hh\\:mm\\:ss")}.");
+                        progressBar.Tick(_metaDataHelper?.Files.Count ?? 0, timeExpected, $"Analyzing Files. {_metaDataHelper?.UniqueTagsCount} Tags Found.");
                     }
                     progressBar.Message = $"Analyzing Files. {_metaDataHelper?.UniqueTagsCount} Tags Found.";
                     progressBar.Tick(progressBar.MaxTicks);

--- a/AppInspector/Commands/GetTagsCommand.cs
+++ b/AppInspector/Commands/GetTagsCommand.cs
@@ -440,7 +440,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
                 record.ScanTime = sw.Elapsed;
 
-                _metaDataHelper?.Metadata.Files.Add(record);
+                _metaDataHelper?.Files.Add(record);
             }
         }
 

--- a/AppInspector/Commands/GetTagsCommand.cs
+++ b/AppInspector/Commands/GetTagsCommand.cs
@@ -95,12 +95,11 @@ namespace Microsoft.ApplicationInspector.Commands
 
         private readonly List<string>? _fileExclusionList;
         private Confidence _confidence;
-        private readonly AnalyzeOptions _options; //copy of incoming caller options
+        private readonly GetTagsCommandOptions _options; //copy of incoming caller options
 
         public GetTagsCommand(GetTagsCommandOptions opt)
         {
             _options = opt;
-            _options.MatchDepth ??= "best";
 
             if (!string.IsNullOrEmpty(opt.FilePathExclusions))
             {
@@ -293,14 +292,14 @@ namespace Microsoft.ApplicationInspector.Commands
 
         #endregion configureMethods
 
-        public void PopulateRecords(CancellationToken cancellationToken, AnalyzeOptions opts)
+        public void PopulateRecords(CancellationToken cancellationToken, GetTagsCommandOptions opts)
         {
-            WriteOnce.SafeLog("AnalyzeCommand::EnumerateRecords", LogLevel.Trace);
+            WriteOnce.SafeLog("GetTagsCommand::PopulateRecords", LogLevel.Trace);
 
-            var analyzeResult = new AnalyzeResult();
+            var gtr = new GetTagsResult();
             if (_rulesProcessor is null)
             {
-                analyzeResult.ResultCode = AnalyzeResult.ExitCode.CriticalError;
+                gtr.ResultCode = GetTagsResult.ExitCode.CriticalError;
                 return;
             }
 
@@ -374,7 +373,7 @@ namespace Microsoft.ApplicationInspector.Commands
         {
             WriteOnce.SafeLog("GetTagsCommand::Run", LogLevel.Trace);
             WriteOnce.Operation(MsgHelp.FormatString(MsgHelp.ID.CMD_RUNNING, "GetTags"));
-            GetTagsResult analyzeResult = new AnalyzeResult()
+            GetTagsResult analyzeResult = new GetTagsResult()
             {
                 AppVersion = Utils.GetVersionString()
             };

--- a/AppInspector/Commands/GetTagsCommand.cs
+++ b/AppInspector/Commands/GetTagsCommand.cs
@@ -486,8 +486,9 @@ namespace Microsoft.ApplicationInspector.Commands
                     while (!done)
                     {
                         Thread.Sleep(10);
+                        pbar.Message = $"Enumerating Files. {fileQueue.Count} Discovered.";
                     }
-
+                    pbar.Message = $"Enumerating Files. {fileQueue.Count} Discovered.";
                     pbar.Finished();
                 }
 
@@ -512,9 +513,11 @@ namespace Microsoft.ApplicationInspector.Commands
 
                     while (!done)
                     {
-                        progressBar.Tick(_metaDataHelper?.Files.Count ?? 0);
                         Thread.Sleep(10);
+                        progressBar.Tick(_metaDataHelper?.Files.Count ?? 0);
+                        progressBar.Message = $"Analyzing Files. {_metaDataHelper?.UniqueTagsCount} Tags Found.";
                     }
+                    progressBar.Message = $"Analyzing Files. {_metaDataHelper?.UniqueTagsCount} Tags Found.";
                     progressBar.Tick(progressBar.MaxTicks);
                 }
             }

--- a/AppInspector/Commands/GetTagsCommand.cs
+++ b/AppInspector/Commands/GetTagsCommand.cs
@@ -301,7 +301,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
             foreach (var srcFile in _srcfileList ?? Array.Empty<string>())
             {
-                foreach (var file in extractor.Extract(srcFile))
+                foreach (var file in extractor.Extract(srcFile, new ExtractorOptions() { Parallel = false }))
                 {
                     yield return file;
                 }

--- a/AppInspector/Commands/GetTagsCommand.cs
+++ b/AppInspector/Commands/GetTagsCommand.cs
@@ -514,7 +514,7 @@ namespace Microsoft.ApplicationInspector.Commands
             }
 
             //wrapup result status
-            if (_metaDataHelper?.Metadata.TotalFiles == _metaDataHelper?.Metadata.FilesSkipped)
+            if (_metaDataHelper?.Files.All(x => x.Status == ScanState.Skipped) ?? false)
             {
                 WriteOnce.Error(MsgHelp.GetString(MsgHelp.ID.ANALYZE_NOSUPPORTED_FILETYPES));
                 getTagsResult.ResultCode = GetTagsResult.ExitCode.NoMatches;

--- a/AppInspector/Commands/PackRulesCommand.cs
+++ b/AppInspector/Commands/PackRulesCommand.cs
@@ -144,7 +144,7 @@ namespace Microsoft.ApplicationInspector.Commands
                 {
                     throw new OpException(MsgHelp.GetString(MsgHelp.ID.VERIFY_RULES_RESULTS_FAIL));
                 }
-                packRulesResult.Rules = new List<Rule>(verifier.CompiledRuleset?.AsEnumerable() ?? new RuleSet(null).AsEnumerable());
+                packRulesResult.Rules = verifier.CompiledRuleset?.GetAppInspectorRules().ToList() ?? new List<Rule>();
                 packRulesResult.ResultCode = PackRulesResult.ExitCode.Success;
             }
             catch (OpException e)

--- a/AppInspector/Commands/TagTestCommand.cs
+++ b/AppInspector/Commands/TagTestCommand.cs
@@ -253,11 +253,11 @@ namespace Microsoft.ApplicationInspector.Commands
         {
             if (_arg_tagTestType == TagTestType.RulesNotPresent)
             {
-                return (!list.Any(v => v.Equals(test)));
+                return (!list?.Any(v => v.Equals(test)) ?? false);
             }
             else
             {
-                return (list.Any(v => v.Equals(test)));
+                return (list?.Any(v => v.Equals(test)) ?? false);
             }
         }
     }

--- a/AppInspector/FileRecord.cs
+++ b/AppInspector/FileRecord.cs
@@ -19,6 +19,7 @@ namespace Microsoft.ApplicationInspector.Commands
         None,
         Skipped,
         TimedOut,
-        Analyzed
+        Analyzed,
+        Affected
     }
 }

--- a/AppInspector/FileRecord.cs
+++ b/AppInspector/FileRecord.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.ApplicationInspector.Commands
+{
+    public class FileRecord
+    {
+        public string FileName { get; set; } = string.Empty;
+        //public long Size { get; set; } = 0;
+        public TimeSpan ScanTime { get; set; } = new TimeSpan();
+    }
+}

--- a/AppInspector/FileRecord.cs
+++ b/AppInspector/FileRecord.cs
@@ -9,7 +9,16 @@ namespace Microsoft.ApplicationInspector.Commands
     public class FileRecord
     {
         public string FileName { get; set; } = string.Empty;
-        //public long Size { get; set; } = 0;
         public TimeSpan ScanTime { get; set; } = new TimeSpan();
+        public ScanState Status { get; set; } = ScanState.None;
+        public int NumFindings { get; set; } = 0;
+    }
+
+    public enum ScanState
+    {
+        None,
+        Skipped,
+        TimedOut,
+        Analyzed
     }
 }

--- a/AppInspector/MetaData.cs
+++ b/AppInspector/MetaData.cs
@@ -65,44 +65,34 @@ namespace Microsoft.ApplicationInspector.Commands
         //stats
 
         /// <summary>
-        /// Total number of files Timed out 
-        /// </summary>
-        [JsonProperty(PropertyName = "filesTimedOut")]
-        public int FilesTimedOut { get { return _FilesTimedOut; } set { _FilesTimedOut = value; } }
-
-        private int _FilesTimedOut;
-
-        /// <summary>
-        /// Total number of files scanned successfully
-        /// </summary>
-        [JsonProperty(PropertyName = "filesAnalyzed")]
-        public int FilesAnalyzed { get { return _FilesAnalyzed; } set { _FilesAnalyzed = value; } }
-
-        private int _FilesAnalyzed;
-
-        /// <summary>
         /// Total number of files in source path
         /// </summary>
         [JsonProperty(PropertyName = "totalFiles")]
-        public int TotalFiles { get { return _TotalFiles; } set { _TotalFiles = value; } }
+        public int TotalFiles { get { return Files.Count; } }
 
-        private int _TotalFiles;
+        /// <summary>
+        /// Total number of files Timed out 
+        /// </summary>
+        [JsonProperty(PropertyName = "filesTimedOut")]
+        public int FilesTimedOut { get { return Files.Count(x => x.Status == ScanState.TimedOut); } }
+
+        /// <summary>
+        /// Total number of files scanned
+        /// </summary>
+        [JsonProperty(PropertyName = "filesAnalyzed")]
+        public int FilesAnalyzed { get { return Files.Count(x => x.Status == ScanState.Analyzed || x.Status == ScanState.Affected); } }
 
         /// <summary>
         /// Total number of skipped files based on supported formats
         /// </summary>
         [JsonProperty(PropertyName = "filesSkipped")]
-        public int FilesSkipped { get { return _FilesSkipped; } set { _FilesSkipped = value; } }
-
-        private int _FilesSkipped;
+        public int FilesSkipped { get { return Files.Count(x => x.Status == ScanState.Skipped); } }
 
         /// <summary>
         /// Total files with at least one result
         /// </summary>
         [JsonProperty(PropertyName = "filesAffected")]
-        public int FilesAffected { get { return _FilesAffected; } set { _FilesAffected = value; } }
-
-        private int _FilesAffected;
+        public int FilesAffected { get { return Files.Count(x => x.Status == ScanState.Affected); } }
 
         /// <summary>
         /// Total matches with supplied argument settings
@@ -111,7 +101,7 @@ namespace Microsoft.ApplicationInspector.Commands
         public int TotalMatchesCount { get { return Matches?.Count ?? 0; } }
 
         /// <summary>
-        /// Total unique matches by tag
+        /// Total unique matches by Rule Id
         /// </summary>
         [JsonProperty(PropertyName = "uniqueMatchesCount")]
         public int UniqueMatchesCount { 
@@ -197,40 +187,15 @@ namespace Microsoft.ApplicationInspector.Commands
         /// List of detailed MatchRecords from scan
         /// </summary>
         [JsonProperty(PropertyName = "detailedMatchList")]
-        public ConcurrentBag<MatchRecord>? Matches { get; set; } = new ConcurrentBag<MatchRecord>();
+        public List<MatchRecord> Matches { get; set; } = new List<MatchRecord>();
 
         [JsonProperty(PropertyName = "filesInformation")]
-        public ConcurrentBag<FileRecord> Files { get; set; } = new ConcurrentBag<FileRecord>();
+        public List<FileRecord> Files { get; set; } = new List<FileRecord>();
 
         public MetaData(string applicationName, string sourcePath)
         {
             ApplicationName = applicationName;
             SourcePath = sourcePath;
-        }
-
-        internal void IncrementFilesTimedOut(int amount = 1)
-        {
-            Interlocked.Add(ref _FilesTimedOut, amount);
-        }
-
-        internal void IncrementFilesAnalyzed(int amount = 1)
-        {
-            Interlocked.Add(ref _FilesAnalyzed, amount);
-        }
-
-        internal void IncrementTotalFiles(int amount = 1)
-        {
-            Interlocked.Add(ref _TotalFiles, amount);
-        }
-
-        internal void IncrementFilesAffected(int amount = 1)
-        {
-            Interlocked.Add(ref _FilesAffected, amount);
-        }
-
-        internal void IncrementFilesSkipped(int amount = 1)
-        {
-            Interlocked.Add(ref _FilesSkipped, amount);
         }
     }
 }

--- a/AppInspector/MetaData.cs
+++ b/AppInspector/MetaData.cs
@@ -109,10 +109,7 @@ namespace Microsoft.ApplicationInspector.Commands
         public int UniqueMatchesCount { 
             get 
             {
-                if (UniqueTags != null)
-                    return UniqueTags.Count;
-                else 
-                    return 0;
+                return Matches?.Select(x => x.Rule).Distinct().Count() ?? 0;
             } 
         }
 
@@ -133,7 +130,6 @@ namespace Microsoft.ApplicationInspector.Commands
         /// </summary>
         [JsonProperty(PropertyName = "uniqueTags")]
         public List<string>? UniqueTags { get; set; } = new List<string>();
-
 
         /// <summary>
         /// List of detected unique code dependency includes
@@ -193,7 +189,7 @@ namespace Microsoft.ApplicationInspector.Commands
         /// List of detailed MatchRecords from scan
         /// </summary>
         [JsonProperty(PropertyName = "detailedMatchList")]
-        public List<MatchRecord>? Matches { get; } = new List<MatchRecord>();
+        public ConcurrentBag<MatchRecord>? Matches { get; } = new ConcurrentBag<MatchRecord>();
 
         public MetaData(string applicationName, string sourcePath)
         {

--- a/AppInspector/MetaData.cs
+++ b/AppInspector/MetaData.cs
@@ -100,9 +100,7 @@ namespace Microsoft.ApplicationInspector.Commands
         /// Total matches with supplied argument settings
         /// </summary>
         [JsonProperty(PropertyName = "totalMatchesCount")]
-        public int TotalMatchesCount { get { return _TotalMatchesCount; } set { _TotalMatchesCount = value; } }
-
-        private int _TotalMatchesCount;
+        public int TotalMatchesCount { get { return Matches?.Count ?? 0; } }
 
         /// <summary>
         /// Total unique matches by tag
@@ -114,7 +112,7 @@ namespace Microsoft.ApplicationInspector.Commands
                 if (UniqueTags != null)
                     return UniqueTags.Count;
                 else 
-                    return 0; 
+                    return 0;
             } 
         }
 
@@ -211,11 +209,6 @@ namespace Microsoft.ApplicationInspector.Commands
         internal void IncrementTotalFiles(int amount = 1)
         {
             Interlocked.Add(ref _TotalFiles, amount);
-        }
-
-        internal void IncrementTotalMatchesCount(int amount = 1)
-        {
-            Interlocked.Add(ref _TotalMatchesCount, amount);
         }
 
         internal void IncrementFilesAffected(int amount = 1)

--- a/AppInspector/MetaData.cs
+++ b/AppInspector/MetaData.cs
@@ -109,7 +109,7 @@ namespace Microsoft.ApplicationInspector.Commands
         public int UniqueMatchesCount { 
             get 
             {
-                return Matches?.Select(x => x.Rule).Distinct().Count() ?? 0;
+                return Matches?.Select(x => x.RuleId).Distinct().Count() ?? 0;
             } 
         }
 
@@ -189,7 +189,7 @@ namespace Microsoft.ApplicationInspector.Commands
         /// List of detailed MatchRecords from scan
         /// </summary>
         [JsonProperty(PropertyName = "detailedMatchList")]
-        public ConcurrentBag<MatchRecord>? Matches { get; } = new ConcurrentBag<MatchRecord>();
+        public ConcurrentBag<MatchRecord>? Matches { get; set; } = new ConcurrentBag<MatchRecord>();
 
         public MetaData(string applicationName, string sourcePath)
         {

--- a/AppInspector/MetaData.cs
+++ b/AppInspector/MetaData.cs
@@ -65,6 +65,14 @@ namespace Microsoft.ApplicationInspector.Commands
         //stats
 
         /// <summary>
+        /// Total number of files Timed out 
+        /// </summary>
+        [JsonProperty(PropertyName = "filesTimedOut")]
+        public int FilesTimedOut { get { return _FilesTimedOut; } set { _FilesTimedOut = value; } }
+
+        private int _FilesTimedOut;
+
+        /// <summary>
         /// Total number of files scanned successfully
         /// </summary>
         [JsonProperty(PropertyName = "filesAnalyzed")]
@@ -191,10 +199,18 @@ namespace Microsoft.ApplicationInspector.Commands
         [JsonProperty(PropertyName = "detailedMatchList")]
         public ConcurrentBag<MatchRecord>? Matches { get; set; } = new ConcurrentBag<MatchRecord>();
 
+        [JsonProperty(PropertyName = "filesInformation")]
+        public ConcurrentBag<FileRecord> Files { get; set; } = new ConcurrentBag<FileRecord>();
+
         public MetaData(string applicationName, string sourcePath)
         {
             ApplicationName = applicationName;
             SourcePath = sourcePath;
+        }
+
+        internal void IncrementFilesTimedOut(int amount = 1)
+        {
+            Interlocked.Add(ref _FilesTimedOut, amount);
         }
 
         internal void IncrementFilesAnalyzed(int amount = 1)

--- a/AppInspector/MetaDataHelper.cs
+++ b/AppInspector/MetaDataHelper.cs
@@ -37,42 +37,7 @@ namespace Microsoft.ApplicationInspector.Commands
         internal ConcurrentBag<MatchRecord> Matches { get; set; } = new ConcurrentBag<MatchRecord>();
         internal ConcurrentBag<FileRecord> Files { get; set; } = new ConcurrentBag<FileRecord>();
 
-        /// <summary>
-        /// Total number of files Timed out 
-        /// </summary>
-        public int FilesTimedOut { get { return _FilesTimedOut; } set { _FilesTimedOut = value; } }
-
-        private int _FilesTimedOut;
-
-        /// <summary>
-        /// Total number of files scanned successfully
-        /// </summary>
-        public int FilesAnalyzed { get { return _FilesAnalyzed; } set { _FilesAnalyzed = value; } }
-
-        private int _FilesAnalyzed;
-
-        /// <summary>
-        /// Total number of files in source path
-        /// </summary>
-        public int TotalFiles { get { return _TotalFiles; } set { _TotalFiles = value; } }
-
-        private int _TotalFiles;
-
-        /// <summary>
-        /// Total number of skipped files based on supported formats
-        /// </summary>
-        public int FilesSkipped { get { return _FilesSkipped; } set { _FilesSkipped = value; } }
-
-        private int _FilesSkipped;
-
-        /// <summary>
-        /// Total files with at least one result
-        /// </summary>
-        public int FilesAffected { get { return _FilesAffected; } set { _FilesAffected = value; } }
-
-        private int _FilesAffected;
-
-        public int UniqueTagsCount { get { return UniqueTags.Count; } }
+        public int UniqueTagsCount { get { return UniqueTags.Keys.Count; } }
 
         internal MetaData Metadata { get; set; }
 
@@ -238,7 +203,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     _ = UniqueTags.TryAdd(tag,0);
                 }
                 
-                Metadata?.Matches?.Add(matchRecord);
+                Matches.Add(matchRecord);
             }
         }
 

--- a/AppInspector/MetaDataHelper.cs
+++ b/AppInspector/MetaDataHelper.cs
@@ -34,6 +34,8 @@ namespace Microsoft.ApplicationInspector.Commands
         private ConcurrentDictionary<string,MetricTagCounter> TagCounters { get; set; } = new ConcurrentDictionary<string, MetricTagCounter>();
         private ConcurrentDictionary<string, int> Languages { get; set; } = new ConcurrentDictionary<string, int>();
 
+        public int UniqueTagsCount { get { return UniqueTags.Count; } }
+
         internal MetaData Metadata { get; set; }
 
         public MetaDataHelper(string sourcePath, bool uniqueMatchesOnly)

--- a/AppInspector/MetaDataHelper.cs
+++ b/AppInspector/MetaDataHelper.cs
@@ -76,8 +76,7 @@ namespace Microsoft.ApplicationInspector.Commands
                         _ = Outputs.TryAdd(ExtractValue(matchRecord.Sample).ToLower(), 0);
                         break;
                     case "Dependency.SourceInclude":
-                        allowAdd = false; //design to keep noise out of detailed match list
-                        break;
+                        return; //design to keep noise out of detailed match list
                     default:
                         if (tag.Contains("Metric."))
                         {
@@ -102,7 +101,7 @@ namespace Microsoft.ApplicationInspector.Commands
             string solutionType = DetectSolutionType(matchRecord);
             if (!string.IsNullOrEmpty(solutionType))
             {
-                _ = AppTypes.TryAdd(solutionType,0);
+                _ = AppTypes.TryAdd(solutionType, 0);
             }
 
             bool CounterOnlyTagSet = false;
@@ -121,15 +120,8 @@ namespace Microsoft.ApplicationInspector.Commands
                 {
                     _ = UniqueTags.TryAdd(tag,0);
                 }
-
-                if (allowAdd)
-                {
-                    Metadata?.Matches?.Add(matchRecord);
-                }
-            }
-            else
-            {
-                Metadata.IncrementTotalMatchesCount(-1);//reduce e.g. tag counters not included as detailed match
+                
+                Metadata?.Matches?.Add(matchRecord);
             }
         }
 

--- a/AppInspector/MetaDataHelper.cs
+++ b/AppInspector/MetaDataHelper.cs
@@ -34,6 +34,44 @@ namespace Microsoft.ApplicationInspector.Commands
         private ConcurrentDictionary<string,MetricTagCounter> TagCounters { get; set; } = new ConcurrentDictionary<string, MetricTagCounter>();
         private ConcurrentDictionary<string, int> Languages { get; set; } = new ConcurrentDictionary<string, int>();
 
+        internal ConcurrentBag<MatchRecord> Matches { get; set; } = new ConcurrentBag<MatchRecord>();
+        internal ConcurrentBag<FileRecord> Files { get; set; } = new ConcurrentBag<FileRecord>();
+
+        /// <summary>
+        /// Total number of files Timed out 
+        /// </summary>
+        public int FilesTimedOut { get { return _FilesTimedOut; } set { _FilesTimedOut = value; } }
+
+        private int _FilesTimedOut;
+
+        /// <summary>
+        /// Total number of files scanned successfully
+        /// </summary>
+        public int FilesAnalyzed { get { return _FilesAnalyzed; } set { _FilesAnalyzed = value; } }
+
+        private int _FilesAnalyzed;
+
+        /// <summary>
+        /// Total number of files in source path
+        /// </summary>
+        public int TotalFiles { get { return _TotalFiles; } set { _TotalFiles = value; } }
+
+        private int _TotalFiles;
+
+        /// <summary>
+        /// Total number of skipped files based on supported formats
+        /// </summary>
+        public int FilesSkipped { get { return _FilesSkipped; } set { _FilesSkipped = value; } }
+
+        private int _FilesSkipped;
+
+        /// <summary>
+        /// Total files with at least one result
+        /// </summary>
+        public int FilesAffected { get { return _FilesAffected; } set { _FilesAffected = value; } }
+
+        private int _FilesAffected;
+
         public int UniqueTagsCount { get { return UniqueTags.Count; } }
 
         internal MetaData Metadata { get; set; }
@@ -220,6 +258,8 @@ namespace Microsoft.ApplicationInspector.Commands
             Metadata.FileExtensions = FileExtensions.Keys.ToList();
             Metadata.Outputs = Outputs.Keys.ToList();
             Metadata.Targets = Targets.Keys.ToList();
+            Metadata.Files = Files.ToList();
+            Metadata.Matches = Matches.ToList();
 
             Metadata.CPUTargets.Sort();
             Metadata.AppTypes.Sort();
@@ -250,7 +290,6 @@ namespace Microsoft.ApplicationInspector.Commands
         }
 
         #region helpers
-
         /// <summary>
         /// Initial best guess to deduce project name; if scanned metadata from project solution value is replaced later
         /// </summary>

--- a/Benchmarks/AnalyzeBenchmark.cs
+++ b/Benchmarks/AnalyzeBenchmark.cs
@@ -25,7 +25,6 @@ namespace Benchmarks
             AnalyzeCommand command = new AnalyzeCommand(new AnalyzeOptions()
             {
                 SourcePath = path,
-                AllowDupTags = false,
                 SingleThread = true,
                 IgnoreDefaultRules = false
             });
@@ -39,7 +38,6 @@ namespace Benchmarks
             AnalyzeCommand command = new AnalyzeCommand(new AnalyzeOptions()
             {
                 SourcePath = path,
-                AllowDupTags = false,
                 SingleThread = false,
                 IgnoreDefaultRules = false
             });

--- a/RulesEngine/AppInspector.RulesEngine.csproj
+++ b/RulesEngine/AppInspector.RulesEngine.csproj
@@ -25,9 +25,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.0.74" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NLog" Version="4.7.5" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.0.83" />
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.0.58" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NLog" Version="4.7.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RulesEngine/Language.cs
+++ b/RulesEngine/Language.cs
@@ -27,14 +27,14 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             Stream? resource = assembly.GetManifestResourceStream("Microsoft.ApplicationInspector.RulesEngine.Resources.comments.json");
             using (StreamReader file = new StreamReader(resource ?? new MemoryStream()))
             {
-                Comments = JsonConvert.DeserializeObject<List<Comment>>(file.ReadToEnd());
+                Comments = JsonConvert.DeserializeObject<List<Comment>>(file.ReadToEnd()) ?? new List<Comment>(); ;
             }
 
             // Load languages
             resource = assembly.GetManifestResourceStream("Microsoft.ApplicationInspector.RulesEngine.Resources.languages.json");
             using (StreamReader file = new StreamReader(resource ?? new MemoryStream()))
             {
-                Languages = JsonConvert.DeserializeObject<List<LanguageInfo>>(file.ReadToEnd());
+                Languages = JsonConvert.DeserializeObject<List<LanguageInfo>>(file.ReadToEnd()) ?? new List<LanguageInfo>();
             }
         }
         /// <summary>
@@ -69,7 +69,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                 {
                     if (item.Name == "typescript-config")//special case where extension used for exact match to a single type
                     {
-                        if (item.Extensions.Any(x => x.ToLower().Equals(file)))
+                        if (item.Extensions?.Any(x => x.ToLower().Equals(file)) ?? false)
                         {
                             info = item;
                             return true;
@@ -120,7 +120,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             {
                 foreach (Comment comment in Instance.Comments)
                 {
-                    if (comment.Languages.Contains(language.ToLower(CultureInfo.InvariantCulture)) && comment.Prefix is { })
+                    if ((comment.Languages?.Contains(language.ToLower(CultureInfo.InvariantCulture)) ?? false) && comment.Prefix is { })
                         return comment.Prefix;
                 }
             }

--- a/RulesEngine/RuleProcessor.cs
+++ b/RulesEngine/RuleProcessor.cs
@@ -167,7 +167,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                                     var boundary = match.Item2;
 
                                     //restrict adds from build files to tags with "metadata" only to avoid false feature positives that are not part of executable code
-                                    if (!_treatEverythingAsCode && languageInfo.Type == LanguageInfo.LangFileType.Build && oatRule.AppInspectorRule.Tags.Any(v => !v.Contains("Metadata")))
+                                    if (!_treatEverythingAsCode && languageInfo.Type == LanguageInfo.LangFileType.Build && (oatRule.AppInspectorRule.Tags?.Any(v => !v.Contains("Metadata")) ?? false))
                                     {
                                         continue;
                                     }
@@ -279,7 +279,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                                     var boundary = match.Item2;
 
                                     //restrict adds from build files to tags with "metadata" only to avoid false feature positives that are not part of executable code
-                                    if (!_treatEverythingAsCode && languageInfo.Type == LanguageInfo.LangFileType.Build && oatRule.AppInspectorRule.Tags.Any(v => !v.Contains("Metadata")))
+                                    if (!_treatEverythingAsCode && languageInfo.Type == LanguageInfo.LangFileType.Build && (oatRule.AppInspectorRule.Tags?.Any(v => !v.Contains("Metadata")) ?? false))
                                     {
                                         continue;
                                     }

--- a/RulesEngine/RuleProcessor.cs
+++ b/RulesEngine/RuleProcessor.cs
@@ -118,10 +118,14 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             return rawResult;
         }
 
-        public List<MatchRecord> AnalyzeFile(FileEntry fileEntry, LanguageInfo languageInfo)
+        public List<MatchRecord> AnalyzeFile(FileEntry fileEntry, LanguageInfo languageInfo, IEnumerable<string>? tagsToIgnore)
         {
             var rulesByLanguage = GetRulesByLanguage(languageInfo.Name).Where(x => !x.AppInspectorRule.Disabled && SeverityLevel.HasFlag(x.AppInspectorRule.Severity));
             var rules = rulesByLanguage.Union(GetRulesByFileName(fileEntry.FullPath).Where(x => !x.AppInspectorRule.Disabled && SeverityLevel.HasFlag(x.AppInspectorRule.Severity)));
+            if (tagsToIgnore is not null && tagsToIgnore.Any())
+            {
+                rules = rules.Where(x => x.Tags.Any(y => !tagsToIgnore.Contains(y)));
+            }
             List<MatchRecord> resultsList = new List<MatchRecord>();
 
             using var sr = new StreamReader(fileEntry.Content);

--- a/RulesEngine/RuleProcessor.cs
+++ b/RulesEngine/RuleProcessor.cs
@@ -36,7 +36,6 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         private readonly int MAX_TEXT_SAMPLE_LENGTH = 200;//char bytes
 
         private Confidence ConfidenceLevelFilter { get; set; }
-        private readonly bool _stopAfterFirstMatch;
         private readonly bool _uniqueTagMatchesOnly;
         private readonly Logger? _logger;
         private readonly bool _treatEverythingAsCode;

--- a/RulesEngine/RuleProcessor.cs
+++ b/RulesEngine/RuleProcessor.cs
@@ -395,7 +395,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                                     var boundary = match.Item2;
 
                                     //restrict adds from build files to tags with "metadata" only to avoid false feature positives that are not part of executable code
-                                    if (!_treatEverythingAsCode && languageInfo.Type == LanguageInfo.LangFileType.Build && oatRule.AppInspectorRule.Tags.Any(v => !v.Contains("Metadata")))
+                                    if (!_treatEverythingAsCode && languageInfo.Type == LanguageInfo.LangFileType.Build && (oatRule.AppInspectorRule.Tags?.Any(v => !v.Contains("Metadata")) ?? false))
                                     {
                                         continue;
                                     }

--- a/RulesEngine/RuleProcessor.cs
+++ b/RulesEngine/RuleProcessor.cs
@@ -15,6 +15,19 @@ using System.Threading.Tasks;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
+    public class RuleProcessorOptions
+    {
+        public RuleProcessorOptions()
+        {
+
+        }
+
+        public Confidence confidenceFilter;
+        public Logger? logger;
+        public bool uniqueMatches = false;
+        public bool treatEverythingAsCode = false;
+    }
+
     /// <summary>
     /// Heart of RulesEngine. Parses code applies rules
     /// </summary>
@@ -49,17 +62,16 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         /// <summary>
         /// Creates instance of RuleProcessor
         /// </summary>
-        public RuleProcessor(RuleSet rules, Confidence confidenceFilter, Logger? logger, bool uniqueMatches = false, bool stopAfterFirstMatch = false, bool treatEverythingAsCode = false)
+        public RuleProcessor(RuleSet rules, RuleProcessorOptions opts)
         {
             _ruleset = rules;
             EnableCache = true;
             _uniqueTagHashes = new ConcurrentDictionary<string,byte>();
             _rulesCache = new ConcurrentDictionary<string, IEnumerable<ConvertedOatRule>>();
-            _stopAfterFirstMatch = stopAfterFirstMatch;
-            _uniqueTagMatchesOnly = uniqueMatches;
-            _logger = logger;
-            _treatEverythingAsCode = treatEverythingAsCode;
-            ConfidenceLevelFilter = confidenceFilter;
+            _uniqueTagMatchesOnly = opts.uniqueMatches;
+            _logger = opts.logger;
+            _treatEverythingAsCode = opts.treatEverythingAsCode;
+            ConfidenceLevelFilter = opts.confidenceFilter;
             SeverityLevel = Severity.Critical | Severity.Important | Severity.Moderate | Severity.BestPractice; //finds all; arg not currently supported
 
             analyzer = new Analyzer();

--- a/RulesEngine/SearchPattern.cs
+++ b/RulesEngine/SearchPattern.cs
@@ -40,16 +40,5 @@ namespace Microsoft.ApplicationInspector.RulesEngine
 
         [JsonProperty(PropertyName = "scopes")]
         public PatternScope[]? Scopes { get; set; }
-
-        public Regex GetRegex(RegexOptions opts)
-        {
-            if (!_compiled.ContainsKey(opts))
-            {
-                _compiled[opts] = new Regex(Pattern, opts | RegexOptions.Compiled);
-            }
-            return _compiled[opts];
-        }
-
-
     }
 }

--- a/RulesEngine/TextContainer.cs
+++ b/RulesEngine/TextContainer.cs
@@ -249,7 +249,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                     }
 
                     var commentedText = text.Substring(lastInline);
-                    int endOfLine = commentedText.IndexOf("\n");//Environment.Newline looks for /r/n which is not guaranteed
+                    int endOfLine = commentedText.IndexOf('\n');//Environment.Newline looks for /r/n which is not guaranteed
                     if (endOfLine < 0)
                     {
                         endOfLine = commentedText.Length - 1;

--- a/UnitTest.Commands/Tests_CLI/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestAnalyzeCmd.cs
@@ -349,10 +349,11 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -r {1} -f json -o {2}",
+                string args = string.Format(@"analyze -s {0} -r {1} -f json -o {2} -k {3}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\project\one"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"),
+                    ".cpp");
 
                 exitCode = (AnalyzeResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
             }

--- a/UnitTest.Commands/Tests_CLI/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestAnalyzeCmd.cs
@@ -73,23 +73,6 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         }
 
         [TestMethod]
-        public void DupTagsHTMLOutput_Fail() //dupliacte tags not supported for html format
-        {
-            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"analyze -b -s {0} -f html -k none -d", Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"));
-                exitCode = (AnalyzeResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-                //check for specific error if desired
-            }
-
-            Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.CriticalError);
-        }
-
-        [TestMethod]
         public void UnknownFormat_Fail() //dupliacte tags not supported for html format
         {
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
@@ -371,7 +354,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
 
             try
             {
-                string args = string.Format(@"analyze -s {0} -d -f json -o {1} -k none --single-threaded",
+                string args = string.Format(@"analyze -s {0} -f json -o {1} -k none --single-threaded",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -395,7 +378,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             try
             {
 
-                string args = string.Format(@"analyze -s {0} -d -f json -o {1} -k none",
+                string args = string.Format(@"analyze -s {0} -f json -o {1} -k none",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 

--- a/UnitTest.Commands/Tests_CLI/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestAnalyzeCmd.cs
@@ -416,32 +416,6 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         }
 
         [TestMethod]
-        public void ExpectedTagCountNoDupsAllowed_Pass()
-        {
-            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"analyze -s {0} -f json -o {1} -k none",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
-
-                exitCode = (AnalyzeResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-
-                if (exitCode == AnalyzeResult.ExitCode.Success)
-                {
-                    string content = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
-                    var result = JsonConvert.DeserializeObject<AnalyzeResult>(content);
-                    exitCode = result.Metadata.TotalMatchesCount == 7 && result.Metadata.UniqueMatchesCount == 7 ? AnalyzeResult.ExitCode.Success : AnalyzeResult.ExitCode.NoMatches;
-                }
-            }
-            catch (Exception)
-            {
-            }
-
-            Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.Success);
-        }
-
-        [TestMethod]
         public void NoMatchesFound_Pass()
         {
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;

--- a/UnitTest.Commands/Tests_CLI/TestGetTagsCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestGetTagsCmd.cs
@@ -1,0 +1,440 @@
+﻿using ApplicationInspector.Unitprocess.Misc;
+using Microsoft.ApplicationInspector.Commands;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System;
+using System.IO;
+
+namespace ApplicationInspector.Unitprocess.CLICommands
+{
+    /// <summary>
+    /// Test class for Analyze Commands
+    /// Each method really needs to be complete i.e. options and command objects created and checked for exceptions etc. based on inputs so
+    /// doesn't create a set of shared objects
+    ///
+    /// </summary>
+    [TestClass]
+    public class CLITestGetTagsCommand
+    {
+        [TestInitialize]
+        public void InitOutput()
+        {
+            Directory.CreateDirectory(Helper.GetPath(Helper.AppPath.testOutput));
+        }
+
+        [TestCleanup]
+        public void CleanUp()
+        {
+            try
+            {
+                Directory.Delete(Helper.GetPath(Helper.AppPath.testOutput), true);
+            }
+            catch
+            {
+            }
+
+            //because these are static and each test is meant to be indpendent null assign the references to create the log
+            WriteOnce.Log = null;
+            Utils.Logger = null;
+        }
+
+
+        [TestMethod]
+        public void UnknownFormat_Fail()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -b -s {0} -f unknown -k none", Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"));
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+            }
+            catch (Exception)
+            {
+                //check for specific error if desired
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);
+        }
+
+        [TestMethod]
+        public void InvalidOutputfilePath_Fail()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -f json -k none -o {1}",
+                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"badir\output.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);
+        }
+
+        [TestMethod]
+        public void InvalidSourcePath_Fail()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -f json -k none -o {1}",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfilepath.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);
+        }
+
+        [TestMethod]
+        public void InvalidRulesPath_Fail()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -r badrulespath -f json -k none -o {1}",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);
+        }
+
+        [TestMethod]
+        public void NoDefaultNoCustomRules_Fail()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -i -f json -k none -o {1}",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);
+        }
+
+        [TestMethod]
+        public void NoDefaultCustomRules_Pass()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -i -r {1} -f json -k none -o {2}",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void DefaultWithCustomRules_Pass()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -r {1} -f json -k none -o {2}",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void DefaultAndCustomRulesPosMatches_Pass()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -r {1} -f json -k none -o {2}",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+
+                string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+                exitCode = testContent.Contains("Data.Parsing.JSON") ? GetTagsResult.ExitCode.Success : exitCode;
+                exitCode = testContent.Contains("Data.Custom1") ? GetTagsResult.ExitCode.Success : exitCode;
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void ExclusionFilter_Pass()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -r {1} -f json -o {2} -k {3}",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\project\one"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"),
+                    ".cpp");
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.NoMatches);
+        }
+
+        [TestMethod]
+        public void ExpectedTagCountDupsAllowed_Pass()
+        {
+            GetTagsResult.ExitCode exitCodeSingleThread = GetTagsResult.ExitCode.CriticalError;
+
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -f json -o {1} -k none --single-threaded",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+
+                exitCodeSingleThread = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+
+                if (exitCodeSingleThread == GetTagsResult.ExitCode.Success)
+                {
+                    string content = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+                    var result = JsonConvert.DeserializeObject<GetTagsResult>(content);
+                    exitCodeSingleThread = result.Metadata.TotalMatchesCount == 0 && result.Metadata.UniqueMatchesCount == 0 && result.Metadata.UniqueTags.Count == 7 ? GetTagsResult.ExitCode.Success : GetTagsResult.ExitCode.NoMatches;
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCodeSingleThread == GetTagsResult.ExitCode.Success);
+
+            GetTagsResult.ExitCode exitCodeMultiThread = GetTagsResult.ExitCode.CriticalError;
+
+            try
+            {
+
+                string args = string.Format(@"get-tags -s {0} -f json -o {1} -k none",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+
+                exitCodeMultiThread = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+
+                if (exitCodeMultiThread == GetTagsResult.ExitCode.Success)
+                {
+                    string content = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+                    var result = JsonConvert.DeserializeObject<GetTagsResult>(content);
+                    exitCodeMultiThread = result.Metadata.TotalMatchesCount == 0 && result.Metadata.UniqueMatchesCount == 0 && result.Metadata.UniqueTags.Count == 7 ? GetTagsResult.ExitCode.Success : GetTagsResult.ExitCode.NoMatches;
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCodeMultiThread == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void NoMatchesFound_Pass()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -f json -o {1} -k none",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.NoMatches);
+        }
+
+        [TestMethod]
+        public void LogTraceLevel_Pass()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -f json -l {1} -v trace -k none",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log1.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+
+                string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log1.txt"));
+                exitCode = testContent.ToLower().Contains("trace") ? GetTagsResult.ExitCode.Success : GetTagsResult.ExitCode.CriticalError;
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void LogErrorLevel_Pass()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -f json -l {1} -v error -k none",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\nofile.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log2.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+
+                string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log2.txt"));
+                exitCode = testContent.ToLower().Contains("error") ? GetTagsResult.ExitCode.Success : GetTagsResult.ExitCode.CriticalError;
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void LogDebugLevel_Pass()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -f json -l {1} -v debug -k none",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log3.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+
+                string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log3.txt"));
+                exitCode = testContent.ToLower().Contains("debug") ? GetTagsResult.ExitCode.Success : GetTagsResult.ExitCode.CriticalError;
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void InvalidLogPath_Fail()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -f json -l {1} -k none",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfile.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"badir\log.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);//test fails even when values match unless this case run individually -mstest bug?
+        }
+
+        [TestMethod]
+        public void InsecureLogPath_Fail()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -f json -l {1} -k none",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);
+        }
+
+        [TestMethod]
+        public void NoConsoleOutput_Pass()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string appInspectorPath = Helper.GetPath(Helper.AppPath.appInspectorCLI);
+
+                string args = string.Format(@"get-tags -s {0} -x none -f text -k none -o {1}",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+
+
+                exitCode = (GetTagsResult.ExitCode)Helper.RunProcess(appInspectorPath, args, out string testContent);
+
+                if (exitCode == GetTagsResult.ExitCode.Success)
+                {
+                    exitCode = String.IsNullOrEmpty(testContent) ? GetTagsResult.ExitCode.Success : GetTagsResult.ExitCode.CriticalError;
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void NoConsoleNoFileOutput_Fail()
+        {
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                string args = string.Format(@"get-tags -s {0} -x none -f text -k none -l {1}",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+
+                exitCode = (GetTagsResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);
+        }
+    }
+}

--- a/UnitTest.Commands/Tests_CLI/TestTagTestCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestTagTestCmd.cs
@@ -229,7 +229,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
                 //check for specific error if desired
             }
 
-            Assert.IsTrue(exitCode == TagTestResult.ExitCode.TestFailed);
+            Assert.IsTrue(exitCode == TagTestResult.ExitCode.CriticalError);
         }
 
         [TestMethod]

--- a/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
@@ -295,7 +295,7 @@ namespace ApplicationInspector.Unitprocess.Commands
             {
                 SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
                 FilePathExclusions = "none", //allow source under unittest path
-\                SingleThread = true
+                SingleThread = true
             };
 
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;

--- a/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
@@ -295,8 +295,7 @@ namespace ApplicationInspector.Unitprocess.Commands
             {
                 SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
                 FilePathExclusions = "none", //allow source under unittest path
-                AllowDupTags = true,
-                SingleThread = true
+\                SingleThread = true
             };
 
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
@@ -335,36 +334,6 @@ namespace ApplicationInspector.Unitprocess.Commands
             }
 
             Assert.IsTrue(exitCodeMultiThread == AnalyzeResult.ExitCode.Success);
-
-        }
-
-        [TestMethod]
-        public void ExpectedTagCountNoDupsAllowed_Pass()
-        {
-            AnalyzeOptions options = new AnalyzeOptions()
-            {
-                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
-                FilePathExclusions = "none", //allow source under unittest path
-                AllowDupTags = false
-            };
-
-            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
-            try
-            {
-                AnalyzeCommand command = new AnalyzeCommand(options);
-                AnalyzeResult result = command.GetResult();
-                exitCode = result.ResultCode;
-                if (exitCode == AnalyzeResult.ExitCode.Success)
-                {
-                    exitCode = result.Metadata.UniqueTags.Count == 7 && result.Metadata.UniqueMatchesCount == 7 ? AnalyzeResult.ExitCode.Success : AnalyzeResult.ExitCode.NoMatches;
-                }
-            }
-            catch (Exception)
-            {
-                exitCode = AnalyzeResult.ExitCode.CriticalError;
-            }
-
-            Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.Success);
         }
 
         [TestMethod]

--- a/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
@@ -356,7 +356,7 @@ namespace ApplicationInspector.Unitprocess.Commands
                 exitCode = result.ResultCode;
                 if (exitCode == AnalyzeResult.ExitCode.Success)
                 {
-                    exitCode = result.Metadata.TotalMatchesCount == 7 && result.Metadata.UniqueMatchesCount == 7 ? AnalyzeResult.ExitCode.Success : AnalyzeResult.ExitCode.NoMatches;
+                    exitCode = result.Metadata.UniqueTags.Count == 7 && result.Metadata.UniqueMatchesCount == 7 ? AnalyzeResult.ExitCode.Success : AnalyzeResult.ExitCode.NoMatches;
                 }
             }
             catch (Exception)

--- a/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
@@ -269,7 +269,8 @@ namespace ApplicationInspector.Unitprocess.Commands
         {
             AnalyzeOptions options = new AnalyzeOptions()
             {
-                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\project\one")
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\project\one"),
+                FilePathExclusions = "main.cpp"
             };
 
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;

--- a/UnitTest.Commands/Tests_NuGet/TestGetTagsCmd.cs
+++ b/UnitTest.Commands/Tests_NuGet/TestGetTagsCmd.cs
@@ -1,0 +1,546 @@
+﻿using ApplicationInspector.Unitprocess.Misc;
+using Microsoft.ApplicationInspector.Commands;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace ApplicationInspector.Unitprocess.Commands
+{
+    /// <summary>
+    /// Test class for Analyze Commands
+    /// Each method really needs to be complete i.e. options and command objects created and checked for exceptions etc. based on inputs so
+    /// doesn't create a set of shared objects
+    /// Note: in order to avoid log reuse, include the optional parameter CloseLogOnCommandExit = true
+    /// </summary>
+    [TestClass]
+    public class TestGetTagsCmd
+    {
+        [TestInitialize]
+        public void InitOutput()
+        {
+            Directory.CreateDirectory(Helper.GetPath(Helper.AppPath.testOutput));
+        }
+
+        [TestCleanup]
+        public void CleanUp()
+        {
+            try
+            {
+                Directory.Delete(Helper.GetPath(Helper.AppPath.testOutput), true);
+            }
+            catch
+            {
+            }
+
+            //because these are static and each test is meant to be indpendent null assign the references to create the log
+            WriteOnce.Log = null;
+            Utils.Logger = null;
+        }
+
+        [TestMethod]
+        public void InvalidLogPath_Fail()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+                LogFilePath = Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"baddir\log.txt")
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);//test fails even when values match unless this case run individually -mstest bug?
+        }
+
+        [TestMethod]
+        public void BasicAnalyze_Pass()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                FilePathExclusions = "none" //allow source under unittest path
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+            }
+            catch (Exception)
+            {
+
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void BasicZipRead_Pass()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"zipped\main.zip"),
+                FilePathExclusions = "none", //allow source under unittest path
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+            }
+            catch (Exception)
+            {
+
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void InvalidSourcePath_Fail()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"baddir\main.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+            }
+            catch (Exception)
+            {
+                //check for specific error if desired
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);
+        }
+
+        [TestMethod]
+        public void InvalidRulesPath_Fail()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+                CustomRulesPath = Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"notfound.json")
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+            }
+            catch (Exception)
+            {
+                //check for specific error if desired
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);
+        }
+
+        [TestMethod]
+        public void NoDefaultNoCustomRules_Fail()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+                IgnoreDefaultRules = true,
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+            }
+            catch (Exception)
+            {
+                //check for specific error if desired
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);
+        }
+
+        [TestMethod]
+        public void NoDefaultCustomRules_Pass()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+                IgnoreDefaultRules = true,
+                CustomRulesPath = Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+            }
+            catch (Exception)
+            {
+                exitCode = GetTagsResult.ExitCode.CriticalError;
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void DefaultWithCustomRules_Pass()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+                CustomRulesPath = Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+            }
+            catch (Exception)
+            {
+                exitCode = GetTagsResult.ExitCode.CriticalError;
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void DefaultAndCustomRulesMatched_Pass()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+                CustomRulesPath = Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json")
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                if (result.Metadata.UniqueTags.Any(v => v.Contains("Authentication.General")) &&
+                    result.Metadata.UniqueTags.Any(v => v.Contains("Data.Custom1")))
+                {
+                    exitCode = GetTagsResult.ExitCode.Success;
+                }
+            }
+            catch (Exception)
+            {
+                exitCode = GetTagsResult.ExitCode.CriticalError;
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void ExclusionFilter_Pass()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\project\one"),
+                FilePathExclusions = "main.cpp"
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+            }
+            catch (Exception)
+            {
+                //check for specific error if desired
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.NoMatches);
+        }
+
+        [TestMethod]
+        public void ExpectedTagCount()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+                SingleThread = true
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+                if (exitCode == GetTagsResult.ExitCode.Success)
+                {
+                    exitCode = result.Metadata.TotalMatchesCount == 0 && result.Metadata.UniqueMatchesCount == 0 && result.Metadata.UniqueTags.Count == 7 ? GetTagsResult.ExitCode.Success : GetTagsResult.ExitCode.NoMatches;
+                }
+            }
+            catch (Exception)
+            {
+                exitCode = GetTagsResult.ExitCode.CriticalError;
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+
+            GetTagsResult.ExitCode exitCodeMultiThread = GetTagsResult.ExitCode.CriticalError;
+            options.SingleThread = false;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCodeMultiThread = result.ResultCode;
+                if (exitCodeMultiThread == GetTagsResult.ExitCode.Success)
+                {
+                    exitCodeMultiThread = result.Metadata.TotalMatchesCount == 0 && result.Metadata.UniqueMatchesCount == 0 && result.Metadata.UniqueTags.Count == 7 ? GetTagsResult.ExitCode.Success : GetTagsResult.ExitCode.NoMatches;
+                }
+            }
+            catch (Exception)
+            {
+                exitCodeMultiThread = GetTagsResult.ExitCode.CriticalError;
+            }
+
+            Assert.IsTrue(exitCodeMultiThread == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void NoMatchesFound_Pass()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+            }
+            catch (Exception)
+            {
+                exitCode = GetTagsResult.ExitCode.CriticalError;
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.NoMatches);
+        }
+
+        [TestMethod]
+        public void LogTraceLevel_Pass()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+
+                LogFileLevel = "trace",
+                LogFilePath = Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"logtrace.txt"),
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+                string testLogContent = File.ReadAllText(options.LogFilePath);
+                if (String.IsNullOrEmpty(testLogContent))
+                {
+                    exitCode = GetTagsResult.ExitCode.CriticalError;
+                }
+                else if (testLogContent.ToLower().Contains("trace"))
+                {
+                    exitCode = GetTagsResult.ExitCode.Success;
+                }
+            }
+            catch (Exception)
+            {
+                exitCode = GetTagsResult.ExitCode.CriticalError;
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void LogErrorLevel_Pass()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfile.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+
+                LogFileLevel = "error",
+                LogFilePath = Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"logerror.txt"),
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+            }
+            catch (Exception)
+            {
+                string testLogContent = File.ReadAllText(options.LogFilePath);
+                if (!String.IsNullOrEmpty(testLogContent) && testLogContent.ToLower().Contains("error"))
+                {
+                    exitCode = GetTagsResult.ExitCode.Success;
+                }
+                else
+                {
+                    exitCode = GetTagsResult.ExitCode.CriticalError;
+                }
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void LogDebugLevel_Pass()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+                LogFileLevel = "debug",
+                LogFilePath = Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"logdebug.txt"),
+                CloseLogOnCommandExit = true
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+                string testLogContent = File.ReadAllText(options.LogFilePath);
+                if (String.IsNullOrEmpty(testLogContent))
+                {
+                    exitCode = GetTagsResult.ExitCode.CriticalError;
+                }
+                else if (testLogContent.ToLower().Contains("debug"))
+                {
+                    exitCode = GetTagsResult.ExitCode.Success;
+                }
+            }
+            catch (Exception)
+            {
+                //check for specific error if desired
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void InsecureLogPath_Fail()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+                LogFilePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                GetTagsCommand command = new GetTagsCommand(options);
+                GetTagsResult result = command.GetResult();
+                exitCode = result.ResultCode;
+            }
+            catch (Exception)
+            {
+                //check for specific error if desired
+            }
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.CriticalError);
+        }
+
+        [TestMethod]
+        public void NoConsoleOutput_Pass()
+        {
+            GetTagsCommandOptions options = new GetTagsCommandOptions()
+            {
+                SourcePath = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
+                FilePathExclusions = "none", //allow source under unittest path
+                ConsoleVerbosityLevel = "none"
+            };
+
+            GetTagsResult.ExitCode exitCode = GetTagsResult.ExitCode.CriticalError;
+            try
+            {
+                // Attempt to open output file.
+                using (var writer = new StreamWriter(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"consoleout.txt")))
+                {
+                    // Redirect standard output from the console to the output file.
+                    Console.SetOut(writer);
+
+                    GetTagsCommand command = new GetTagsCommand(options);
+                    GetTagsResult result = command.GetResult();
+                    exitCode = result.ResultCode;
+                    try
+                    {
+                        string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"consoleout.txt"));
+                        if (String.IsNullOrEmpty(testContent))
+                        {
+                            exitCode = GetTagsResult.ExitCode.Success;
+                        }
+                        else
+                        {
+                            exitCode = GetTagsResult.ExitCode.NoMatches;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        exitCode = GetTagsResult.ExitCode.Success;//no console output file found
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                exitCode = GetTagsResult.ExitCode.CriticalError;
+            }
+
+            //reset to normal
+            var standardOutput = new StreamWriter(Console.OpenStandardOutput());
+            standardOutput.AutoFlush = true;
+            Console.SetOut(standardOutput);
+
+            Assert.IsTrue(exitCode == GetTagsResult.ExitCode.Success);
+        }
+    }
+}

--- a/UnitTest.Commands/UnitTest.Commands.csproj
+++ b/UnitTest.Commands/UnitTest.Commands.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
   </ItemGroup>


### PR DESCRIPTION
* Refactor RuleProcessor.cs.
* Rewrites the Analyze Command for Performance and Reliability.  Removes some complex functionality and refactors into the Get Tags command.
* Adds the GetTags command to just get the unique tags that match.
* Adds a progress bar for analyze and get tags commands.
* Add GetTags tests and update test behavior to match new code.
* Fixes non-thread safe Match loss bug in Metadata.cs
* Adds Per File Timeout option (Fix #342) `--file-timeout N` to time out after N seconds.
* The metadata now reports on analysis status and duration for each file in Analyze and GetTags commands.
* The new paradigm is to do direct data collection in the threadsafe `MetaDataHelper` and then to compile it into a non-threadsafe but serializable `Metadata` report using the `CompileReport` command in `MetaDataHelper`.  Previously some data (like matches) was being directly collected in the metadata but some was being collected in the metadata helper.  If you see any cases that directly write data to the metadata that should no longer be the case.

Confirmed that the html report for single and multi-threaded shows the same number of results for a large project (.net codebase).

The number shown on the progress bar may differ but should not ultimately matter.