### PR TITLE
Fix result loss bug while running parallel

### DIFF
--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -382,7 +382,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     WriteOnce.Error(MsgHelp.GetString(MsgHelp.ID.ANALYZE_NOSUPPORTED_FILETYPES));
                     analyzeResult.ResultCode = AnalyzeResult.ExitCode.NoMatches;
                 }
-                else if (_metaDataHelper?.Metadata?.Matches?.Count == 0)
+                else if (_metaDataHelper?.Matches.Count == 0)
                 {
                     WriteOnce.Error(MsgHelp.GetString(MsgHelp.ID.ANALYZE_NOPATTERNS));
                     analyzeResult.ResultCode = AnalyzeResult.ExitCode.NoMatches;

--- a/AppInspector/MetaData.cs
+++ b/AppInspector/MetaData.cs
@@ -195,7 +195,7 @@ namespace Microsoft.ApplicationInspector.Commands
         /// List of detailed MatchRecords from scan
         /// </summary>
         [JsonProperty(PropertyName = "detailedMatchList")]
-        public List<MatchRecord>? Matches { get; } = new List<MatchRecord>();
+        public List<MatchRecord> Matches { get; set; } = new List<MatchRecord>();
 
         public MetaData(string applicationName, string sourcePath)
         {

--- a/AppInspector/MetaDataHelper.cs
+++ b/AppInspector/MetaDataHelper.cs
@@ -35,6 +35,7 @@ namespace Microsoft.ApplicationInspector.Commands
         private ConcurrentDictionary<string, int> Languages { get; set; } = new ConcurrentDictionary<string, int>();
 
         internal MetaData Metadata { get; set; }
+        public ConcurrentBag<MatchRecord> Matches { get; set; } = new ConcurrentBag<MatchRecord>();
 
         public MetaDataHelper(string sourcePath, bool uniqueMatchesOnly)
         {
@@ -124,7 +125,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
                 if (allowAdd)
                 {
-                    Metadata?.Matches?.Add(matchRecord);
+                    Matches?.Add(matchRecord);
                 }
             }
             else
@@ -160,6 +161,8 @@ namespace Microsoft.ApplicationInspector.Commands
             Metadata.FileExtensions.Sort();
             Metadata.Outputs.Sort();
             Metadata.Targets.Sort();
+
+            Metadata.Matches = Matches.ToList();
 
             Metadata.Languages = Languages.ToImmutableSortedDictionary();
 


### PR DESCRIPTION
The Metadata.Matches list is not threadsafe and was leaking results.