### PR TITLE
Rename argument to reduce confusion if attempting to use regular strings with the old -k

### DIFF
--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('c', "confidence-filters", Required = false, HelpText = "Output only matches with specified confidence <value>,<value> [high|medium|low]", Default = "high,medium")]
         public string ConfidenceFilters { get; set; } = "high,medium";
 
-        [Option('k', "file-path-exclusions", Required = false, HelpText = "Exclude source files that match glob patterns. Example: \"**/.git/**,*Tests*\".  Use \"none\" to disable.", Default = new string[] { "**/bin/**", "**/obj/**", "**/.vs/**", "**/.git/**" }, Separator = ',')]
+        [Option('g', "exclusion-globs", Required = false, HelpText = "Exclude source files that match glob patterns. Example: \"**/.git/**,*Tests*\".  Use \"none\" to disable.", Default = new string[] { "**/bin/**", "**/obj/**", "**/.vs/**", "**/.git/**" }, Separator = ',')]
 
         public IEnumerable<string> FilePathExclusions { get; set; } = new string[0];
 

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -48,10 +48,10 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('e', "text-format", Required = false, HelpText = "Match text format specifiers", Default = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m")]
         public string TextOutputFormat { get; set; } = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m";
 
-        [Option('F',"file-timeout", Required = false, HelpText = "If non-zero, maximum amount of time in milliseconds to allow for processing each file. Default: 60000.", Default = 60000)]
+        [Option('F',"file-timeout", Required = false, HelpText = "Maximum amount of time in milliseconds to allow for processing each file. 0 is infinity. Default: 60000.", Default = 60000)]
         public int FileTimeOut { get; set; } = 60000;
 
-        [Option('p',"processing-timeout", Required = false, HelpText = "If set, maximum amount of time in milliseconds to allow for processing overall.", Default = 0)]
+        [Option('p',"processing-timeout", Required = false, HelpText = "Maximum amount of time in milliseconds to allow for processing overall. 0 is infinity. Default: 0.", Default = 0)]
         public int ProcessingTimeOut { get; set; }
 
         [Option('S',"single-threaded", Required = false, HelpText = "Disables parallel processing.")]
@@ -95,10 +95,10 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('i', "ignore-default-rules", Required = false, HelpText = "Exclude default rules bundled with application", Default = false)]
         public bool IgnoreDefaultRules { get; set; }
 
-        [Option('F', "file-timeout", Required = false, HelpText = "If non-zero, maximum amount of time in milliseconds to allow for processing each file. Default: 60000.", Default = 60000)]
+        [Option('F', "file-timeout", Required = false, HelpText = "Maximum amount of time in milliseconds to allow for processing each file. 0 is infinity.  Default: 60000.", Default = 60000)]
         public int FileTimeOut { get; set; } = 60000;
 
-        [Option('p',"processing-timeout", Required = false, HelpText = "If set, maximum amount of time in milliseconds to allow for processing each source.", Default = 0)]
+        [Option('p',"processing-timeout", Required = false, HelpText = "Maximum amount of time in milliseconds to allow for processing each source. 0 is infinity. Default: 0.", Default = 0)]
         public int ProcessingTimeOut { get; set; }
 
         [Option('u', "scan-unknown-filetypes", Required = false, HelpText = "Scan files of unknown types.")]

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -48,22 +48,22 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('e', "text-format", Required = false, HelpText = "Match text format specifiers", Default = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m")]
         public string TextOutputFormat { get; set; } = "Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m";
 
-        [Option("file-timeout", Required = false, HelpText = "If set, maximum amount of time in milliseconds to allow for processing each file.", Default = 60000)]
+        [Option('F',"file-timeout", Required = false, HelpText = "If non-zero, maximum amount of time in milliseconds to allow for processing each file. Default: 60000.", Default = 60000)]
         public int FileTimeOut { get; set; } = 60000;
 
-        [Option("processing-timeout", Required = false, HelpText = "If set, maximum amount of time in milliseconds to allow for processing overall.", Default = 0)]
-        public int ProcessingTimeOut { get; set; } = 0;
+        [Option('p',"processing-timeout", Required = false, HelpText = "If set, maximum amount of time in milliseconds to allow for processing overall.", Default = 0)]
+        public int ProcessingTimeOut { get; set; }
 
-        [Option("single-threaded", Required = false, HelpText = "Disables parallel processing.")]
+        [Option('S',"single-threaded", Required = false, HelpText = "Disables parallel processing.")]
         public bool SingleThread { get; set; }
 
-        [Option("no-show-progress", Required = false, HelpText = "Disable progress information.")]
+        [Option('N',"no-show-progress", Required = false, HelpText = "Disable progress information.")]
         public bool NoShowProgressBar { get; set; }
 
-        [Option("context-lines", Required = false, HelpText = "Number of lines of context on each side to include in excerpt (up to a maximum of 100 * NumLines characters on each side). 0 to skip exerpt. -1 to not extract samples or excerpts (implied by -t).")]
+        [Option('C',"context-lines", Required = false, HelpText = "Number of lines of context on each side to include in excerpt (up to a maximum of 100 * NumLines characters on each side). 0 to skip exerpt. -1 to not extract samples or excerpts (implied by -t).")]
         public int ContextLines { get; set; } = 3;
 
-        [Option("scan-unknown-filetypes", Required = false, HelpText = "Scan files of unknown types.")]
+        [Option('u',"scan-unknown-filetypes", Required = false, HelpText = "Scan files of unknown types.")]
         public bool ScanUnknownTypes { get; set; }
 
         [Option('t',"tags-only", Required = false, HelpText = "Only get tags (no detailed match data).")]
@@ -95,11 +95,23 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('i', "ignore-default-rules", Required = false, HelpText = "Exclude default rules bundled with application", Default = false)]
         public bool IgnoreDefaultRules { get; set; }
 
-        [Option("file-timeout", Required = false, HelpText = "If set, maximum amount of time in milliseconds to allow for processing each file.", Default = 60000)]
+        [Option('F', "file-timeout", Required = false, HelpText = "If non-zero, maximum amount of time in milliseconds to allow for processing each file. Default: 60000.", Default = 60000)]
         public int FileTimeOut { get; set; } = 60000;
 
-        [Option("processing-timeout", Required = false, HelpText = "If set, maximum amount of time in milliseconds to allow for processing overall.", Default = 0)]
-        public int ProcessingTimeOut { get; set; } = 0;
+        [Option('p',"processing-timeout", Required = false, HelpText = "If set, maximum amount of time in milliseconds to allow for processing each source.", Default = 0)]
+        public int ProcessingTimeOut { get; set; }
+
+        [Option('u', "scan-unknown-filetypes", Required = false, HelpText = "Scan files of unknown types.")]
+        public bool ScanUnknownTypes { get; set; }
+
+        [Option('S', "single-threaded", Required = false, HelpText = "Disables parallel processing.")]
+        public bool SingleThread { get; set; }
+
+        [Option('n', "no-file-metadata", Required = false, HelpText = "Don't collect metadata about each individual file.")]
+        public bool NoFileMetadata { get; set; }
+
+        [Option('c', "confidence-filters", Required = false, HelpText = "Output only matches with specified confidence <value>,<value> [high|medium|low]", Default = "high,medium")]
+        public string ConfidenceFilters { get; set; } = "high,medium";
     }
 
     [Verb("exporttags", HelpText = "Export unique rule tags to view what code features may be detected")]

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('t', "test-type", Required = false, HelpText = "Type of test to run [equality|inequality]", Default = "equality")]
         public string TestType { get; set; } = "equality";
 
-        [Option('k', "file-path-exclusions", Required = false, HelpText = "Exclude source files that match glob patterns. Example: \"**/.git/**,*Tests*\".  Use \"none\" to disable.", Default = new string[] { "**/bin/**", "**/obj/**", "**/.vs/**", "**/.git/**" }, Separator = ',')]
+        [Option('g', "exclusion-globs", Required = false, HelpText = "Exclude source files that match glob patterns. Example: \"**/.git/**,*Tests*\".  Use \"none\" to disable.", Default = new string[] { "**/bin/**", "**/obj/**", "**/.vs/**", "**/.git/**" }, Separator = ',')]
         public IEnumerable<string> FilePathExclusions { get; set; } = new string[] { };
 
         [Option('r', "custom-rules-path", Required = false, HelpText = "Custom rules file or directory path")]

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -107,9 +107,6 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('S', "single-threaded", Required = false, HelpText = "Disables parallel processing.")]
         public bool SingleThread { get; set; }
 
-        [Option('n', "no-file-metadata", Required = false, HelpText = "Don't collect metadata about each individual file.")]
-        public bool NoFileMetadata { get; set; }
-
         [Option('c', "confidence-filters", Required = false, HelpText = "Output only matches with specified confidence <value>,<value> [high|medium|low]", Default = "high,medium")]
         public string ConfidenceFilters { get; set; } = "high,medium";
     }

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -327,7 +327,6 @@ namespace Microsoft.ApplicationInspector.CLI
                 ConfidenceFilters = cliOptions.ConfidenceFilters,
                 FileTimeOut = cliOptions.FileTimeOut,
                 ProcessingTimeOut = cliOptions.ProcessingTimeOut,
-                NoFileMetadata = cliOptions.NoFileMetadata,
                 ScanUnknownTypes = cliOptions.ScanUnknownTypes,
                 SingleThread = cliOptions.SingleThread,
                 LogFilePath = cliOptions.LogFilePath,

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -323,7 +323,15 @@ namespace Microsoft.ApplicationInspector.CLI
                 FilePathExclusions = cliOptions.FilePathExclusions,
                 ConsoleVerbosityLevel = cliOptions.ConsoleVerbosityLevel,
                 TestType = cliOptions.TestType,
-                Log = cliOptions.Log
+                Log = cliOptions.Log,
+                ConfidenceFilters = cliOptions.ConfidenceFilters,
+                FileTimeOut = cliOptions.FileTimeOut,
+                ProcessingTimeOut = cliOptions.ProcessingTimeOut,
+                NoFileMetadata = cliOptions.NoFileMetadata,
+                ScanUnknownTypes = cliOptions.ScanUnknownTypes,
+                SingleThread = cliOptions.SingleThread,
+                LogFilePath = cliOptions.LogFilePath,
+                LogFileLevel = cliOptions.LogFileLevel
             });
 
             TagDiffResult tagDiffResult = command.GetResult();

--- a/AppInspector/Commands/TagDiffCommand.cs
+++ b/AppInspector/Commands/TagDiffCommand.cs
@@ -20,6 +20,10 @@ namespace Microsoft.ApplicationInspector.Commands
         public bool IgnoreDefaultRules { get; set; }
         public int FileTimeOut { get; set; }
         public int ProcessingTimeOut { get; set; }
+        public bool ScanUnknownTypes { get; set; }
+        public bool SingleThread { get; set; }
+        public bool NoFileMetadata { get; set; }
+        public string ConfidenceFilters { get; set; } = "high,medium";
     }
 
     /// <summary>
@@ -170,7 +174,6 @@ namespace Microsoft.ApplicationInspector.Commands
 
             try
             {
-                #region setup analyze calls
                 if (_options is null)
                 {
                     throw new ArgumentNullException("_options");
@@ -184,6 +187,13 @@ namespace Microsoft.ApplicationInspector.Commands
                     ConsoleVerbosityLevel = "none",
                     Log = _options.Log,
                     TagsOnly = true,
+                    ConfidenceFilters = _options.ConfidenceFilters,
+                    FileTimeOut = _options.FileTimeOut,
+                    ProcessingTimeOut = _options.ProcessingTimeOut,
+                    NoFileMetadata = _options.NoFileMetadata,
+                    NoShowProgress = true,
+                    ScanUnknownTypes = _options.ScanUnknownTypes,
+                    SingleThread = _options.SingleThread,
                 });
                 AnalyzeCommand cmd2 = new(new AnalyzeOptions()
                 {
@@ -193,7 +203,14 @@ namespace Microsoft.ApplicationInspector.Commands
                     FilePathExclusions = _options.FilePathExclusions,
                     ConsoleVerbosityLevel = "none",
                     Log = _options.Log,
-                    TagsOnly = true
+                    TagsOnly = true,
+                    ConfidenceFilters = _options.ConfidenceFilters,
+                    FileTimeOut = _options.FileTimeOut,
+                    ProcessingTimeOut = _options.ProcessingTimeOut,
+                    NoFileMetadata = _options.NoFileMetadata,
+                    NoShowProgress = true,
+                    ScanUnknownTypes = _options.ScanUnknownTypes,
+                    SingleThread = _options.SingleThread,
                 });
 
                 AnalyzeResult analyze1 = cmd1.GetResult();
@@ -201,8 +218,6 @@ namespace Microsoft.ApplicationInspector.Commands
 
                 //restore
                 WriteOnce.Verbosity = saveVerbosity;
-
-                #endregion setup analyze calls
 
                 //process results for each analyze call before comparing results
                 if (analyze1.ResultCode == AnalyzeResult.ExitCode.CriticalError)

--- a/AppInspector/Commands/TagDiffCommand.cs
+++ b/AppInspector/Commands/TagDiffCommand.cs
@@ -22,7 +22,6 @@ namespace Microsoft.ApplicationInspector.Commands
         public int ProcessingTimeOut { get; set; }
         public bool ScanUnknownTypes { get; set; }
         public bool SingleThread { get; set; }
-        public bool NoFileMetadata { get; set; }
         public string ConfidenceFilters { get; set; } = "high,medium";
     }
 
@@ -190,7 +189,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     ConfidenceFilters = _options.ConfidenceFilters,
                     FileTimeOut = _options.FileTimeOut,
                     ProcessingTimeOut = _options.ProcessingTimeOut,
-                    NoFileMetadata = _options.NoFileMetadata,
+                    NoFileMetadata = true,
                     NoShowProgress = true,
                     ScanUnknownTypes = _options.ScanUnknownTypes,
                     SingleThread = _options.SingleThread,
@@ -207,7 +206,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     ConfidenceFilters = _options.ConfidenceFilters,
                     FileTimeOut = _options.FileTimeOut,
                     ProcessingTimeOut = _options.ProcessingTimeOut,
-                    NoFileMetadata = _options.NoFileMetadata,
+                    NoFileMetadata = true,
                     NoShowProgress = true,
                     ScanUnknownTypes = _options.ScanUnknownTypes,
                     SingleThread = _options.SingleThread,

--- a/JustRunIt.md
+++ b/JustRunIt.md
@@ -4,33 +4,26 @@ If you're not looking to build the application and simply want to download it an
 the .NET Core pre-requisites.
 
 ## Get Application Inspector
+### .NET Tool (recommended)
+#### Pre-Requisite
+- Download and install the .NET Core 5.0 [SDK](https://dotnet.microsoft.com/download/dotnet-core/5.0)
+
+#### Install
+- Use the dotnet command `dotnet tool install --global Microsoft.CST.ApplicationInspector.CLI` See more in the [wiki](https://github.com/microsoft/ApplicationInspector/wiki/7.-NuGet-Support)
+
 ### Platform Dependent Binary
 - Download Application Inspector by selecting the pre-built package for the operating system of choice shown under the Assets section
 of the [Releases](https://github.com/microsoft/ApplicationInspector/releases) page and expand the files to your local system drive
 using the decompression utility of choice e.g. WinZip, 7zip, Gzip etc. 
 
-### .NET Tool
-#### Pre-Requisite
-- Download and install the .NET Core 3.1 [SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+## Start Using It
 
-#### Install
-- Use the dotnet command `dotnet tool install --global Microsoft.CST.ApplicationInspector.CLI` See more in the [wiki](https://github.com/microsoft/ApplicationInspector/wiki/7.-NuGet-Support)
-
-#### Start Using It
-
-That's it.  Start using the application by selecting and downloading the source code you want to scan to a local directory then run Application Inspector against it either from the source code directory or the Application Inspector install directory using the instructions found on this site on the home page or Readme.md file.  
-
-Note there are two main components for invoking the application, the ApplicationInspector.Commands.dll containing the core logic and ApplicationInspector.CLI.dll and .exe (Windows) containing the launch entry point for command line use which uses the other.
-The ApplicationInspector.Commands.dll is most likely of help in using the functionaly programmatically and can most easily be installed via www.nuget.com.  See the project wiki for more on use.  To just use the application as-is, follow the help below.
+Nuget Tool: Run Application Inspector against your source code: `appinspector analyze -s path/to/src`.
 
 ## Getting Help
 
 You can also get help directly from the application by simply typing in the application name without a command
 or with a command to get the required and optional arguments for a given command.
 
-Windows: just run the .exe i.e. applicationinspector.cli.exe
-Other: run as dotnet applicationinspector.cli.dll
-
-* applicationinspector.cli <no arguments> - to get a list of available top level commands
-* applicationinspector.cli [command] < no arguments> - to get a list of required and optional arguments to supply with the selected command
-* applicationinspector.cli [command] [arguments] -to run a given command with the required or optional parameters
+* `appinspector --help` - to get a list of available top level commands
+* `appinspector [command] --help` - to get a list of required and optional arguments to supply with the selected command

--- a/README.md
+++ b/README.md
@@ -9,9 +9,26 @@ Application Inspector is different from traditional static analysis tools in tha
 
 The tool supports scanning various programming languages including C, C++, C#, Java, JavaScript, HTML, Python, Objective-C, Go, Ruby, PowerShell and [more](https://github.com/microsoft/ApplicationInspector/wiki/3.4-Applies_to-(languages)) and can scan projects with mixed language files.  It supports generating results in HTML, JSON and text output formats with the **default being an HTML report** similar to the one shown here.
 
-![AppInspector-Features](https://user-images.githubusercontent.com/47648296/72893326-9c82c700-3ccd-11ea-8944-9831ea17f3e0.png)
+![appinspector-Features](https://user-images.githubusercontent.com/47648296/72893326-9c82c700-3ccd-11ea-8944-9831ea17f3e0.png)
 
 Be sure to see our complete project wiki page https://Github.com/Microsoft/ApplicationInspector/wiki for additional information and help.
+
+# Quick Start
+## Obtain Application Inspector
+### .NET Tool (recommended)
+- Download and install the .NET Core 5.0 [SDK](https://dotnet.microsoft.com/download/dotnet-core/5.0)
+- Run `dotnet tool install --global Microsoft.CST.ApplicationInspector.CLI` 
+
+See more in the [wiki](https://github.com/microsoft/ApplicationInspector/wiki/7.-NuGet-Support)
+
+### Platform Dependent Binary
+- Download Application Inspector by selecting the pre-built package for the operating system of choice shown under the Assets section
+of the [Releases](https://github.com/microsoft/ApplicationInspector/releases).
+
+## Run Application Inspector
+
+Nuget Tool: `appinspector analyze -s path/to/src`.
+Platform Specific: `applicationinspector.cli.exe analyze -s path/to/src`
 
 # Goals
 
@@ -39,25 +56,18 @@ The C# library is available on NuGet as [Microsoft.CST.ApplicationInspector.Comm
 
 The .NET Global Tool is available on NuGet as [Microsoft.CST.ApplicationInspector.CLI](https://www.nuget.org/packages/Microsoft.CST.ApplicationInspector.CLI/).
 
-If you use the .NET Core version, you will need to have .NET Core 3.1 or later installed.  See the [JustRunIt.md](https://github.com/microsoft/ApplicationInspector/blob/master/JustRunIt.md) or [Build.md](https://github.com/microsoft/ApplicationInspector/blob/master/BUILD.md) files for more.
+If you use the .NET Core version, you will need to have .NET Core 5.0 or later installed.  See the [JustRunIt.md](https://github.com/microsoft/ApplicationInspector/blob/master/JustRunIt.md) or [Build.md](https://github.com/microsoft/ApplicationInspector/blob/master/BUILD.md) files for more.
 
-# Basic CLI Usage
+# CLI Usage Information
 
 ```
-> dotnet ApplicationInspector.CLI.dll or on *Windows* simply ApplicationInspector.CLI.exe <command> <options>
-
-Microsoft Application Inspector
-
-(c) Microsoft Corporation. All rights reserved
-
-ERROR(S):
-  No verb selected.
+> appinspector --help
+ApplicationInspector.CLI 1.4.0+6bdef0356b
+c Microsoft Corporation. All rights reserved.
 
   analyze        Inspect source directory/file/compressed file (.tgz|zip) against defined characteristics
 
   tagdiff        Compares unique tag values between two source paths
-
-  gettags       Checks the provided source for matching tags without additional analysis context
 
   exporttags     Export unique rule tags to view what code features may be detected
 
@@ -73,13 +83,69 @@ ERROR(S):
 ## Examples:
 
 ### Command Help
-```
-  Usage: dotnet ApplicationInspector.CLI.dll [arguments] [options]
+To get help for a specific command run `appinspector <command> --help`.
 
-  dotnet ApplicationInspector.CLI.dll <no args> -description of available commands
-  dotnet ApplicationInspector.CLI.dll <command> <no args> -arg options description for a given command
+### Analyze Command
+The Analyze Command is the workhorse of Application Inspector.
+#### Simple Default Analyze
+This will produce an output.html of the analysis in the current directory using default arguments and rules.
 ```
+appinspector analyze -s path/to/files
+```
+#### Excluding Files using Globs
+This will create a json output named data.json of the analysis in the current directory, excluding all files in `test` and `.git` folders using the provided glob patterns.
+```
+appinspector analyze -s path/to/files -o data.json -f json -g **/tests/**,**/.git/**
+```
+#### Additional Usage Information
+```
+> appinspector analyze --help
+ApplicationInspector.CLI 1.4.0+6bdef0356b
+c Microsoft Corporation. All rights reserved.
 
+  -s, --source-path             Required. Source file or directory to inspect, comma separated
+
+  -r, --custom-rules-path       Custom rules file or directory path
+
+  -i, --ignore-default-rules    (Default: false) Exclude default rules bundled with application
+
+  -c, --confidence-filters      (Default: high,medium) Output only matches with specified confidence <value>,<value> [high|medium|low]
+
+  -g, --exclusion-globs         (Default: **/bin/** **/obj/** **/.vs/** **/.git/**) Exclude source files that match glob patterns. Example: "**/.git/**,*Tests*".  Use "none" to disable.
+
+  -f, --output-file-format      (Default: html) Output format [html|json|text]
+
+  -e, --text-format             (Default: Tag:%T,Rule:%N,Ruleid:%R,Confidence:%X,File:%F,Sourcetype:%t,Line:%L,Sample:%m) Match text format specifiers
+
+  --file-timeout                (Default: 60000) If set, maximum amount of time in milliseconds to allow for processing each file.
+
+  --processing-timeout          (Default: 0) If set, maximum amount of time in milliseconds to allow for processing overall.
+
+  --single-threaded             Disables parallel processing.
+
+  --no-show-progress            Disable progress information.
+
+  --context-lines               Number of lines of context on each side to include in excerpt (up to a maximum of 100 * NumLines characters on each side). 0 to skip exerpt. -1 to not extract
+                                samples or excerpts (implied by -t).
+
+  --scan-unknown-filetypes      Scan files of unknown types.
+
+  -t, --tags-only               Only get tags (no detailed match data).
+
+  -n, --no-file-metadata        Don't collect metadata about each individual file.
+
+  -o, --output-file-path        Output file path
+
+  -x, --console-verbosity       (Default: medium) Console verbosity [high|medium|low|none]
+
+  -l, --log-file-path           Log file path
+
+  -v, --log-file-level          (Default: Error) Log file level [Debug|Info|Warn|Error|Trace|Fatal|Off]
+
+  --help                        Display this help screen.
+
+  --version                     Display version information.
+```
 For additional help on use of the console interface see [CLI Usage](https://github.com/microsoft/ApplicationInspector/wiki/1.-CLI-Usage).  
 
 For help using the NuGet package see [NuGet Support](https://github.com/microsoft/ApplicationInspector/wiki/2.-NuGet-Support)
@@ -88,4 +154,3 @@ For help using the NuGet package see [NuGet Support](https://github.com/microsof
 # Build Instructions
 
 See [build.md](https://github.com/microsoft/ApplicationInspector/blob/main/BUILD.md)
-

--- a/UnitTest.Commands/Tests_CLI/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestAnalyzeCmd.cs
@@ -43,7 +43,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void BasicHTMLOutput_Pass()
         {
-            string args = string.Format(@"analyze -s {0} -f html -k none", Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"));
+            string args = string.Format(@"analyze -s {0} -f html -g none", Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"));
             var exitCode = (AnalyzeResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
 
             Assert.AreEqual(AnalyzeResult.ExitCode.Success, exitCode);
@@ -53,7 +53,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void UnknownFormat_Fail() //dupliacte tags not supported for html format
         {
-            string args = string.Format(@"analyze -b -s {0} -f unknown -k none", Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"));
+            string args = string.Format(@"analyze -b -s {0} -f unknown -g none", Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"));
             var exitCode = (AnalyzeResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
 
             Assert.AreEqual(AnalyzeResult.ExitCode.CriticalError, exitCode);
@@ -62,7 +62,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void ZipReadHTMLOutput_Pass()
         {
-            string args = string.Format(@"analyze -s {0} -f html -k none -l {1}",
+            string args = string.Format(@"analyze -s {0} -f html -g none -l {1}",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"zipped\mainx.zip"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
@@ -74,7 +74,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void InvalidOutputfilePath_Fail()
         {
-            string args = string.Format(@"analyze -s {0} -f json -k none -o {1}",
+            string args = string.Format(@"analyze -s {0} -f json -g none -o {1}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"badir\output.txt"));
 
@@ -86,7 +86,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void InvalidSourcePath_Fail()
         {
-            string args = string.Format(@"analyze -s {0} -f json -k none -o {1}",
+            string args = string.Format(@"analyze -s {0} -f json -g none -o {1}",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfilepath.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -98,7 +98,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void InvalidRulesPath_Fail()
         {            
-            string args = string.Format(@"analyze -s {0} -r badrulespath -f json -k none -o {1}",
+            string args = string.Format(@"analyze -s {0} -r badrulespath -f json -g none -o {1}",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -111,7 +111,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void NoDefaultNoCustomRules_Fail()
         {
-            string args = string.Format(@"analyze -s {0} -i -f json -k none -o {1}",
+            string args = string.Format(@"analyze -s {0} -i -f json -g none -o {1}",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -123,7 +123,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void NoDefaultCustomRules_Pass()
         {
-            string args = string.Format(@"analyze -s {0} -i -r {1} -f json -k none -o {2}",
+            string args = string.Format(@"analyze -s {0} -i -r {1} -f json -g none -o {2}",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
@@ -136,7 +136,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void DefaultWithCustomRules_Pass()
         {
-            string args = string.Format(@"analyze -s {0} -r {1} -f json -k none -o {2}",
+            string args = string.Format(@"analyze -s {0} -r {1} -f json -g none -o {2}",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
@@ -149,7 +149,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void DefaultAndCustomRulesPosMatches_Pass()
         {
-            string args = string.Format(@"analyze -s {0} -r {1} -f json -k none -o {2}",
+            string args = string.Format(@"analyze -s {0} -r {1} -f json -g none -o {2}",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
@@ -164,7 +164,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void ExclusionFilter_Pass()
         {
-            string args = string.Format(@"analyze -s {0} -r {1} -f json -o {2} -k {3}",
+            string args = string.Format(@"analyze -s {0} -r {1} -f json -o {2} -g {3}",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\project\one"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"),
@@ -179,7 +179,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         public void MultiFiles()
         {
             var mainduptags = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp");
-            string args = string.Format(@"analyze -s {0} -f json -o {1} -k none",
+            string args = string.Format(@"analyze -s {0} -f json -o {1} -g none",
                 $"{mainduptags}",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -191,7 +191,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             var matches = result.Metadata.TotalMatchesCount;
             var uniqueMatches = result.Metadata.UniqueMatchesCount;
             mainduptags = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp");
-            args = string.Format(@"analyze -s {0} -f json -o {1} -k none",
+            args = string.Format(@"analyze -s {0} -f json -o {1} -g none",
                 $"{mainduptags},{mainduptags}",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -208,7 +208,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void ExpectedTagCountDupsAllowed_Pass()
         {
-            string args = string.Format(@"analyze -s {0} -f json -o {1} -k none --single-threaded",
+            string args = string.Format(@"analyze -s {0} -f json -o {1} -g none --single-threaded",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -221,7 +221,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             Assert.AreEqual(11, result.Metadata.TotalMatchesCount);
             Assert.AreEqual(7, result.Metadata.UniqueMatchesCount);
             
-            args = string.Format(@"analyze -s {0} -f json -o {1} -k none",
+            args = string.Format(@"analyze -s {0} -f json -o {1} -g none",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -237,7 +237,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void NoMatchesFound_Pass()
         {
-            string args = string.Format(@"analyze -s {0} -f json -o {1} -k none",
+            string args = string.Format(@"analyze -s {0} -f json -o {1} -g none",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -249,7 +249,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void LogTraceLevel_Pass()
         {
-            string args = string.Format(@"analyze -s {0} -f json -l {1} -v trace -k none",
+            string args = string.Format(@"analyze -s {0} -f json -l {1} -v trace -g none",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log1.txt"));
 
@@ -263,7 +263,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void LogErrorLevel_Pass()
         {
-            string args = string.Format(@"analyze -s {0} -f json -l {1} -v error -k none",
+            string args = string.Format(@"analyze -s {0} -f json -l {1} -v error -g none",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\nofile.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log2.txt"));
 
@@ -276,7 +276,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void LogDebugLevel_Pass()
         {
-            string args = string.Format(@"analyze -s {0} -f json -l {1} -v debug -k none",
+            string args = string.Format(@"analyze -s {0} -f json -l {1} -v debug -g none",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log3.txt"));
 
@@ -290,7 +290,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         public void InvalidLogPath_Fail()
         {
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
-            string args = string.Format(@"analyze -s {0} -f json -l {1} -k none",
+            string args = string.Format(@"analyze -s {0} -f json -l {1} -g none",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfile.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"badir\log.txt"));
 
@@ -302,7 +302,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void InsecureLogPath_Fail()
         {
-            string args = string.Format(@"analyze -s {0} -f json -l {1} -k none",
+            string args = string.Format(@"analyze -s {0} -f json -l {1} -g none",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"));
 
@@ -315,7 +315,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         {
             string appInspectorPath = Helper.GetPath(Helper.AppPath.appInspectorCLI);
 
-            string args = string.Format(@"analyze -s {0} -x none -f text -k none -o {1} --no-show-progress",
+            string args = string.Format(@"analyze -s {0} -x none -f text -g none -o {1} --no-show-progress",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
@@ -328,7 +328,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void NoConsoleNoFileOutput_Fail()
         {
-            string args = string.Format(@"analyze -s {0} -x none -f text -k none -l {1} --no-show-progress",
+            string args = string.Format(@"analyze -s {0} -x none -f text -g none -l {1} --no-show-progress",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 

--- a/UnitTest.Commands/Tests_CLI/TestAnalyzeTagsOnlyCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestAnalyzeTagsOnlyCmd.cs
@@ -43,7 +43,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void UnknownFormat_Fail()
         {
-            string args = string.Format(@"analyze -b -s {0} -f unknown -k none -t", Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"));
+            string args = string.Format(@"analyze -b -s {0} -f unknown -g none -t", Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"));
             var exitCode = (AnalyzeResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
             Assert.AreEqual(AnalyzeResult.ExitCode.CriticalError, exitCode);
         }
@@ -51,7 +51,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void InvalidOutputfilePath_Fail()
         {
-            string args = string.Format(@"analyze -s {0} -f json -k none -o {1} -t",
+            string args = string.Format(@"analyze -s {0} -f json -g none -o {1} -t",
                      Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                      Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"badir\output.txt"));
 
@@ -62,7 +62,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void InvalidSourcePath_Fail()
         {
-            string args = string.Format(@"analyze -s {0} -f json -k none -o {1} -t",
+            string args = string.Format(@"analyze -s {0} -f json -g none -o {1} -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfilepath.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -76,7 +76,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -r badrulespath -f json -k none -o {1} -t",
+                string args = string.Format(@"analyze -s {0} -r badrulespath -f json -g none -o {1} -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -95,7 +95,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -i -f json -k none -o {1} -t",
+                string args = string.Format(@"analyze -s {0} -i -f json -g none -o {1} -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -114,7 +114,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -i -r {1} -f json -k none -o {2} -t",
+                string args = string.Format(@"analyze -s {0} -i -r {1} -f json -g none -o {2} -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
@@ -134,7 +134,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -r {1} -f json -k none -o {2} -t",
+                string args = string.Format(@"analyze -s {0} -r {1} -f json -g none -o {2} -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
@@ -152,7 +152,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         public void DefaultAndCustomRulesPosMatches_Pass()
         {
             
-            string args = string.Format(@"analyze -s {0} -r {1} -f json -k none -o {2} -t",
+            string args = string.Format(@"analyze -s {0} -r {1} -f json -g none -o {2} -t",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
@@ -171,7 +171,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -r {1} -f json -o {2} -k {3} -t",
+                string args = string.Format(@"analyze -s {0} -r {1} -f json -o {2} -g {3} -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\project\one"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"),
@@ -190,7 +190,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         public void MultiFiles()
         {
             var mainduptags = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp");
-            string args = string.Format(@"analyze -s {0} -f json -o {1} -k none -t",
+            string args = string.Format(@"analyze -s {0} -f json -o {1} -g none -t",
                 $"{mainduptags}",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -202,7 +202,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             var matches = result.Metadata.TotalMatchesCount;
             var uniqueMatches = result.Metadata.UniqueMatchesCount;
             mainduptags = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp");
-            args = string.Format(@"analyze -s {0} -f json -o {1} -k none -t",
+            args = string.Format(@"analyze -s {0} -f json -o {1} -g none -t",
                 $"{mainduptags},{mainduptags}",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -219,7 +219,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
         [TestMethod]
         public void ExpectedTagCountDupsAllowed_Pass()
         {
-            string args = string.Format(@"analyze -s {0} -f json -o {1} -k none --single-threaded -t",
+            string args = string.Format(@"analyze -s {0} -f json -o {1} -g none --single-threaded -t",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -231,7 +231,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             Assert.AreEqual(0, result.Metadata.UniqueMatchesCount);
             Assert.AreEqual(7, result.Metadata.UniqueTags.Count);
             
-            args = string.Format(@"analyze -s {0} -f json -o {1} -k none -t",
+            args = string.Format(@"analyze -s {0} -f json -o {1} -g none -t",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
                 Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -252,7 +252,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -f json -o {1} -k none -t",
+                string args = string.Format(@"analyze -s {0} -f json -o {1} -g none -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
@@ -271,7 +271,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -f json -l {1} -v trace -k none -t",
+                string args = string.Format(@"analyze -s {0} -f json -l {1} -v trace -g none -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log1.txt"));
 
@@ -293,7 +293,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -f json -l {1} -v error -k none -t",
+                string args = string.Format(@"analyze -s {0} -f json -l {1} -v error -g none -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\nofile.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log2.txt"));
 
@@ -315,7 +315,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -f json -l {1} -v debug -k none -t",
+                string args = string.Format(@"analyze -s {0} -f json -l {1} -v debug -g none -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log3.txt"));
 
@@ -337,7 +337,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -f json -l {1} -k none -t",
+                string args = string.Format(@"analyze -s {0} -f json -l {1} -g none -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfile.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"badir\log.txt"));
 
@@ -356,7 +356,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -f json -l {1} -k none -t",
+                string args = string.Format(@"analyze -s {0} -f json -l {1} -g none -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"));
 
@@ -377,7 +377,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             {
                 string appInspectorPath = Helper.GetPath(Helper.AppPath.appInspectorCLI);
 
-                string args = string.Format(@"analyze -s {0} -x none -f text -k none -o {1} --no-show-progress -t",
+                string args = string.Format(@"analyze -s {0} -x none -f text -g none -o {1} --no-show-progress -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
@@ -401,7 +401,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"analyze -s {0} -x none -f text -k none -l {1} --no-show-progress -t",
+                string args = string.Format(@"analyze -s {0} -x none -f text -g none -l {1} --no-show-progress -t",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 

--- a/UnitTest.Commands/Tests_CLI/TestTagDiffCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestTagDiffCmd.cs
@@ -45,7 +45,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
@@ -65,7 +65,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
@@ -85,7 +85,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"zipped\mainx.zip"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
@@ -106,7 +106,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
 
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -t inequality -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -t inequality -g none -l {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
@@ -126,7 +126,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -t inequality -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -t inequality -g none -l {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
@@ -146,7 +146,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
@@ -167,7 +167,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfile.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
@@ -188,7 +188,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\blank.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
@@ -209,7 +209,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -i -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -i -g none -l {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
@@ -230,7 +230,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -i -r {2} -k none -l {3}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -i -r {2} -g none -l {3}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
@@ -252,7 +252,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -r {2} -k none -l {3}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -r {2} -g none -l {3}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
@@ -274,7 +274,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f text -k none -o {2} -l {3}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f text -g none -o {2} -l {3}",
                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"),
@@ -310,7 +310,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f json -k none -o {2} -l {3}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f json -g none -o {2} -l {3}",
                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json"),
@@ -344,7 +344,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f unknown -k none -o {2} -l {3}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f unknown -g none -o {2} -l {3}",
                   Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                   Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
                   Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"),
@@ -371,7 +371,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -k none -l {2} -o {3}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2} -o {3}",
                      Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                      Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                      Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"\badir\tagdiffout.txt"),
@@ -393,7 +393,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -k none -v trace -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -v trace -l {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
@@ -416,7 +416,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfilepath.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
@@ -439,7 +439,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -r {2} -k none -v debug -l {3}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -r {2} -g none -v debug -l {3}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\baddir\mainx.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"mybadrule.json"),
@@ -466,7 +466,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"\baddir\log.txt"));
@@ -486,7 +486,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\blank.cpp"));
@@ -508,7 +508,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             {
                 string appInspectorPath = Helper.GetPath(Helper.AppPath.appInspectorCLI);
 
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -x none -f text -k none -o {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -x none -f text -g none -o {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
@@ -534,7 +534,7 @@ namespace ApplicationInspector.Unitprocess.CLICommands
             TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -x none -f text -k none -l {2}",
+                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -x none -f text -g none -l {2}",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.3",
+  "version": "1.4",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
This PR changes file path exclusion argument is now `-g` or `--exclusion-globs`.

This will reduce confusion for users coming from 1.2 where `-k` meant substring matches.

Also bring argument parity to the TagDiff command.

This is a semver relevant change so this bumps to `1.4`.