### PR TITLE
Comments : Ruby : Skip code under multi-line commented portion

### DIFF
--- a/RulesEngine/Resources/comments.json
+++ b/RulesEngine/Resources/comments.json
@@ -27,7 +27,6 @@
       "perl6",
       "r",
       "shellscript",
-      "ruby",
       "yaml",
       "powershell",
       "python"
@@ -52,5 +51,13 @@
       "vb"
     ],
     "inline": "'"
+  },
+  {
+    "language": [
+      "ruby"
+    ],
+    "inline": "#",
+    "prefix": "=begin",
+    "suffix": "=end"
   }
 ]


### PR DESCRIPTION
To be able to skip the scanning between the commented code written in Ruby I mentioned prefix and suffix commenting style for the same. This change will just skip the matches/samples found under ```"=begin"``` and ```"=end"```.