### PR TITLE
Fix #396

### DIFF
--- a/RulesEngine/TextContainer.cs
+++ b/RulesEngine/TextContainer.cs
@@ -32,10 +32,11 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             {
                 LineEnds.Add(pos);
 
-                if (pos > 0 && pos + 1 < FullContent.Length)
+                if (pos + 1 < FullContent.Length)
                 {
                     LineStarts.Add(pos + 1);
                 }
+
                 pos = FullContent.IndexOf('\n', pos + 1);
             }
 


### PR DESCRIPTION
If the first character of a file was '\n' we were incorrectly skipping adding the linestart for that line.