### PR TITLE
Fix #402

### DIFF
--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -74,6 +74,9 @@ namespace Microsoft.ApplicationInspector.CLI
 
         [Option('A', "allow-all-tags-in-build-files", Required = false, HelpText = "Allow all tags (not just Metadata tags) in files of type Build.")]
         public bool AllowAllTagsInBuildFiles { get; internal set; }
+
+        [Option('M', "max-num-matches-per-tag", Required = false, HelpText = "If non-zero, and TagsOnly is not set, will ignore rules based on if all of their tags have been found the set value number of times.")]
+        public int MaxNumMatchesPerTag { get; set; } = 0;
     }
 
     [Verb("tagdiff", HelpText = "Compares unique tag values between two source paths")]

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -262,7 +262,8 @@ namespace Microsoft.ApplicationInspector.CLI
                 ScanUnknownTypes = cliOptions.ScanUnknownTypes,
                 TagsOnly = cliOptions.TagsOnly,
                 NoFileMetadata = cliOptions.NoFileMetadata,
-                AllowAllTagsInBuildFiles = cliOptions.AllowAllTagsInBuildFiles
+                AllowAllTagsInBuildFiles = cliOptions.AllowAllTagsInBuildFiles,
+                MaxNumMatchesPerTag = cliOptions.MaxNumMatchesPerTag
             });
 
             if (!cliOptions.NoShowProgressBar)

--- a/AppInspector/MetaDataHelper.cs
+++ b/AppInspector/MetaDataHelper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ApplicationInspector.Commands
         internal ConcurrentDictionary<string, byte> UniqueDependencies { get; set; } = new ConcurrentDictionary<string, byte>();
 
         private ConcurrentDictionary<string, byte> AppTypes { get; set; } = new ConcurrentDictionary<string, byte>();
-        internal ConcurrentDictionary<string, byte> UniqueTags { get; set; } = new ConcurrentDictionary<string, byte>();
+        internal ConcurrentDictionary<string, int> UniqueTags { get; set; } = new ConcurrentDictionary<string, int>();
         private ConcurrentDictionary<string, byte> Outputs { get; set; } = new ConcurrentDictionary<string, byte>();
         private ConcurrentDictionary<string, byte> Targets { get; set; } = new ConcurrentDictionary<string, byte>();
         private ConcurrentDictionary<string, byte> CPUTargets { get; set; } = new ConcurrentDictionary<string, byte>();
@@ -122,7 +122,10 @@ namespace Microsoft.ApplicationInspector.Commands
                 //update list of unique tags as we go
                 foreach (string tag in matchRecord.Tags ?? Array.Empty<string>())
                 {
-                    UniqueTags.TryAdd(tag, 0);
+                    if (!UniqueTags.TryAdd(tag, 1))
+                    {
+                        UniqueTags[tag]++;
+                    }
                 }
             }
         }
@@ -196,7 +199,10 @@ namespace Microsoft.ApplicationInspector.Commands
                 //update list of unique tags as we go
                 foreach (string tag in nonCounters)
                 {
-                    UniqueTags.TryAdd(tag, 0);
+                    if (!UniqueTags.TryAdd(tag, 1))
+                    {
+                        UniqueTags[tag]++;
+                    }
                 }
 
                 Matches.Add(matchRecord);

--- a/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
@@ -67,6 +67,78 @@ namespace ApplicationInspector.Unitprocess.Commands
         }
 
         [TestMethod]
+        public void MaxNumMatches_Pass()
+        {
+            AnalyzeOptions options = new AnalyzeOptions()
+            {
+                SourcePath = new string[1] { Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp") },
+                FilePathExclusions = Array.Empty<string>(), //allow source under unittest path,
+                MaxNumMatchesPerTag = 1
+            };
+
+            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
+            AnalyzeCommand command = new AnalyzeCommand(options);
+            AnalyzeResult result = command.GetResult();
+            Assert.AreEqual(1, result.Metadata.Matches.Count(x => x.Tags.Contains("Platform.OS.Microsoft.WindowsStandard")));
+            exitCode = result.ResultCode;
+            Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public void MaxNumMatchesDisabled_Pass()
+        {
+            AnalyzeOptions options = new AnalyzeOptions()
+            {
+                SourcePath = new string[1] { Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp") },
+                FilePathExclusions = Array.Empty<string>(), //allow source under unittest path,
+                MaxNumMatchesPerTag = 0
+            };
+
+            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
+            AnalyzeCommand command = new AnalyzeCommand(options);
+            AnalyzeResult result = command.GetResult();
+            Assert.AreEqual(3, result.Metadata.Matches.Count(x => x.Tags.Contains("Platform.OS.Microsoft.WindowsStandard")));
+            exitCode = result.ResultCode;
+            Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public async Task MaxNumMatchesAsync_Pass()
+        {
+            AnalyzeOptions options = new AnalyzeOptions()
+            {
+                SourcePath = new string[1] { Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp") },
+                FilePathExclusions = Array.Empty<string>(), //allow source under unittest path,
+                MaxNumMatchesPerTag = 1
+            };
+
+            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
+            AnalyzeCommand command = new AnalyzeCommand(options);
+            AnalyzeResult result = await command.GetResultAsync(new CancellationTokenSource().Token);
+            Assert.AreEqual(1, result.Metadata.Matches.Count(x => x.Tags.Contains("Platform.OS.Microsoft.WindowsStandard")));
+            exitCode = result.ResultCode;
+            Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.Success);
+        }
+
+        [TestMethod]
+        public async Task MaxNumMatchesAsyncDisabled_Pass()
+        {
+            AnalyzeOptions options = new AnalyzeOptions()
+            {
+                SourcePath = new string[1] { Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp") },
+                FilePathExclusions = Array.Empty<string>(), //allow source under unittest path,
+                MaxNumMatchesPerTag = 1
+            };
+
+            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
+            AnalyzeCommand command = new AnalyzeCommand(options);
+            AnalyzeResult result = await command.GetResultAsync(new CancellationTokenSource().Token);
+            Assert.AreEqual(3, result.Metadata.Matches.Count(x => x.Tags.Contains("Platform.OS.Microsoft.WindowsStandard")));
+            exitCode = result.ResultCode;
+            Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.Success);
+        }
+
+        [TestMethod]
         public void BasicAnalyze_Pass()
         {
             AnalyzeOptions options = new AnalyzeOptions()

--- a/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
@@ -91,7 +91,6 @@ namespace ApplicationInspector.Unitprocess.Commands
             {
                 SourcePath = new string[1] { Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp") },
                 FilePathExclusions = Array.Empty<string>(), //allow source under unittest path,
-                MaxNumMatchesPerTag = 0
             };
 
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
@@ -127,7 +126,6 @@ namespace ApplicationInspector.Unitprocess.Commands
             {
                 SourcePath = new string[1] { Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp") },
                 FilePathExclusions = Array.Empty<string>(), //allow source under unittest path,
-                MaxNumMatchesPerTag = 1
             };
 
             AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;


### PR DESCRIPTION
Adds an argument to limit the number of matches a given tag will produce.  Matches will only be recorded if they contain at least one tag which does not have the requested max number of matches already.