### PR TITLE
Fix wrong visibility on new property.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,8 @@ name: "CodeQL"
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: '0 7 * * 5'

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.ApplicationInspector.CLI
         public bool NoFileMetadata { get; set; }
 
         [Option('A', "allow-all-tags-in-build-files", Required = false, HelpText = "Allow all tags (not just Metadata tags) in files of type Build.")]
-        public bool AllowAllTagsInBuildFiles { get; internal set; }
+        public bool AllowAllTagsInBuildFiles { get; set; }
 
         [Option('M', "max-num-matches-per-tag", Required = false, HelpText = "If non-zero, and TagsOnly is not set, will ignore rules based on if all of their tags have been found the set value number of times.")]
         public int MaxNumMatchesPerTag { get; set; } = 0;

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -36,9 +36,9 @@ namespace Microsoft.ApplicationInspector.Commands
         /// </summary>
         public bool AllowAllTagsInBuildFiles { get; set; } = false;
         /// <summary>
-        /// Sets <see cref="AllowAllTagsInBuildFiles"/>
+        /// Alias for <see cref="AllowAllTagsInBuildFiles"/>.
         /// </summary>
-        [Obsolete("Use AllowAllTagsInBuildFiles")]
+        [Obsolete("Use AllowAllTagsInBuildFiles.")]
         public bool TreatEverythingAsCode => AllowAllTagsInBuildFiles;
         public bool NoShowProgress { get; set; } = true;
         public bool TagsOnly { get; set; } = false;

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -32,9 +32,12 @@ namespace Microsoft.ApplicationInspector.Commands
         public IEnumerable<string> FilePathExclusions { get; set; } = Array.Empty<string>();
         public bool SingleThread { get; set; } = false;
         /// <summary>
-        /// Treat <see cref="LanguageInfo.LangFileType.Build"/> files as if they were code when determining if tags apply.
+        /// Treat <see cref="LanguageInfo.LangFileType.Build"/> files as if they were <see cref="LanguageInfo.LangFileType.Code"/> when determining if tags should apply.
         /// </summary>
         public bool AllowAllTagsInBuildFiles { get; set; } = false;
+        /// <summary>
+        /// Sets <see cref="AllowAllTagsInBuildFiles"/>
+        /// </summary>
         [Obsolete("Use AllowAllTagsInBuildFiles")]
         public bool TreatEverythingAsCode => AllowAllTagsInBuildFiles;
         public bool NoShowProgress { get; set; } = true;


### PR DESCRIPTION
The new AllowAllTagsInBuildFiles option was mistakenly labelled as internal rather than public.  This cascades to the TreatEverythingAsCode option which has been deprecated and simply sets this new value.  This is a better name for the behavior of the property.