### PR TITLE
Add basic sarif implementation for the analyze command.

### DIFF
--- a/AppInspector.CLI/AppInspector.CLI.csproj
+++ b/AppInspector.CLI/AppInspector.CLI.csproj
@@ -67,6 +67,7 @@
   <ItemGroup>
     <PackageReference Include="DotLiquid" Version="2.2.585" />
     <PackageReference Include="NLog" Version="4.7.12" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
     <PackageReference Include="ShellProgressBar" Version="5.1.0" />
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
   </ItemGroup>  

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -77,6 +77,9 @@ namespace Microsoft.ApplicationInspector.CLI
 
         [Option('M', "max-num-matches-per-tag", Required = false, HelpText = "If non-zero, and TagsOnly is not set, will ignore rules based on if all of their tags have been found the set value number of times.")]
         public int MaxNumMatchesPerTag { get; set; } = 0;
+
+        [Option("base-path", Required = false, HelpText = "If set, when outputting sarif, will have paths made relative to the provided path.")]
+        public string? BasePath { get; set; } = null;
     }
 
     [Verb("tagdiff", HelpText = "Compares unique tag values between two source paths")]

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -60,13 +60,13 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('N',"no-show-progress", Required = false, HelpText = "Disable progress information.")]
         public bool NoShowProgressBar { get; set; }
 
-        [Option('C',"context-lines", Required = false, HelpText = "Number of lines of context on each side to include in excerpt (up to a maximum of 100 * NumLines characters on each side). 0 to skip exerpt. -1 to not extract samples or excerpts (implied by -t).")]
+        [Option('C',"context-lines", Required = false, HelpText = "Number of lines of context on each side to include in excerpt (up to a maximum of 100 * NumLines characters on each side). 0 to skip exerpt. -1 to not extract samples or excerpts (implied by -t). When outputting sarif use -1 for no snippets, all other values ignored.")]
         public int ContextLines { get; set; } = 3;
 
         [Option('u',"scan-unknown-filetypes", Required = false, HelpText = "Scan files of unknown types.")]
         public bool ScanUnknownTypes { get; set; }
 
-        [Option('t',"tags-only", Required = false, HelpText = "Only get tags (no detailed match data).")]
+        [Option('t',"tags-only", Required = false, HelpText = "Only get tags (no detailed match data). Ignored if output format is sarif.")]
         public bool TagsOnly { get; set; }
 
         [Option('n', "no-file-metadata", Required = false, HelpText = "Don't collect metadata about each individual file.")]

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -80,6 +80,12 @@ namespace Microsoft.ApplicationInspector.CLI
 
         [Option("base-path", Required = false, HelpText = "If set, when outputting sarif, will have paths made relative to the provided path.")]
         public string? BasePath { get; set; } = null;
+
+        [Option("repository-uri", Required = false, HelpText = "If set, when outputting sarif, include this information.")]
+        public string? RepositoryUri { get; set; } = null;
+
+        [Option("commit-hash", Required = false, HelpText = "If set, when outputting sarif, include this information.")]
+        public string? CommitHash { get; set; } = null;
     }
 
     [Verb("tagdiff", HelpText = "Compares unique tag values between two source paths")]

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -177,7 +177,8 @@ namespace Microsoft.ApplicationInspector.CLI
             {
                 "html",
                 "text",
-                "json"
+                "json",
+                "sarif"
             };
 
             string[] checkFormats;

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -249,8 +249,11 @@ namespace Microsoft.ApplicationInspector.CLI
 
             // If we are outputting sarif we don't use any of the context information so we want to set context to 0.
             // If the user manually specified -1 this means they also don't even want the snippet in sarif, so we respect that option
-            int numContextLines = cliOptions.ContextLines == -1 ? cliOptions.ContextLines : cliOptions.OutputFileFormat.Equals("sarif",StringComparison.InvariantCultureIgnoreCase) ? 0 : cliOptions.ContextLines;
-            AnalyzeCommand command = new AnalyzeCommand(new AnalyzeOptions()
+            bool isSarif = cliOptions.OutputFileFormat.Equals("sarif", StringComparison.InvariantCultureIgnoreCase);
+            int numContextLines = cliOptions.ContextLines == -1 ? cliOptions.ContextLines : isSarif ? 0 : cliOptions.ContextLines;
+            // tagsOnly isn't compatible with sarif output, we choose to prioritize the choice of sarif.
+            bool tagsOnly = !isSarif && cliOptions.TagsOnly;
+            AnalyzeCommand command = new(new AnalyzeOptions()
             {
                 SourcePath = cliOptions.SourcePath ?? Array.Empty<string>(),
                 CustomRulesPath = cliOptions.CustomRulesPath ?? "",
@@ -265,7 +268,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 ProcessingTimeOut = cliOptions.ProcessingTimeOut,
                 ContextLines = numContextLines,
                 ScanUnknownTypes = cliOptions.ScanUnknownTypes,
-                TagsOnly = cliOptions.TagsOnly,
+                TagsOnly = tagsOnly,
                 NoFileMetadata = cliOptions.NoFileMetadata,
                 AllowAllTagsInBuildFiles = cliOptions.AllowAllTagsInBuildFiles,
                 MaxNumMatchesPerTag = cliOptions.MaxNumMatchesPerTag

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -246,6 +246,10 @@ namespace Microsoft.ApplicationInspector.CLI
 
         private static int RunAnalyzeCommand(CLIAnalyzeCmdOptions cliOptions)
         {
+
+            // If we are outputting sarif we don't use any of the context information so we want to set context to 0.
+            // If the user manually specified -1 this means they also don't even want the snippet in sarif, so we respect that option
+            int numContextLines = cliOptions.ContextLines == -1 ? cliOptions.ContextLines : cliOptions.OutputFileFormat.Equals("sarif",StringComparison.InvariantCultureIgnoreCase) ? 0 : cliOptions.ContextLines;
             AnalyzeCommand command = new AnalyzeCommand(new AnalyzeOptions()
             {
                 SourcePath = cliOptions.SourcePath ?? Array.Empty<string>(),
@@ -259,7 +263,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 NoShowProgress = cliOptions.NoShowProgressBar,
                 FileTimeOut = cliOptions.FileTimeOut,
                 ProcessingTimeOut = cliOptions.ProcessingTimeOut,
-                ContextLines = cliOptions.ContextLines,
+                ContextLines = numContextLines,
                 ScanUnknownTypes = cliOptions.ScanUnknownTypes,
                 TagsOnly = cliOptions.TagsOnly,
                 NoFileMetadata = cliOptions.NoFileMetadata,

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -246,9 +246,8 @@ namespace Microsoft.ApplicationInspector.CLI
 
         private static int RunAnalyzeCommand(CLIAnalyzeCmdOptions cliOptions)
         {
-
-            // If we are outputting sarif we don't use any of the context information so we want to set context to 0.
             // If the user manually specified -1 this means they also don't even want the snippet in sarif, so we respect that option
+            // Otherwise if we are outputting sarif we don't use any of the context information so we set context to 0, if not sarif leave it alone.
             bool isSarif = cliOptions.OutputFileFormat.Equals("sarif", StringComparison.InvariantCultureIgnoreCase);
             int numContextLines = cliOptions.ContextLines == -1 ? cliOptions.ContextLines : isSarif ? 0 : cliOptions.ContextLines;
             // tagsOnly isn't compatible with sarif output, we choose to prioritize the choice of sarif.

--- a/AppInspector.CLI/ResultsWriter.cs
+++ b/AppInspector.CLI/ResultsWriter.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ApplicationInspector.CLI
                 commandCompletedMsg = "Analyze";
 
                 //additional prechecks required for analyze html format
-                if (cLIAnalyzeCmdOptions.OutputFileFormat == "html")
+                if (writer is AnalyzeHtmlWriter)
                 {
                     int MAX_HTML_REPORT_FILE_SIZE = 1024 * 1000 * 3;  //warn about potential slow rendering
 

--- a/AppInspector.CLI/Writers/AnalyzeSarifWriter.cs
+++ b/AppInspector.CLI/Writers/AnalyzeSarifWriter.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+using Microsoft.ApplicationInspector.Commands;
+using Microsoft.ApplicationInspector.Common;
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CST.OAT.Utils;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Result = Microsoft.ApplicationInspector.Commands.Result;
+
+namespace Microsoft.ApplicationInspector.CLI
+{
+    /// <summary>
+    /// Writes in sarif format
+    /// </summary>
+    public class AnalyzeSarifWriter : CommandResultsWriter
+    {
+        public AnalyzeSarifWriter()
+        {
+
+        }
+
+        public override void WriteResults(Result result, CLICommandOptions commandOptions, bool autoClose = true)
+        {
+            string? basePath = null;
+            if (commandOptions is CLIAnalyzeCmdOptions cLIAnalyzeCmdOptions)
+            {
+                basePath = cLIAnalyzeCmdOptions.BasePath;
+            }
+            if (result is AnalyzeResult analyzeResult)
+            {
+                SarifLog log = new SarifLog();
+                SarifVersion sarifVersion = SarifVersion.Current;
+                log.SchemaUri = sarifVersion.ConvertToSchemaUri();
+                log.Version = sarifVersion;
+                log.Runs = new List<Run>();
+                var run = new Run();
+                var artifacts = new List<Artifact>();
+                run.Tool = new Tool
+                {
+                    Driver = new ToolComponent
+                    {
+                        Name = $"Application Inspector",
+                        InformationUri = new Uri("https://github.com/microsoft/ApplicationInspector/"),
+                        Organization = "Microsoft",
+                        Version = Helpers.GetVersionString(),
+                    }
+                };
+                var reportingDescriptors = new List<ReportingDescriptor>();
+                run.Results = new List<CodeAnalysis.Sarif.Result>();
+                foreach (var match in analyzeResult.Metadata.Matches)
+                {
+                    var sarifResult = new CodeAnalysis.Sarif.Result();
+
+                    // Maybe should instead populate all the rules being used and then match them here
+                    if (match.Rule is not null)
+                    {
+                        if (!reportingDescriptors.Any(r => r.Id == match.Rule.Id))
+                        {
+                            ReportingDescriptor reportingDescriptor = new()
+                            {
+                                FullDescription = new MultiformatMessageString() { Text = match.Rule.Description },
+                                Id = match.Rule.Id,
+                                Name = match.Rule.Name,
+                            };
+
+                            reportingDescriptor.DefaultConfiguration = new ReportingConfiguration()
+                            {
+                                Level = GetSarifFailureLevel(match.Rule.Severity)
+                            };
+                            if (match.Rule.Tags is not null)
+                            {
+                                foreach (var tag in match.Rule.Tags)
+                                {
+                                    reportingDescriptor.Tags.Add(tag);
+                                }
+                            }
+                        }
+
+                        sarifResult.Level = GetSarifFailureLevel(match.Rule.Severity);
+                        sarifResult.RuleId = match.Rule.Id;
+                        sarifResult.Message = new Message() { Text = match.Rule.Description };
+                    }
+
+                    if (match.FileName is not null)
+                    {
+                        string fileName = match.FileName;
+                        if (basePath is not null)
+                        {
+                            fileName = Path.GetRelativePath(basePath, fileName);
+                        }
+                        if (Uri.TryCreate(fileName, UriKind.RelativeOrAbsolute, out Uri? outUri))
+                        {
+                            int artifactIndex = artifacts.FindIndex(a => a.Location.Uri.Equals(outUri));
+                            if (artifactIndex == -1)
+                            {
+                                Artifact artifact = new()
+                                {
+                                    Location = new ArtifactLocation()
+                                    {
+                                        Index = artifacts.Count,
+                                        Uri = outUri
+                                    },
+                                };
+                                artifactIndex = artifact.Location.Index;
+                                artifacts.Add(artifact);
+                            }
+                            sarifResult.Locations = new List<Location>()
+                            {
+                                new Location()
+                                {
+                                    PhysicalLocation = new PhysicalLocation()
+                                    {
+                                        ArtifactLocation = new ArtifactLocation()
+                                        {
+                                            Index = artifactIndex
+                                        },
+                                        Region = new Region()
+                                        {
+                                            StartLine = match.StartLocationLine,
+                                            StartColumn = match.StartLocationColumn,
+                                            EndLine = match.EndLocationLine,
+                                            EndColumn = match.EndLocationColumn
+                                        }
+                                    }
+                                }
+                            };
+                        }
+                    }
+                    run.Artifacts = artifacts;
+                    run.Tool.Driver.Rules = reportingDescriptors;
+                    run.Results.Add(sarifResult);
+                }
+
+                log.Runs.Add(run);
+                JsonSerializerSettings serializerSettings = new();
+                string theOutput = JsonConvert.SerializeObject(log, serializerSettings);
+                if (commandOptions.OutputFilePath is null)
+                {
+                    WriteOnce.Info(theOutput);
+                }
+                else
+                {
+                    File.WriteAllText(commandOptions.OutputFilePath, theOutput);
+                }
+            }
+            else
+            {
+                throw new ArgumentException("This writer can only write Analyze results.", nameof(result));
+            }
+        }
+
+        private static FailureLevel GetSarifFailureLevel(RulesEngine.Severity severity) => severity switch
+        {
+            RulesEngine.Severity.BestPractice => FailureLevel.Note,
+            RulesEngine.Severity.Critical => FailureLevel.Error,
+            RulesEngine.Severity.Important => FailureLevel.Warning,
+            RulesEngine.Severity.ManualReview => FailureLevel.Note,
+            RulesEngine.Severity.Moderate => FailureLevel.Warning,
+            _ => FailureLevel.Note
+        };
+    }
+}

--- a/AppInspector.CLI/Writers/AnalyzeSarifWriter.cs
+++ b/AppInspector.CLI/Writers/AnalyzeSarifWriter.cs
@@ -94,6 +94,11 @@ namespace Microsoft.ApplicationInspector.CLI
                         sarifResult.Level = GetSarifFailureLevel(match.Rule.Severity);
                         sarifResult.RuleId = match.Rule.Id;
                         sarifResult.Tags.AddRange(match.Rule.Tags);
+                        sarifResult.Message = new Message()
+                        {
+                            Text = match.Rule.Description
+                        };
+
                         if (match.FileName is not null)
                         {
                             string fileName = match.FileName;
@@ -141,7 +146,11 @@ namespace Microsoft.ApplicationInspector.CLI
                                                 StartLine = match.StartLocationLine,
                                                 StartColumn = match.StartLocationColumn,
                                                 EndLine = match.EndLocationLine,
-                                                EndColumn = match.EndLocationColumn
+                                                EndColumn = match.EndLocationColumn,
+                                                Snippet = new ArtifactContent()
+                                                {
+                                                    Text = match.Sample
+                                                }
                                             }
                                         }
                                     }

--- a/AppInspector.CLI/Writers/WriterFactory.cs
+++ b/AppInspector.CLI/Writers/WriterFactory.cs
@@ -76,6 +76,10 @@ namespace Microsoft.ApplicationInspector.CLI
                     writer = new AnalyzeHtmlWriter();
                     break;
 
+                case "sarif":
+                    writer = new AnalyzeSarifWriter();
+                    break;
+
                 default:
                     WriteOnce.Error(MsgHelp.FormatString(MsgHelp.ID.CMD_INVALID_ARG_VALUE, "-f"));
                     throw new OpException((MsgHelp.FormatString(MsgHelp.ID.CMD_INVALID_ARG_VALUE, "-f")));

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ApplicationInspector.Commands
         public bool ScanUnknownTypes { get; set; }
         public bool NoFileMetadata { get; set; }
         /// <summary>
-        /// If non-zero, and <see cref="TagsOnly"/> is not set, will ignore rules based on if all of their tags have been found the set value number of times.
+        /// If non-zero, and <see cref="TagsOnly"/> is not set, will ignore matches if all of the matches tags have already been found the set value number of times.
         /// </summary>
         public int MaxNumMatchesPerTag { get; set; } = 0;
     }

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -398,7 +398,7 @@ namespace Microsoft.ApplicationInspector.Commands
                                 }
                                 else if (opts.MaxNumMatchesPerTag > 0)
                                 {
-                                    results = _rulesProcessor.AnalyzeFile(file, languageInfo, _metaDataHelper.UniqueTags.Where(x => x.Value < opts.MaxNumMatchesPerTag).Select(x => x.Key), opts.ContextLines);
+                                    results = _rulesProcessor.AnalyzeFile(file, languageInfo, _metaDataHelper.UniqueTags.Where(x => x.Value >= opts.MaxNumMatchesPerTag).Select(x => x.Key), opts.ContextLines);
                                 }
                                 else
                                 {

--- a/AppInspector/MetaDataHelper.cs
+++ b/AppInspector/MetaDataHelper.cs
@@ -244,7 +244,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
             foreach (MetricTagCounter metricTagCounter in TagCounters.Values)
             {
-                Metadata?.TagCounters?.Add(metricTagCounter);
+                Metadata.TagCounters?.Add(metricTagCounter);
             }
         }
 

--- a/AppInspector/MetaDataHelper.cs
+++ b/AppInspector/MetaDataHelper.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.ApplicationInspector.Commands
 {
@@ -82,7 +83,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     case "Dependency.SourceInclude":
                         return; //design to keep noise out of detailed match list
                     default:
-                        if (tag.Contains("Metric."))
+                        if (tag.Split('.').Contains("Metric"))
                         {
                             _ = TagCounters.TryAdd(tag, new MetricTagCounter()
                             {

--- a/AppInspector/MetaDataHelper.cs
+++ b/AppInspector/MetaDataHelper.cs
@@ -137,74 +137,13 @@ namespace Microsoft.ApplicationInspector.Commands
         /// <param name="matchRecord"></param>
         public void AddMatchRecord(MatchRecord matchRecord)
         {
-            //special handling for standard characteristics in report
-            foreach (var tag in matchRecord.Tags ?? Array.Empty<string>())
-            {
-                switch (tag)
-                {
-                    case "Metadata.Application.Author":
-                    case "Metadata.Application.Publisher":
-                        Metadata.Authors = ExtractValue(matchRecord.Sample);
-                        break;
-                    case "Metadata.Application.Description":
-                        Metadata.Description = ExtractValue(matchRecord.Sample);
-                        break;
-                    case "Metadata.Application.Name":
-                        Metadata.ApplicationName = ExtractValue(matchRecord.Sample);
-                        break;
-                    case "Metadata.Application.Version":
-                        Metadata.SourceVersion = ExtractValue(matchRecord.Sample);
-                        break;
-                    case "Metadata.Application.Target.Processor":
-                        CPUTargets.TryAdd(ExtractValue(matchRecord.Sample).ToLower(), 0);
-                        break;
-                    case "Metadata.Application.Output.Type":
-                        Outputs.TryAdd(ExtractValue(matchRecord.Sample).ToLower(), 0);
-                        break;
-                    case "Dependency.SourceInclude":
-                        return; //design to keep noise out of detailed match list
-                    default:
-                        if (tag.Contains("Metric."))
-                        {
-                            TagCounters.TryAdd(tag, new MetricTagCounter()
-                            {
-                                Tag = tag
-                            });
-                            TagCounters[tag].IncrementCount();
-                        }
-                        else if (tag.Contains(".Platform.OS"))
-                        {
-                            OSTargets.TryAdd(tag.Substring(tag.LastIndexOf('.', tag.Length - 1) + 1), 0);
-                        }
-                        else if (tag.Contains("CloudServices.Hosting"))
-                        {
-                            CloudTargets.TryAdd(tag.Substring(tag.LastIndexOf('.', tag.Length - 1) + 1), 0);
-                        }
-                        break;
-                }
-            }
-
-            //Special handling; attempt to detect app types...review for multiple pattern rule limitation
-            string solutionType = DetectSolutionType(matchRecord);
-            if (!string.IsNullOrEmpty(solutionType))
-            {
-                AppTypes.TryAdd(solutionType, 0);
-            }
+            AddTagsFromMatchRecord(matchRecord);
 
             var nonCounters = matchRecord.Tags?.Where(x => !TagCounters.Any(y => y.Key == x)) ?? Array.Empty<string>();
 
             //omit adding if it if all the tags were counters
             if (nonCounters.Any())
             {
-                //update list of unique tags as we go
-                foreach (string tag in nonCounters)
-                {
-                    if (!UniqueTags.TryAdd(tag, 1))
-                    {
-                        UniqueTags[tag]++;
-                    }
-                }
-
                 Matches.Add(matchRecord);
             }
         }

--- a/RulesEngine/Language.cs
+++ b/RulesEngine/Language.cs
@@ -36,6 +36,20 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                 Languages = JsonConvert.DeserializeObject<List<LanguageInfo>>(file.ReadToEnd()) ?? new List<LanguageInfo>();
             }
         }
+
+        /// <summary>
+        /// Returns the language for a given file name if detected.
+        /// </summary>
+        /// <param name="fileName">The FileName to check.</param>
+        /// <param name="info">If this returns true, a valid LanguageInfo object. If false, undefined.</param>
+        /// <returns>True if the language could be detected based on the filename.</returns>
+        public static bool FromFileNameOut(string fileName, out LanguageInfo info)
+        {
+            info = new LanguageInfo();
+
+            return FromFileName(fileName, ref info);
+        }
+
         /// <summary>
         /// Returns language for given file name
         /// </summary>


### PR DESCRIPTION
Adds basic sarif format output.
Fix #402 implementation.
Fix #406 by supporting Metric specification in any portion of the tag.