### PR TITLE
Clean up the initial matches if some don't pass later conditions.

### DIFF
--- a/AppInspector.CLI/AppInspector.CLI.csproj
+++ b/AppInspector.CLI/AppInspector.CLI.csproj
@@ -65,10 +65,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="DotLiquid" Version="2.2.585" />
+    <PackageReference Include="DotLiquid" Version="2.2.595" />
     <PackageReference Include="NLog" Version="4.7.13" />
     <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
     <PackageReference Include="ShellProgressBar" Version="5.1.0" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
   </ItemGroup>  
 </Project>

--- a/AppInspector.CLI/Writers/AnalyzeSarifWriter.cs
+++ b/AppInspector.CLI/Writers/AnalyzeSarifWriter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ApplicationInspector.CLI
         {
             if (TextWriter is null)
             {
-                throw new ArgumentNullException(nameof(TextWriter));
+                throw new NullReferenceException(nameof(TextWriter));
             }
             string? basePath = null;
             if (commandOptions is CLIAnalyzeCmdOptions cLIAnalyzeCmdOptions)

--- a/AppInspector.Common/AppInspector.Common.csproj
+++ b/AppInspector.Common/AppInspector.Common.csproj
@@ -32,8 +32,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
-  </ItemGroup>
-
 </Project>

--- a/AppInspector/AppInspector.Commands.csproj
+++ b/AppInspector/AppInspector.Commands.csproj
@@ -57,14 +57,13 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="DotLiquid" Version="2.2.585" />
+    <PackageReference Include="DotLiquid" Version="2.2.595" />
     <PackageReference Include="Glob" Version="1.1.9" />
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.15" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.5" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.16" />
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog" Version="4.7.13" />
     <PackageReference Include="ShellProgressBar" Version="5.1.0" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AppInspector/MetaData.cs
+++ b/AppInspector/MetaData.cs
@@ -46,8 +46,6 @@ namespace Microsoft.ApplicationInspector.Commands
         [JsonProperty(PropertyName = "description")]
         public string? Description { get; set; }
 
-        private readonly DateTime _lastUpdated = DateTime.MinValue;
-
         /// <summary>
         /// Last modified date for source code scanned
         /// </summary>
@@ -145,7 +143,7 @@ namespace Microsoft.ApplicationInspector.Commands
         /// List of detected unique tags 
         /// </summary>
         [JsonProperty(PropertyName = "uniqueTags")]
-        public List<string>? UniqueTags { get; set; } = new List<string>();
+        public List<string> UniqueTags { get; set; } = new List<string>();
 
         /// <summary>
         /// List of detected unique code dependency includes

--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AppInspector\AppInspector.Commands.csproj" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.3.37</Version>
+      <Version>3.4.255</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/Pipelines/core-pipeline.yml
+++ b/Pipelines/core-pipeline.yml
@@ -84,7 +84,7 @@ stages:
       inputs:
         packageType: 'sdk'
         version: '6.0.x'
-    - script: 'dotnet tool install -g nbgv'
+    - script: 'dotnet tool update -g nbgv'
       displayName: 'Install GitVersioning'
     - task: PowerShell@2
       displayName: Set Release Version

--- a/RulesEngine/AppInspector.RulesEngine.csproj
+++ b/RulesEngine/AppInspector.RulesEngine.csproj
@@ -25,9 +25,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.15" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.5" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.16" />
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog" Version="4.7.13" />
   </ItemGroup>

--- a/RulesEngine/OatRegexWithIndexOp.cs
+++ b/RulesEngine/OatRegexWithIndexOp.cs
@@ -31,7 +31,7 @@
 
         public static IEnumerable<Violation> RegexWithIndexValidationDelegate(CST.OAT.Rule rule, Clause clause)
         {
-            if (clause.Data?.Count == null || clause.Data?.Count == 0)
+            if (clause.Data?.Count is null or 0)
             {
                 yield return new Violation(string.Format(Strings.Get("Err_ClauseNoData"), rule.Name, clause.Label ?? rule.Clauses.IndexOf(clause).ToString(CultureInfo.InvariantCulture)), rule, clause);
             }

--- a/RulesEngine/OatSubstringIndexOperation.cs
+++ b/RulesEngine/OatSubstringIndexOperation.cs
@@ -26,11 +26,11 @@
 
         public static IEnumerable<Violation> SubstringIndexValidationDelegate(CST.OAT.Rule rule, Clause clause)
         {
-            if (clause.Data?.Count == null || clause.Data?.Count == 0)
+            if (clause.Data?.Count is null or 0)
             {
                 yield return new Violation(string.Format(Strings.Get("Err_ClauseNoData"), rule.Name, clause.Label ?? rule.Clauses.IndexOf(clause).ToString(CultureInfo.InvariantCulture)), rule, clause);
             }
-            if (clause.DictData != null && clause.DictData?.Count > 0)
+            if (clause.DictData?.Count is not null && clause.DictData.Count > 0)
             {
                 yield return new Violation(string.Format(Strings.Get("Err_ClauseDictDataUnexpected"), rule.Name, clause.Label ?? rule.Clauses.IndexOf(clause).ToString(CultureInfo.InvariantCulture), clause.Operation.ToString()), rule, clause);
             }

--- a/RulesEngine/RuleProcessor.cs
+++ b/RulesEngine/RuleProcessor.cs
@@ -130,7 +130,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             List<MatchRecord> resultsList = new();
 
             TextContainer textContainer = new(contents, languageInfo.Name);
-            var caps = analyzer.GetCaptures(rules, textContainer).ToList();
+            var caps = analyzer.GetCaptures(rules, textContainer);
             foreach (var ruleCapture in caps)
             {
                 foreach (var cap in ruleCapture.Captures)

--- a/RulesEngine/Ruleset.cs
+++ b/RulesEngine/Ruleset.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         private readonly Logger? _logger;
         private readonly List<ConvertedOatRule> _oatRules = new();//used for analyze cmd primarily
         private IEnumerable<Rule> _rules { get => _oatRules.Select(x => x.AppInspectorRule); }
-        private Regex searchInRegex = new("\\((.*),(.*)\\)", RegexOptions.Compiled);
+        private readonly Regex searchInRegex = new("\\((.*),(.*)\\)", RegexOptions.Compiled);
 
         /// <summary>
         ///     Creates instance of Ruleset
@@ -231,7 +231,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                             Arguments = condition.Pattern.Modifiers?.ToList() ?? new List<string>(),
                             FindingOnly = true,
                             CustomOperation = "Within",
-                            Scopes = condition.Pattern.Scopes
+                            Scopes = condition.Pattern.Scopes ?? new PatternScope[] { PatternScope.All }
                         });
                         expression.Append(" AND ");
                         expression.Append(clauseNumber);
@@ -267,7 +267,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                                 CustomOperation = "Within",
                                 Before = argList[0],
                                 After = argList[1],
-                                Scopes = condition.Pattern.Scopes
+                                Scopes = condition.Pattern.Scopes ?? new PatternScope[] { PatternScope.All }
                             });
                             expression.Append(" AND ");
                             expression.Append(clauseNumber);
@@ -284,7 +284,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                             Arguments = condition.Pattern.Modifiers?.ToList() ?? new List<string>(),
                             SameLineOnly = true,
                             CustomOperation = "Within",
-                            Scopes = condition.Pattern.Scopes
+                            Scopes = condition.Pattern.Scopes ?? new PatternScope[]{ PatternScope.All }
                         });
                         expression.Append(" AND ");
                         expression.Append(clauseNumber);

--- a/RulesEngine/WithinOperation.cs
+++ b/RulesEngine/WithinOperation.cs
@@ -36,7 +36,8 @@
                 {
                     if (captureHolder is TypedClauseCapture<List<(int, Boundary)>> tcc)
                     {
-                        foreach (var capture in tcc.Result.Select(x => x.Item2))
+                        List<(int, Boundary)> toRemove = new();
+                        foreach ((int clauseNum, Boundary capture) in tcc.Result)
                         {
                             if (wc.FindingOnly)
                             {
@@ -47,6 +48,10 @@
                                     {
                                         passed.AddRange(boundaryList.Result);
                                     }
+                                }
+                                else
+                                {
+                                    toRemove.Add((clauseNum, capture));
                                 }
                             }
                             else if (wc.SameLineOnly)
@@ -61,12 +66,16 @@
                                         passed.AddRange(boundaryList.Result);
                                     }
                                 }
+                                else
+                                {
+                                    toRemove.Add((clauseNum, capture));
+                                }
                             }
                             else
                             {
                                 var startLine = tc.GetLocation(capture.Index).Line;
                                 // Before is already a negative number
-                                var start = tc.LineEnds[Math.Max(0, startLine + wc.Before)];
+                                var start = tc.LineEnds[Math.Max(1, startLine + wc.Before)];
                                 var end = tc.LineEnds[Math.Min(tc.LineEnds.Count - 1, startLine + wc.After)];
                                 var res = ProcessLambda(tc.FullContent[start..end], capture);
                                 if (res.Result)
@@ -76,8 +85,13 @@
                                         passed.AddRange(boundaryList.Result);
                                     }
                                 }
+                                else
+                                {
+                                    toRemove.Add((clauseNum, capture));
+                                }
                             }
                         }
+                        tcc.Result.RemoveAll(x => toRemove.Contains(x));
                     }
                 }
                 return new OperationResult(passed.Any() ^ wc.Invert, passed.Any() ? new TypedClauseCapture<List<Boundary>>(wc, passed) : null);

--- a/RulesEngine/WithinOperation.cs
+++ b/RulesEngine/WithinOperation.cs
@@ -165,6 +165,6 @@
             }
         }
 
-        private RegexOperation regexEngine;
+        private readonly RegexOperation regexEngine;
     }
 }

--- a/UnitTest.Commands/Tests_CLI/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestAnalyzeCmd.cs
@@ -220,7 +220,7 @@
             var result = JsonConvert.DeserializeObject<AnalyzeResult>(content);
             Assert.IsNotNull(result);
             Assert.AreEqual(10, result.Metadata.TotalMatchesCount);
-            Assert.AreEqual(7, result.Metadata.UniqueMatchesCount);
+            Assert.AreEqual(6, result.Metadata.UniqueMatchesCount);
             
             args = string.Format(@"analyze -s {0} -f json -o {1} -g none",
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
@@ -232,8 +232,8 @@
             content = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
             result = JsonConvert.DeserializeObject<AnalyzeResult>(content);
             Assert.IsNotNull(result);
-            Assert.AreEqual(11, result.Metadata.TotalMatchesCount);
-            Assert.AreEqual(7, result.Metadata.UniqueMatchesCount);
+            Assert.AreEqual(10, result.Metadata.TotalMatchesCount);
+            Assert.AreEqual(6, result.Metadata.UniqueMatchesCount);
         }
 
         [TestMethod]

--- a/UnitTest.Commands/Tests_CLI/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestAnalyzeCmd.cs
@@ -219,7 +219,7 @@
             string content = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
             var result = JsonConvert.DeserializeObject<AnalyzeResult>(content);
             Assert.IsNotNull(result);
-            Assert.AreEqual(11, result.Metadata.TotalMatchesCount);
+            Assert.AreEqual(10, result.Metadata.TotalMatchesCount);
             Assert.AreEqual(7, result.Metadata.UniqueMatchesCount);
             
             args = string.Format(@"analyze -s {0} -f json -o {1} -g none",

--- a/UnitTest.Commands/Tests_CLI/TestAnalyzeTagsOnlyCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestAnalyzeTagsOnlyCmd.cs
@@ -199,6 +199,7 @@
 
             string content = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
             var result = JsonConvert.DeserializeObject<AnalyzeResult>(content);
+            Assert.IsNotNull(result);
             var matches = result.Metadata.TotalMatchesCount;
             var uniqueMatches = result.Metadata.UniqueMatchesCount;
             mainduptags = Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp");
@@ -211,6 +212,7 @@
 
             content = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
             var result2 = JsonConvert.DeserializeObject<AnalyzeResult>(content);
+            Assert.IsNotNull(result2);
 
             Assert.AreEqual(matches * 2, result2.Metadata.TotalMatchesCount);
             Assert.AreEqual(uniqueMatches, result2.Metadata.UniqueMatchesCount);
@@ -227,6 +229,7 @@
             Assert.AreEqual(AnalyzeResult.ExitCode.Success, exitCode);
             string content = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
             var result = JsonConvert.DeserializeObject<AnalyzeResult>(content);
+            Assert.IsNotNull(result);
             Assert.AreEqual(0, result.Metadata.TotalMatchesCount);
             Assert.AreEqual(0, result.Metadata.UniqueMatchesCount);
             Assert.AreEqual(6, result.Metadata.UniqueTags.Count);
@@ -240,6 +243,7 @@
             Assert.AreEqual(AnalyzeResult.ExitCode.Success, exitCode);
             content = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
             result = JsonConvert.DeserializeObject<AnalyzeResult>(content);
+            Assert.IsNotNull(result);
             Assert.AreEqual(0, result.Metadata.TotalMatchesCount);
             Assert.AreEqual(0, result.Metadata.UniqueMatchesCount);
             Assert.AreEqual(6, result.Metadata.UniqueTags.Count);

--- a/UnitTest.Commands/Tests_CLI/TestAnalyzeTagsOnlyCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestAnalyzeTagsOnlyCmd.cs
@@ -229,7 +229,7 @@
             var result = JsonConvert.DeserializeObject<AnalyzeResult>(content);
             Assert.AreEqual(0, result.Metadata.TotalMatchesCount);
             Assert.AreEqual(0, result.Metadata.UniqueMatchesCount);
-            Assert.AreEqual(7, result.Metadata.UniqueTags.Count);
+            Assert.AreEqual(6, result.Metadata.UniqueTags.Count);
             
             args = string.Format(@"analyze -s {0} -f json -o {1} -g none -t",
                 Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainduptags.cpp"),
@@ -242,7 +242,7 @@
             result = JsonConvert.DeserializeObject<AnalyzeResult>(content);
             Assert.AreEqual(0, result.Metadata.TotalMatchesCount);
             Assert.AreEqual(0, result.Metadata.UniqueMatchesCount);
-            Assert.AreEqual(7, result.Metadata.UniqueTags.Count);
+            Assert.AreEqual(6, result.Metadata.UniqueTags.Count);
             
         }
 

--- a/UnitTest.Commands/Tests_CLI/TestTagDiffCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestTagDiffCmd.cs
@@ -271,7 +271,6 @@
         [TestMethod]
         public void TagdiffToTextFilePath_Pass()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
                 string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f text -g none -o {2} -l {3}",
@@ -285,29 +284,24 @@
                     File.Delete(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
                 }
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-
-                if (exitCode == TagDiffResult.ExitCode.TestFailed)//looking for diff list
+                if ((TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')) == TagDiffResult.ExitCode.TestFailed)//looking for diff list
                 {
                     if (!File.Exists(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt")) ||
                         new FileInfo(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt")).Length == 0)
                     {
-                        exitCode = TagDiffResult.ExitCode.CriticalError;
+                        Assert.Fail();
                     }
                 }
             }
             catch (Exception)
             {
-                exitCode = TagDiffResult.ExitCode.CriticalError;
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.TestFailed);
         }
 
         [TestMethod]
         public void TagdiffToJsonFilePath_Pass()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
                 string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f json -g none -o {2} -l {3}",
@@ -321,21 +315,18 @@
                     File.Delete(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json"));
                 }
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-
-                if (exitCode == TagDiffResult.ExitCode.TestPassed)
+                if ((TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')) == TagDiffResult.ExitCode.TestPassed)
                 {
                     string content = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json"));
                     var result = JsonConvert.DeserializeObject<TagDiffResult>(content);
-                    exitCode = result.TagDiffList.Count > 0 ? TagDiffResult.ExitCode.TestPassed : TagDiffResult.ExitCode.CriticalError;
+                    Assert.IsNotNull(result);
+                    Assert.IsTrue(result.TagDiffList.Count > 0);
                 }
             }
             catch (Exception)
             {
-                exitCode = TagDiffResult.ExitCode.CriticalError;
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.CriticalError);
         }
 
         [TestMethod]
@@ -390,7 +381,6 @@
         [TestMethod]
         public void LogTraceLevel_Pass()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
                 string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -v trace -l {2}",
@@ -398,22 +388,19 @@
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+                Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
                 string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
-                exitCode = testContent.ToLower().Contains("trace") ? TagDiffResult.ExitCode.TestPassed : TagDiffResult.ExitCode.CriticalError;
+                Assert.IsTrue(testContent.ToLower().Contains("trace"));
             }
             catch (Exception)
             {
-                exitCode = TagDiffResult.ExitCode.CriticalError;
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.TestPassed);
         }
 
         [TestMethod]
         public void LogErrorLevel_Pass()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
                 string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
@@ -421,22 +408,19 @@
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+                Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
                 string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
-                exitCode = testContent.ToLower().Contains("error") ? TagDiffResult.ExitCode.TestPassed : TagDiffResult.ExitCode.CriticalError;
+                Assert.IsTrue(testContent.ToLower().Contains("error"));
             }
             catch (Exception)
             {
-                exitCode = TagDiffResult.ExitCode.CriticalError;
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.TestPassed);
         }
 
         [TestMethod]
         public void LogDebugLevel_Pass()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
                 string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -r {2} -g none -v debug -l {3}",
@@ -445,25 +429,19 @@
                     Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"mybadrule.json"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-                if (exitCode == TagDiffResult.ExitCode.CriticalError)
-                {
-                    string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
-                    exitCode = testContent.ToLower().Contains("debug") ? TagDiffResult.ExitCode.TestPassed : TagDiffResult.ExitCode.CriticalError;
-                }
+                Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
+                string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+                Assert.IsTrue(testContent.ToLower().Contains("debug"));
             }
             catch (Exception)
             {
-                exitCode = TagDiffResult.ExitCode.CriticalError;
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.TestPassed);
         }
 
         [TestMethod]
         public void InvalidLogPath_Fail()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
                 string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
@@ -471,13 +449,12 @@
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"\baddir\log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+                Assert.AreEqual(TagDiffResult.ExitCode.CriticalError,(TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
             }
             catch (Exception)
             {
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.CriticalError);//test fails even when values match unless this case run individually -mstest bug?
         }
 
         [TestMethod]
@@ -491,19 +468,17 @@
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\blank.cpp"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+                Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
             }
             catch (Exception)
             {
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.CriticalError);
         }
 
         [TestMethod]
         public void NoConsoleOutput_Pass()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
                 string appInspectorPath = Helper.GetPath(Helper.AppPath.appInspectorCLI);
@@ -513,19 +488,12 @@
                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Helper.RunProcess(appInspectorPath, args, out string testContent);
-
-                if (exitCode == TagDiffResult.ExitCode.TestPassed)
-                {
-                    exitCode = String.IsNullOrEmpty(testContent) ? TagDiffResult.ExitCode.TestPassed : TagDiffResult.ExitCode.CriticalError;
-                }
+                Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Helper.RunProcess(appInspectorPath, args, out string testContent));
             }
             catch (Exception)
             {
-                exitCode = TagDiffResult.ExitCode.CriticalError;
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.TestPassed);
         }
 
         [TestMethod]

--- a/UnitTest.Commands/Tests_CLI/TestTagDiffCmd.cs
+++ b/UnitTest.Commands/Tests_CLI/TestTagDiffCmd.cs
@@ -42,258 +42,143 @@
         [TestMethod]
         public void Equality_Pass()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.TestPassed);
+            Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void Equality_Fail()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.TestFailed);
+            Assert.AreEqual(TagDiffResult.ExitCode.TestFailed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void ZipReadDiff_Pass()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"zipped\mainx.zip"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"zipped\mainx.zip"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.TestPassed);
+            Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void InEquality_Pass()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -t inequality -g none -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -t inequality -g none -l {2}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
-
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.TestPassed);
+            Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void InEquality_Fail()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -t inequality -g none -l {2}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -t inequality -g none -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.TestFailed);
+            Assert.AreEqual(TagDiffResult.ExitCode.TestFailed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void OneSrcResult_Fail()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-                //check for specific error if desired
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.CriticalError);
+            Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void InvalidSourcePath_Fail()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfile.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfile.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-                //check for specific error if desired
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.CriticalError);
+            Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void NoResults_Fail()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\blank.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\empty.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\blank.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-                //check for specific error if desired
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.CriticalError);
+            Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void NoDefaultNoCustomRules_Fail()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -i -g none -l {2}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -i -g none -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-                //check for specific error if desired
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.CriticalError);
+            Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void NoDefaultCustomRules_Pass()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -i -r {2} -g none -l {3}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -i -r {2} -g none -l {3}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-                //check for specific error if desired
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.TestPassed);
+            Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void DefaultWithCustomRules_Pass()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -r {2} -g none -l {3}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -r {2} -g none -l {3}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-                //check for specific error if desired
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.TestPassed);
+            Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void TagdiffToTextFilePath_Pass()
         {
-            try
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f text -g none -o {2} -l {3}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+
+            if (File.Exists(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt")))
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f text -g none -o {2} -l {3}",
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"),
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
-
-                if (File.Exists(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt")))
-                {
-                    File.Delete(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
-                }
-
-                if ((TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')) == TagDiffResult.ExitCode.TestFailed)//looking for diff list
-                {
-                    if (!File.Exists(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt")) ||
-                        new FileInfo(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt")).Length == 0)
-                    {
-                        Assert.Fail();
-                    }
-                }
+                File.Delete(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
             }
-            catch (Exception)
+
+            Assert.AreEqual(TagDiffResult.ExitCode.TestFailed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
+            if (!File.Exists(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt")) ||
+                new FileInfo(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt")).Length == 0)
             {
                 Assert.Fail();
             }
@@ -302,165 +187,105 @@
         [TestMethod]
         public void TagdiffToJsonFilePath_Pass()
         {
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f json -g none -o {2} -l {3}",
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json"),
-                   Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f json -g none -o {2} -l {3}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                if (File.Exists(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json")))
-                {
-                    File.Delete(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json"));
-                }
-
-                if ((TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')) == TagDiffResult.ExitCode.TestPassed)
-                {
-                    string content = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json"));
-                    var result = JsonConvert.DeserializeObject<TagDiffResult>(content);
-                    Assert.IsNotNull(result);
-                    Assert.IsTrue(result.TagDiffList.Count > 0);
-                }
-            }
-            catch (Exception)
+            if (File.Exists(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json")))
             {
-                Assert.Fail();
+                File.Delete(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json"));
             }
+
+            Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
+            string content = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json"));
+            var result = JsonConvert.DeserializeObject<TagDiffResult>(content);
+            Assert.IsNotNull(result);
         }
 
         [TestMethod]
         public void TagdiffToUnknownFormatFilePath_Fail()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f unknown -g none -o {2} -l {3}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+
+            if (File.Exists(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json")))
             {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -f unknown -g none -o {2} -l {3}",
-                  Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                  Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
-                  Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"),
-                  Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
-
-                if (File.Exists(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json")))
-                {
-                    File.Delete(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json"));
-                }
-
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
+                File.Delete(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.json"));
             }
-            catch (Exception)
-            {
-                //check for specific error if desired
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.CriticalError);
+            Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void TagdiffToOutFilePath_Fail()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2} -o {3}",
-                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                     Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
-                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"\badir\tagdiffout.txt"),
-                     Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2} -o {3}",
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"\badir\tagdiffout.txt"),
+                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-                //check for specific error if desired
-            }
 
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.CriticalError);
+            Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void LogTraceLevel_Pass()
         {
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -v trace -l {2}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -v trace -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
-                string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
-                Assert.IsTrue(testContent.ToLower().Contains("trace"));
-            }
-            catch (Exception)
-            {
-                Assert.Fail();
-            }
+            Assert.AreEqual(TagDiffResult.ExitCode.TestFailed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
+            string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            Assert.IsTrue(testContent.ToLower().Contains("trace"));
         }
 
         [TestMethod]
-        public void LogErrorLevel_Pass()
+        public void LogErrorLevel_Fail()
         {
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfilepath.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
-
-                Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
-                string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
-                Assert.IsTrue(testContent.ToLower().Contains("error"));
-            }
-            catch (Exception)
-            {
-                Assert.Fail();
-            }
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\badfilepath.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
+            string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            Assert.IsTrue(testContent.ToLower().Contains("error"));
         }
 
         [TestMethod]
         public void LogDebugLevel_Pass()
         {
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -r {2} -g none -v debug -l {3}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\baddir\mainx.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"mybadrule.json"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -r {2} -g none -v debug -l {3}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\baddir\mainx.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"mybadrule.json"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
 
-                Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
-                string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
-                Assert.IsTrue(testContent.ToLower().Contains("debug"));
-            }
-            catch (Exception)
-            {
-                Assert.Fail();
-            }
+            Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
+            string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            Assert.IsTrue(testContent.ToLower().Contains("debug"));
         }
 
         [TestMethod]
         public void InvalidLogPath_Fail()
         {
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"\baddir\log.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\mainx.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"\baddir\log.txt"));
 
-                Assert.AreEqual(TagDiffResult.ExitCode.CriticalError,(TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
-            }
-            catch (Exception)
-            {
-                Assert.Fail();
-            }
+            Assert.AreEqual(TagDiffResult.ExitCode.CriticalError,(TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
 
         [TestMethod]
         public void InsecureLogPath_Fail()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
             try
             {
                 string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -g none -l {2}",
@@ -470,50 +295,34 @@
 
                 Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                Assert.Fail();
+                Assert.Fail(e.Message);
             }
         }
 
         [TestMethod]
         public void NoConsoleOutput_Pass()
         {
-            try
-            {
-                string appInspectorPath = Helper.GetPath(Helper.AppPath.appInspectorCLI);
+            string appInspectorPath = Helper.GetPath(Helper.AppPath.appInspectorCLI);
 
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -x none -f text -g none -o {2}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -x none -f text -g none -o {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"output.txt"));
 
-                Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Helper.RunProcess(appInspectorPath, args, out string testContent));
-            }
-            catch (Exception)
-            {
-                Assert.Fail();
-            }
+            Assert.AreEqual(TagDiffResult.ExitCode.TestPassed, (TagDiffResult.ExitCode)Helper.RunProcess(appInspectorPath, args, out string testContent));
+            Assert.AreEqual(string.Empty, testContent);
         }
 
         [TestMethod]
         public void NoConsoleNoFileOutput_Fail()
         {
-            TagDiffResult.ExitCode exitCode = TagDiffResult.ExitCode.CriticalError;
-            try
-            {
-                string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -x none -f text -g none -l {2}",
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
-                    Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
-
-                exitCode = (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' '));
-            }
-            catch (Exception)
-            {
-            }
-
-            Assert.IsTrue(exitCode == TagDiffResult.ExitCode.CriticalError);
+            string args = string.Format(@"tagdiff --src1 {0} --src2 {1} -x none -f text -g none -l {2}",
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\main.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testSource), @"unzipped\simple\maincopy.cpp"),
+                Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"log.txt"));
+            Assert.AreEqual(TagDiffResult.ExitCode.CriticalError, (TagDiffResult.ExitCode)Microsoft.ApplicationInspector.CLI.Program.Main(args.Split(' ')));
         }
     }
 }

--- a/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
@@ -466,8 +466,8 @@
             command = new AnalyzeCommand(options);
             result = command.GetResult();
             Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
-            Assert.AreEqual(11, result.Metadata.TotalMatchesCount);
-            Assert.AreEqual(7, result.Metadata.UniqueMatchesCount);
+            Assert.AreEqual(10, result.Metadata.TotalMatchesCount);
+            Assert.AreEqual(6, result.Metadata.UniqueMatchesCount);
         }
 
         [TestMethod]

--- a/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
+++ b/UnitTest.Commands/Tests_NuGet/TestAnalyzeCmd.cs
@@ -368,8 +368,8 @@
             AnalyzeCommand command = new(options);
             AnalyzeResult result = await command.GetResultAsync(new CancellationToken());
             Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
-            Assert.AreEqual(11, result.Metadata.TotalMatchesCount);
-            Assert.AreEqual(7, result.Metadata.UniqueMatchesCount);
+            Assert.AreEqual(10, result.Metadata.TotalMatchesCount);
+            Assert.AreEqual(6, result.Metadata.UniqueMatchesCount);
         }
 
         [TestMethod]
@@ -458,8 +458,8 @@
             AnalyzeCommand command = new(options);
             AnalyzeResult result = command.GetResult();
             Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
-            Assert.AreEqual(11, result.Metadata.TotalMatchesCount);
-            Assert.AreEqual(7, result.Metadata.UniqueMatchesCount);
+            Assert.AreEqual(10, result.Metadata.TotalMatchesCount);
+            Assert.AreEqual(6, result.Metadata.UniqueMatchesCount);
 
 
             options.SingleThread = false;

--- a/UnitTest.Commands/Tests_NuGet/TestAnalyzeTagsOnlyCmd.cs
+++ b/UnitTest.Commands/Tests_NuGet/TestAnalyzeTagsOnlyCmd.cs
@@ -391,19 +391,12 @@
                 LogFilePath = Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"logtrace.txt"),
             };
 
-            try
-            {
-                AnalyzeCommand command = new(options);
-                AnalyzeResult result = command.GetResult();
-                Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
-                string testLogContent = File.ReadAllText(options.LogFilePath);
-                Assert.IsFalse(string.IsNullOrEmpty(testLogContent));
-                Assert.IsTrue(testLogContent.ToLower().Contains("trace"));
-            }
-            catch (Exception)
-            {
-                Assert.Fail();
-            }
+            AnalyzeCommand command = new(options);
+            AnalyzeResult result = command.GetResult();
+            Assert.AreEqual(AnalyzeResult.ExitCode.NoMatches, result.ResultCode);
+            string testLogContent = File.ReadAllText(options.LogFilePath);
+            Assert.IsFalse(string.IsNullOrEmpty(testLogContent));
+            Assert.IsTrue(testLogContent.ToLower().Contains("trace"));
         }
 
         [TestMethod]

--- a/UnitTest.Commands/Tests_NuGet/TestAnalyzeTagsOnlyCmd.cs
+++ b/UnitTest.Commands/Tests_NuGet/TestAnalyzeTagsOnlyCmd.cs
@@ -297,7 +297,7 @@
             Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
             Assert.AreEqual(0, result.Metadata.TotalMatchesCount);
             Assert.AreEqual(0, result.Metadata.UniqueMatchesCount);
-            Assert.AreEqual(7, result.Metadata.UniqueTags.Count);
+            Assert.AreEqual(6, result.Metadata.UniqueTags.Count);
         }
 
         [TestMethod]
@@ -315,14 +315,14 @@
             AnalyzeResult result = command.GetResult();
             Assert.AreEqual(result.ResultCode, AnalyzeResult.ExitCode.Success);
             Assert.AreEqual(0, result.Metadata.TotalMatchesCount);
-            Assert.AreEqual(8, result.Metadata.UniqueTags.Count);
+            Assert.AreEqual(7, result.Metadata.UniqueTags.Count);
 
             options.SingleThread = false;
             command = new AnalyzeCommand(options);
             result = command.GetResult();
             Assert.AreEqual(result.ResultCode, AnalyzeResult.ExitCode.Success);
             Assert.AreEqual(0, result.Metadata.TotalMatchesCount);
-            Assert.AreEqual(8, result.Metadata.UniqueTags.Count);
+            Assert.AreEqual(7, result.Metadata.UniqueTags.Count);
         }
 
         [TestMethod]
@@ -336,42 +336,34 @@
                 TagsOnly = true
             };
 
-            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
                 AnalyzeCommand command = new(options);
                 AnalyzeResult result = command.GetResult();
-                exitCode = result.ResultCode;
-                if (exitCode == AnalyzeResult.ExitCode.Success)
-                {
-                    exitCode = result.Metadata.TotalMatchesCount == 0 && result.Metadata.UniqueMatchesCount == 0 && result.Metadata.UniqueTags.Count == 7 ? AnalyzeResult.ExitCode.Success : AnalyzeResult.ExitCode.NoMatches;
-                }
+                Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
+                Assert.AreEqual(0, result.Metadata.TotalMatchesCount);
+                Assert.AreEqual(0, result.Metadata.UniqueMatchesCount);
+                Assert.AreEqual(6, result.Metadata.UniqueTags.Count);
             }
             catch (Exception)
             {
-                exitCode = AnalyzeResult.ExitCode.CriticalError;
+                Assert.Fail();
             }
 
-            Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.Success);
-
-            AnalyzeResult.ExitCode exitCodeMultiThread = AnalyzeResult.ExitCode.CriticalError;
             options.SingleThread = false;
             try
             {
                 AnalyzeCommand command = new(options);
                 AnalyzeResult result = command.GetResult();
-                exitCodeMultiThread = result.ResultCode;
-                if (exitCodeMultiThread == AnalyzeResult.ExitCode.Success)
-                {
-                    exitCodeMultiThread = result.Metadata.TotalMatchesCount == 0 && result.Metadata.UniqueMatchesCount == 0 && result.Metadata.UniqueTags.Count == 7 ? AnalyzeResult.ExitCode.Success : AnalyzeResult.ExitCode.NoMatches;
-                }
+                Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
+                Assert.AreEqual(0, result.Metadata.TotalMatchesCount);
+                Assert.AreEqual(0, result.Metadata.UniqueMatchesCount);
+                Assert.AreEqual(6, result.Metadata.UniqueTags.Count);
             }
             catch (Exception)
             {
-                exitCodeMultiThread = AnalyzeResult.ExitCode.CriticalError;
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCodeMultiThread == AnalyzeResult.ExitCode.Success);
         }
 
         [TestMethod]

--- a/UnitTest.Commands/Tests_NuGet/TestAnalyzeTagsOnlyCmd.cs
+++ b/UnitTest.Commands/Tests_NuGet/TestAnalyzeTagsOnlyCmd.cs
@@ -91,14 +91,11 @@
                 TagsOnly = true,
                 SingleThread = true
             };
-
-            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             
             AnalyzeCommand command = new(options);
             AnalyzeResult result = command.GetResult();
-            exitCode = result.ResultCode;
 
-            Assert.AreEqual(AnalyzeResult.ExitCode.Success, exitCode);
+            Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
         }
 
         [TestMethod]
@@ -190,19 +187,16 @@
                 CustomRulesPath = Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
             };
 
-            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
                 AnalyzeCommand command = new(options);
                 AnalyzeResult result = command.GetResult();
-                exitCode = result.ResultCode;
+                Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
             }
             catch (Exception)
             {
-                exitCode = AnalyzeResult.ExitCode.CriticalError;
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.Success);
         }
 
         [TestMethod]
@@ -216,19 +210,16 @@
                 CustomRulesPath = Path.Combine(Helper.GetPath(Helper.AppPath.testRules), @"myrule.json"),
             };
 
-            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
                 AnalyzeCommand command = new(options);
                 AnalyzeResult result = command.GetResult();
-                exitCode = result.ResultCode;
+                Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
             }
             catch (Exception)
             {
-                exitCode = AnalyzeResult.ExitCode.CriticalError;
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.Success);
         }
 
         [TestMethod]
@@ -376,19 +367,16 @@
                 TagsOnly = true
             };
 
-            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
                 AnalyzeCommand command = new(options);
                 AnalyzeResult result = command.GetResult();
-                exitCode = result.ResultCode;
+                Assert.AreEqual(AnalyzeResult.ExitCode.NoMatches, result.ResultCode);
             }
             catch (Exception)
             {
-                exitCode = AnalyzeResult.ExitCode.CriticalError;
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.NoMatches);
         }
 
         [TestMethod]
@@ -403,28 +391,19 @@
                 LogFilePath = Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"logtrace.txt"),
             };
 
-            AnalyzeResult.ExitCode exitCode = AnalyzeResult.ExitCode.CriticalError;
             try
             {
                 AnalyzeCommand command = new(options);
                 AnalyzeResult result = command.GetResult();
-                exitCode = result.ResultCode;
+                Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
                 string testLogContent = File.ReadAllText(options.LogFilePath);
-                if (String.IsNullOrEmpty(testLogContent))
-                {
-                    exitCode = AnalyzeResult.ExitCode.CriticalError;
-                }
-                else if (testLogContent.ToLower().Contains("trace"))
-                {
-                    exitCode = AnalyzeResult.ExitCode.Success;
-                }
+                Assert.IsFalse(string.IsNullOrEmpty(testLogContent));
+                Assert.IsTrue(testLogContent.ToLower().Contains("trace"));
             }
             catch (Exception)
             {
-                exitCode = AnalyzeResult.ExitCode.CriticalError;
+                Assert.Fail();
             }
-
-            Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.Success);
         }
 
         [TestMethod]
@@ -538,30 +517,28 @@
             try
             {
                 // Attempt to open output file.
-                using (var writer = new StreamWriter(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"consoleout.txt")))
-                {
-                    // Redirect standard output from the console to the output file.
-                    Console.SetOut(writer);
+                using var writer = new StreamWriter(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"consoleout.txt"));
+                // Redirect standard output from the console to the output file.
+                Console.SetOut(writer);
 
-                    AnalyzeCommand command = new(options);
-                    AnalyzeResult result = command.GetResult();
-                    exitCode = result.ResultCode;
-                    try
+                AnalyzeCommand command = new(options);
+                AnalyzeResult result = command.GetResult();
+                exitCode = result.ResultCode;
+                try
+                {
+                    string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"consoleout.txt"));
+                    if (String.IsNullOrEmpty(testContent))
                     {
-                        string testContent = File.ReadAllText(Path.Combine(Helper.GetPath(Helper.AppPath.testOutput), @"consoleout.txt"));
-                        if (String.IsNullOrEmpty(testContent))
-                        {
-                            exitCode = AnalyzeResult.ExitCode.Success;
-                        }
-                        else
-                        {
-                            exitCode = AnalyzeResult.ExitCode.NoMatches;
-                        }
+                        exitCode = AnalyzeResult.ExitCode.Success;
                     }
-                    catch (Exception)
+                    else
                     {
-                        exitCode = AnalyzeResult.ExitCode.Success;//no console output file found
+                        exitCode = AnalyzeResult.ExitCode.NoMatches;
                     }
+                }
+                catch (Exception)
+                {
+                    exitCode = AnalyzeResult.ExitCode.Success;//no console output file found
                 }
             }
             catch (Exception)
@@ -570,8 +547,10 @@
             }
 
             //reset to normal
-            var standardOutput = new StreamWriter(Console.OpenStandardOutput());
-            standardOutput.AutoFlush = true;
+            StreamWriter standardOutput = new(Console.OpenStandardOutput())
+            {
+                AutoFlush = true
+            };
             Console.SetOut(standardOutput);
 
             Assert.IsTrue(exitCode == AnalyzeResult.ExitCode.Success);

--- a/UnitTest.Commands/UnitTest.Commands.csproj
+++ b/UnitTest.Commands/UnitTest.Commands.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix #422

When a finding condition is used Application Inspector uses a WithinClause to parse the existing captures and see if any of them are valid given the conditon.  This worked fine when there was a single match with a condition. When there are multiple matches if any of them passed the condition they were all being returned because we were extracting the results from the initial match not the within clause and we neglected to remove the matches that did not match the condition.  This PR changes the WithinClause to remove any matches which don't pass its condition from the original list of captures which is later processed (if any of them pass the withinclause).

Also bumps some dependencies and refactors some tests.