### PR TITLE
Fixes for #442 and #443

### DIFF
--- a/AppInspector.CLI/html/resources/js/appinspector.js
+++ b/AppInspector.CLI/html/resources/js/appinspector.js
@@ -155,23 +155,23 @@ class TemplateInsertion {
         };
 
         for (let match of $this.md) {
-            let excerpt = (match.excerpt || '') || match.sample;
-            if (match.ruleId === ruleId || match.ruleName === ruleId) {
+            let excerpt = (match.Excerpt || '') || match.Sample;
+            if (match.RuleId === ruleId || match.RuleName === ruleId) {
                 let $li = $('<li>');
                 let $a = $('<a>');
-                let $l = match.startLocationLine - 3;
-                let $e = match.endLocationLine;
+                let $l = match.StartLocationLine;
+                let $e = match.EndLocationLine;
                 if ($l <= 0) $l = 1; //fix #183
                 $a.addClass('content-link')
                     .attr('href', '#')
                     .data('excerpt', excerpt)
                     .data('startLocationLine', $l)
                     .data('endLocationLine', $e)
-                    .text(removePrefix(match.fileName));
+                    .text(removePrefix(match.FileName));
                 $li.append($a);
                 $('#file_listing_modal ul').append($li);
 
-                $('#match-line-number').text('Line number: ' + match.startLocationLine.toString());
+                $('#match-line-number').text('Line number: ' + match.StartLocationLine.toString());
             }
         }
         $('#file_listing_modal').on('shown.bs.modal', function (e) {
@@ -214,7 +214,7 @@ class TemplateInsertion {
             // a tag that matches what we're looking for, we'll keep that icon visible.
             search_loop:
             for (let match of this.md) {
-                for (let tag of match.tags) {
+                for (let tag of match.Tags) {
                     if (targetRegex.exec(tag)) {
                         foundTag = true;        // We have at least one match for this icon
                         break search_loop;
@@ -275,9 +275,9 @@ class TemplateInsertion {
             const targetRegex = new RegExp(targetRegexValue, 'i');
             let identifiedRules = {};
             for (let match of this.md) {
-                for (let tag of match.tags) {
+                for (let tag of match.Tags) {
                     if (targetRegex.exec(tag)) {
-                        identifiedRules[match.ruleName] = this.combineConfidence(identifiedRules[match.ruleName], match.confidence);
+                        identifiedRules[match.RuleName] = this.combineConfidence(identifiedRules[match.RuleName], match.Confidence);
                         break;  // Only break out of inner loop, we only need one match per tag set
                     }
                 }

--- a/AppInspector.CLI/html/resources/js/appinspector.js
+++ b/AppInspector.CLI/html/resources/js/appinspector.js
@@ -42,6 +42,20 @@
         const editor = ace.edit("editor");
 
         editor.setOption('firstLineNumber', startLocationLine - 3);
+
+        // Decode the content (HTML encoded) for Ace to display
+        // Disabled, needs better testing, since it's prone to XSS if content contains JS.
+        // Maybe there is a better way of doing this.
+        if (false)
+        {
+            const htmlEntityDecoder = (content) => {
+                const textArea = document.createElement('textarea');
+                textArea.innerHTML = content;
+                return textArea.value;
+            }
+            content = htmlEntityDecoder(content);
+        }
+
         editor.getSession().setValue(content);
         editor.resize();
         editor.scrollToLine(0);

--- a/AppInspector.CLI/html/resources/js/appinspector.js
+++ b/AppInspector.CLI/html/resources/js/appinspector.js
@@ -41,13 +41,14 @@
         const endLocationLine = $(e.target).data('endLocationLine');
         const editor = ace.edit("editor");
 
-        editor.setOption('firstLineNumber', startLocationLine);
+        editor.setOption('firstLineNumber', startLocationLine - 3);
         editor.getSession().setValue(content);
         editor.resize();
         editor.scrollToLine(0);
-        editor.gotoLine(endLocationLine - startLocationLine + 1);
+        editor.gotoLine(endLocationLine - startLocationLine + 1 + 3);
 
         $('editor-container').removeClass('d-none');
+        $('#match-line-number').text('Line number: ' + startLocationLine.toString());
     });
 
     const templateInsertion = new TemplateInsertion(data);


### PR DESCRIPTION
This PR contains cosmetic fixes to the HTML report, the most important of which is because the match object's keys are now Uppercase, and the appinspector.js file had references to them all in lowercase, so it was causing the UI to break.
