### PR TITLE
Fix #461

### DIFF
--- a/AppInspector.CLI/ResultsWriter.cs
+++ b/AppInspector.CLI/ResultsWriter.cs
@@ -56,13 +56,6 @@ namespace Microsoft.ApplicationInspector.CLI
                 {
                     int MAX_HTML_REPORT_FILE_SIZE = 1024 * 1000 * 3;  //warn about potential slow rendering
 
-                    //prechecks
-                    if (analyzeResult.ResultCode != AnalyzeResult.ExitCode.Success)
-                    {
-                        Finalize(writer, commandCompletedMsg);
-                        return;
-                    }
-
                     writer.WriteResults(analyzeResult, cLIAnalyzeCmdOptions);
 
                     //post checks

--- a/AppInspector.Common/MsgHelp.cs
+++ b/AppInspector.Common/MsgHelp.cs
@@ -38,6 +38,7 @@ namespace Microsoft.ApplicationInspector.Common
             CMD_CRITICAL_FILE_ERR,
             CMD_INVALID_ARG_VALUE,
             CMD_INVALID_FILE_OR_DIR,
+            CMD_NO_FILES_IN_SOURCE,
             CMD_REPORT_DONE,
             CMD_REQUIRED_ARG_MISSING,
             CMD_RUNNING,

--- a/AppInspector.Common/Properties/Resources.Designer.cs
+++ b/AppInspector.Common/Properties/Resources.Designer.cs
@@ -304,6 +304,15 @@ namespace Microsoft.ApplicationInspector.Common.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Specified source location does not contain any files. {0}.
+        /// </summary>
+        internal static string CMD_NO_FILES_IN_SOURCE {
+            get {
+                return ResourceManager.GetString("CMD_NO_FILES_IN_SOURCE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No output specified.  Raise the console versosity or provide an output file argument..
         /// </summary>
         internal static string CMD_NO_OUTPUT {

--- a/AppInspector.Common/Properties/Resources.resx
+++ b/AppInspector.Common/Properties/Resources.resx
@@ -192,6 +192,9 @@
   <data name="CMD_INVALID_FILE_OR_DIR" xml:space="preserve">
     <value>Invalid file or directory {0}</value>
   </data>
+  <data name="CMD_NO_FILES_IN_SOURCE" xml:space="preserve">
+    <value>Specified source location does not contain any files. {0}</value>
+  </data>
   <data name="CMD_INVALID_LOG_PATH" xml:space="preserve">
     <value>The requested log file {0} could not be read.</value>
   </data>

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -149,6 +149,7 @@ namespace Microsoft.ApplicationInspector.Commands
             {
                 _severity |= severity;
             }
+
             ConfigSourcetoScan();
             ConfigRules();
         }
@@ -189,7 +190,7 @@ namespace Microsoft.ApplicationInspector.Commands
             }
             if (_srcfileList.Count == 0)
             {
-                throw new OpException(MsgHelp.FormatString(MsgHelp.ID.CMD_INVALID_FILE_OR_DIR, string.Join(',', _options.SourcePath)));
+                throw new OpException(MsgHelp.FormatString(MsgHelp.ID.CMD_NO_FILES_IN_SOURCE, string.Join(',', _options.SourcePath)));
             }
         }
 


### PR DESCRIPTION
Attempt to create the HTML report regardless of analysis status.

Adds a new string to clarify when the failure is due to no files existing in the source directories provided.

Fix #461