### PR TITLE
Switch match references to camelCase.

### DIFF
--- a/AppInspector.CLI/html/resources/js/appinspector.js
+++ b/AppInspector.CLI/html/resources/js/appinspector.js
@@ -170,23 +170,23 @@ class TemplateInsertion {
         };
 
         for (let match of $this.md) {
-            let excerpt = (match.Excerpt || '') || match.Sample;
-            if (match.RuleId === ruleId || match.RuleName === ruleId) {
+            let excerpt = (match.excerpt || '') || match.sample;
+            if (match.ruleId === ruleId || match.ruleName === ruleId) {
                 let $li = $('<li>');
                 let $a = $('<a>');
-                let $l = match.StartLocationLine;
-                let $e = match.EndLocationLine;
+                let $l = match.startLocationLine;
+                let $e = match.endLocationLine;
                 if ($l <= 0) $l = 1; //fix #183
                 $a.addClass('content-link')
                     .attr('href', '#')
                     .data('excerpt', excerpt)
                     .data('startLocationLine', $l)
                     .data('endLocationLine', $e)
-                    .text(removePrefix(match.FileName));
+                    .text(removePrefix(match.fileName));
                 $li.append($a);
                 $('#file_listing_modal ul').append($li);
 
-                $('#match-line-number').text('Line number: ' + match.StartLocationLine.toString());
+                $('#match-line-number').text('Line number: ' + match.startLocationLine.toString());
             }
         }
         $('#file_listing_modal').on('shown.bs.modal', function (e) {
@@ -229,7 +229,7 @@ class TemplateInsertion {
             // a tag that matches what we're looking for, we'll keep that icon visible.
             search_loop:
             for (let match of this.md) {
-                for (let tag of match.Tags) {
+                for (let tag of match.tags) {
                     if (targetRegex.exec(tag)) {
                         foundTag = true;        // We have at least one match for this icon
                         break search_loop;
@@ -290,9 +290,9 @@ class TemplateInsertion {
             const targetRegex = new RegExp(targetRegexValue, 'i');
             let identifiedRules = {};
             for (let match of this.md) {
-                for (let tag of match.Tags) {
+                for (let tag of match.tags) {
                     if (targetRegex.exec(tag)) {
-                        identifiedRules[match.RuleName] = this.combineConfidence(identifiedRules[match.RuleName], match.Confidence);
+                        identifiedRules[match.ruleName] = this.combineConfidence(identifiedRules[match.ruleName], match.confidence);
                         break;  // Only break out of inner loop, we only need one match per tag set
                     }
                 }

--- a/AppInspector.CLI/html/resources/js/appinspector.js
+++ b/AppInspector.CLI/html/resources/js/appinspector.js
@@ -134,12 +134,12 @@ class TemplateInsertion {
             }
         });
 
-        $('#s_pi_application_name').html(this.mt.applicationName);
-        $('#s_pi_version').html(this.mt.sourceVersion);
-        $('#s_pi_description').html(this.mt.description || 'No description available.');
-        $('#s_pi_source_path').html(this.mt.sourcePath);
-        $('#s_pi_author').html(this.mt.authors || 'No author found.');
-        $('#s_pi_date_scanned').html(this.mt.dateScanned);
+        $('#s_pi_application_name').text(this.mt.applicationName);
+        $('#s_pi_version').text(this.mt.sourceVersion);
+        $('#s_pi_description').text(this.mt.description || 'No description available.');
+        $('#s_pi_source_path').text(this.mt.sourcePath);
+        $('#s_pi_author').text(this.mt.authors || 'No author found.');
+        $('#s_pi_date_scanned').text(this.mt.dateScanned);
     }
 
     combineConfidence(a, b) {

--- a/AppInspector.Tests/Commands/TestExportTagsCmd.cs
+++ b/AppInspector.Tests/Commands/TestExportTagsCmd.cs
@@ -18,7 +18,7 @@ namespace AppInspector.Tests.Commands
         private LogOptions logOptions = new();
         private ILoggerFactory factory = new NullLoggerFactory();
 
-        [TestInitialize]
+        [ClassInitialize]
         public void InitOutput()
         {
             factory = logOptions.GetLoggerFactory();
@@ -27,7 +27,7 @@ namespace AppInspector.Tests.Commands
             File.WriteAllText(testRulesPath, findWindows);
         }
 
-        [TestCleanup]
+        [ClassCleanup]
         public void CleanUp()
         {
             Directory.Delete(TestHelpers.GetPath(TestHelpers.AppPath.testOutput), true);

--- a/AppInspector.Tests/Commands/TestTagDiffCmd.cs
+++ b/AppInspector.Tests/Commands/TestTagDiffCmd.cs
@@ -43,7 +43,7 @@ namespace AppInspector.Tests.Commands
             File.WriteAllText(testRulesPath, findWindows);
         }
 
-        [TestCleanup]
+        [ClassCleanup]
         public void CleanUp()
         {
             Directory.Delete(TestHelpers.GetPath(TestHelpers.AppPath.testOutput), true);

--- a/AppInspector.Tests/Commands/TestVerifyRulesCmd.cs
+++ b/AppInspector.Tests/Commands/TestVerifyRulesCmd.cs
@@ -19,7 +19,7 @@ namespace AppInspector.Tests.Commands
         private string _validRulesPath = string.Empty;
         private LogOptions _logOptions = new();
         private ILoggerFactory _factory = new NullLoggerFactory();
-        [TestInitialize]
+        [ClassCleanup]
         public void InitOutput()
         {
             _factory = _logOptions.GetLoggerFactory();
@@ -28,7 +28,7 @@ namespace AppInspector.Tests.Commands
             File.WriteAllText(_validRulesPath, _validRules);
         }
 
-        [TestCleanup]
+        [ClassCleanup]
         public void CleanUp()
         {
             Directory.Delete(TestHelpers.GetPath(TestHelpers.AppPath.testOutput), true);

--- a/AppInspector.Tests/Languages/LanguagesTests.cs
+++ b/AppInspector.Tests/Languages/LanguagesTests.cs
@@ -1,10 +1,11 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Text.Json;
+
 using Microsoft.ApplicationInspector.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using Serilog.Events;
 
 namespace AppInspector.Tests.Languages
@@ -72,8 +73,8 @@ namespace AppInspector.Tests.Languages
         [TestMethod]
         public void EmptyLanguagesOnInvalidCommentsAndLanguages()
         {
-            Assert.ThrowsException<JsonException>(() => Microsoft.ApplicationInspector.RulesEngine.Languages.FromConfigurationFiles(_factory, invalidTestCommentsPath, null));
-            Assert.ThrowsException<JsonException>(() => Microsoft.ApplicationInspector.RulesEngine.Languages.FromConfigurationFiles(_factory, null, invalidTestLanguagesPath));
+            Assert.ThrowsException<JsonSerializationException>(() => Microsoft.ApplicationInspector.RulesEngine.Languages.FromConfigurationFiles(_factory, invalidTestCommentsPath, null));
+            Assert.ThrowsException<JsonSerializationException>(() => Microsoft.ApplicationInspector.RulesEngine.Languages.FromConfigurationFiles(_factory, null, invalidTestLanguagesPath));
         }
 
         [TestMethod]

--- a/AppInspector/AppInspector.Commands.csproj
+++ b/AppInspector/AppInspector.Commands.csproj
@@ -62,7 +62,6 @@
     <PackageReference Include="ShellProgressBar" Version="5.2.0" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="6.0.1" />
-    <PackageReference Include="System.Text.Json" Version="6.0.5" />
     
   </ItemGroup>
 

--- a/AppInspector/Commands/VerifyRulesCommand.cs
+++ b/AppInspector/Commands/VerifyRulesCommand.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
-using System.Text.Json.Serialization;
 using Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.ApplicationInspector.Commands
 {
@@ -11,7 +12,7 @@ namespace Microsoft.ApplicationInspector.Commands
     using Microsoft.CST.OAT;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
-    using System.Text.Json;
+    
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -36,7 +37,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
     public class VerifyRulesResult : Result
     {
-        [Newtonsoft.Json.JsonConverter(typeof(JsonStringEnumConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(StringEnumConverter))]
         public enum ExitCode
         {
             Verified = 0,
@@ -44,10 +45,10 @@ namespace Microsoft.ApplicationInspector.Commands
             CriticalError = Utils.ExitCode.CriticalError
         }
 
-        [JsonPropertyName("resultCode")]
+        [JsonProperty(PropertyName ="resultCode")]
         public ExitCode ResultCode { get; set; }
 
-        [JsonPropertyName("ruleStatusList")]
+        [JsonProperty(PropertyName ="ruleStatusList")]
         public List<RuleStatus> RuleStatusList { get; set; }
 
         public VerifyRulesResult()

--- a/RulesEngine/AppInspector.RulesEngine.csproj
+++ b/RulesEngine/AppInspector.RulesEngine.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.CST.OAT" Version="1.2.15" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="System.Text.Json" Version="6.0.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     
   </ItemGroup>
 

--- a/RulesEngine/Comment.cs
+++ b/RulesEngine/Comment.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright(C) Microsoft.All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
@@ -10,16 +10,16 @@ namespace Microsoft.ApplicationInspector.RulesEngine
     /// </summary>
     internal class Comment
     {
-        [JsonPropertyName("language")]
+        [JsonProperty(PropertyName ="language")]
         public string[]? Languages { get; set; }
 
-        [JsonPropertyName("inline")]
+        [JsonProperty(PropertyName ="inline")]
         public string? Inline { get; set; }
 
-        [JsonPropertyName("prefix")]
+        [JsonProperty(PropertyName ="prefix")]
         public string? Prefix { get; set; }
 
-        [JsonPropertyName("suffix")]
+        [JsonProperty(PropertyName ="suffix")]
         public string? Suffix { get; set; }
     }
 }

--- a/RulesEngine/Confidence.cs
+++ b/RulesEngine/Confidence.cs
@@ -1,10 +1,11 @@
-﻿using System.Text.Json.Serialization;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
     using System;
 
     [Flags]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum Confidence { Unspecified = 0, Low = 1, Medium = 2, High = 4 }
 }

--- a/RulesEngine/LanguageInfo.cs
+++ b/RulesEngine/LanguageInfo.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright(C) Microsoft.All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
@@ -12,17 +13,17 @@ namespace Microsoft.ApplicationInspector.RulesEngine
     {
         public enum LangFileType { Code, Build };
 
-        [JsonPropertyName("name")]
+        [JsonProperty(PropertyName ="name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("extensions")]
+        [JsonProperty(PropertyName ="extensions")]
         public string[]? Extensions { get; set; }
 
-        [JsonPropertyName("file-names")]
+        [JsonProperty(PropertyName ="file-names")]
         public string[]? FileNames { get; set; }
         
-        [JsonPropertyName("type")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonProperty(PropertyName ="type")]
+        [JsonConverter(typeof(StringEnumConverter))]
         public LangFileType Type { get; set; } = LangFileType.Code;
     }
 }

--- a/RulesEngine/Languages.cs
+++ b/RulesEngine/Languages.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
+using Newtonsoft.Json;
+
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
     using Microsoft.Extensions.Logging;
@@ -10,7 +12,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
     using System.IO;
     using System.Linq;
     using System.Reflection;
-    using System.Text.Json;
+    
 
     /// <summary>
     /// Helper class for language based commenting
@@ -28,6 +30,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             _logger = loggerFactory?.CreateLogger<Languages>() ?? new NullLogger<Languages>();
             Assembly assembly = typeof(Languages).Assembly;
             Stream? commentResource = commentsStream ?? assembly.GetManifestResourceStream(CommentResourcePath);
+
             if (commentResource is null)
             {
                 _logger.LogError("Failed to load embedded comments configuration from {CommentResourcePath}", CommentResourcePath);
@@ -35,7 +38,10 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             }
             else
             {
-                _comments = JsonSerializer.Deserialize<List<Comment>>(commentResource) ?? new List<Comment>();
+                using StreamReader commentStreamReader = new(commentResource);
+                using JsonReader commentJsonReader = new JsonTextReader(commentStreamReader);
+                JsonSerializer jsonSerializer = new();
+                _comments = jsonSerializer.Deserialize<List<Comment>>(commentJsonReader) ?? new List<Comment>();
             }
             
             Stream? languagesResource = languagesStream ?? assembly.GetManifestResourceStream(LanguagesResourcePath);
@@ -46,7 +52,10 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             }
             else
             {
-                _languageInfos = JsonSerializer.Deserialize<List<LanguageInfo>>(languagesResource) ?? new List<LanguageInfo>();
+                using StreamReader languagesStreamReader = new(languagesResource);
+                using JsonReader languagesJsonReader = new JsonTextReader(languagesStreamReader);
+                JsonSerializer jsonSerializer = new();
+                _languageInfos = jsonSerializer.Deserialize<List<LanguageInfo>>(languagesJsonReader) ?? new List<LanguageInfo>();
             }
         }
 

--- a/RulesEngine/MatchRecord.cs
+++ b/RulesEngine/MatchRecord.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
@@ -39,35 +39,35 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         /// <summary>
         /// Rule Id found in matching rule
         /// </summary>
-        [JsonPropertyName("ruleId")]
+        [JsonProperty(PropertyName ="ruleId")]
         [ExcludeFromCodeCoverage]
         public string RuleId { get; set; }
 
         /// <summary>
         /// Rule name found in matching rule
         /// </summary>
-        [JsonPropertyName("ruleName")]
+        [JsonProperty(PropertyName ="ruleName")]
         [ExcludeFromCodeCoverage]
         public string RuleName { get; set;  }
 
         /// <summary>
         /// Rule description found in matching rule
         /// </summary>
-        [JsonPropertyName("ruleDescription")]
+        [JsonProperty(PropertyName ="ruleDescription")]
         [ExcludeFromCodeCoverage]
         public string? RuleDescription { get; set; }
 
         /// <summary>
         /// Tags in matching rule
         /// </summary>
-        [JsonPropertyName("tags")]
+        [JsonProperty(PropertyName ="tags")]
         [ExcludeFromCodeCoverage]
         public string[]? Tags { get; set;  }
 
         /// <summary>
         /// Rule severity
         /// </summary>_rule
-        [JsonPropertyName("severity")]
+        [JsonProperty(PropertyName ="severity")]
         [ExcludeFromCodeCoverage]
         public Severity Severity { get; set;  }
 
@@ -78,21 +78,21 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         /// <summary>
         /// Matching pattern found in matching rule
         /// </summary>
-        [JsonPropertyName("pattern")]
+        [JsonProperty(PropertyName ="pattern")]
         [ExcludeFromCodeCoverage]
         public string? Pattern => MatchingPattern?.Pattern;
 
         /// <summary>
         /// Pattern confidence in matching rule pattern
         /// </summary>
-        [JsonPropertyName("confidence")]
+        [JsonProperty(PropertyName ="confidence")]
         [ExcludeFromCodeCoverage]
         public Confidence Confidence => MatchingPattern?.Confidence ?? Confidence.Unspecified;
 
         /// <summary>
         /// Pattern type of matching pattern
         /// </summary>
-        [JsonPropertyName("type")]
+        [JsonProperty(PropertyName ="type")]
         [ExcludeFromCodeCoverage]
         public string? PatternType => MatchingPattern?.PatternType.ToString();
 
@@ -110,27 +110,27 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         /// <summary>
         /// Friendly source type
         /// </summary>
-        [JsonPropertyName("language")]
+        [JsonProperty(PropertyName ="language")]
         public string? Language => LanguageInfo?.Name;
 
         /// <summary>
         /// Filename of this match
         /// </summary>
-        [JsonPropertyName("fileName")]
+        [JsonProperty(PropertyName ="fileName")]
         [ExcludeFromCodeCoverage]
         public string? FileName { get; set; }
 
         /// <summary>
         /// Matching text for this record
         /// </summary>
-        [JsonPropertyName("sample")]
+        [JsonProperty(PropertyName ="sample")]
         [ExcludeFromCodeCoverage]
         public string Sample { get; set; } = "";
 
         /// <summary>
         /// Matching surrounding context text for sample in this record
         /// </summary>
-        [JsonPropertyName("excerpt")]
+        [JsonProperty(PropertyName ="excerpt")]
         [ExcludeFromCodeCoverage]
         public string Excerpt { get; set; } = "";
 
@@ -141,28 +141,28 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         /// <summary>
         /// Starting line location of the matching text
         /// </summary>
-        [JsonPropertyName("startLocationLine")]
+        [JsonProperty(PropertyName ="startLocationLine")]
         [ExcludeFromCodeCoverage]
         public int StartLocationLine { get; set; }
 
         /// <summary>
         /// Starting column location of the matching text
         /// </summary>
-        [JsonPropertyName("startLocationColumn")]
+        [JsonProperty(PropertyName ="startLocationColumn")]
         [ExcludeFromCodeCoverage]
         public int StartLocationColumn { get; set; }
 
         /// <summary>
         /// Ending line location of the matching text
         /// </summary>
-        [JsonPropertyName("endLocationLine")]
+        [JsonProperty(PropertyName ="endLocationLine")]
         [ExcludeFromCodeCoverage]
         public int EndLocationLine { get; set; }
 
         /// <summary>
         /// Ending column of the matching text
         /// </summary>
-        [JsonPropertyName("endLocationColumn")]
+        [JsonProperty(PropertyName ="endLocationColumn")]
         [ExcludeFromCodeCoverage]
         public int EndLocationColumn { get; set; }
     }

--- a/RulesEngine/PatternScope.cs
+++ b/RulesEngine/PatternScope.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum PatternScope
     {
         All,

--- a/RulesEngine/PatternType.cs
+++ b/RulesEngine/PatternType.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
     /// <summary>
     /// Pattern Type for search pattern
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum PatternType
     {
         Regex,

--- a/RulesEngine/Rule.cs
+++ b/RulesEngine/Rule.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
@@ -34,19 +35,19 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         [JsonIgnore]
         public bool Disabled { get; set; }
 
-        [JsonPropertyName("name")]
+        [JsonProperty(PropertyName ="name")]
         public string Name { get; set; } = "";
 
-        [JsonPropertyName("id")]
+        [JsonProperty(PropertyName ="id")]
         public string Id { get; set; } = "";
 
-        [JsonPropertyName("description")]
+        [JsonProperty(PropertyName ="description")]
         public string? Description { get; set; } = "";
 
-        [JsonPropertyName("applies_to")]
+        [JsonProperty(PropertyName ="applies_to")]
         public string[]? AppliesTo { get; set; }
 
-        [JsonPropertyName("applies_to_file_regex")]
+        [JsonProperty(PropertyName ="applies_to_file_regex")]
         public string[]? FileRegexes
         {
             get => _fileRegexes;
@@ -76,20 +77,20 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         private IEnumerable<Regex> _compiled = Array.Empty<Regex>();
         private bool _updateCompiledFileRegex = false;
 
-        [JsonPropertyName("tags")]
+        [JsonProperty(PropertyName ="tags")]
         public string[]? Tags { get; set; }
 
-        [JsonPropertyName("severity")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonProperty(PropertyName ="severity")]
+        [JsonConverter(typeof(StringEnumConverter))]
         public Severity Severity { get; set; } = Severity.Moderate;
 
-        [JsonPropertyName("overrides")]
+        [JsonProperty(PropertyName ="overrides")]
         public string[]? Overrides { get; set; }
 
-        [JsonPropertyName("patterns")]
+        [JsonProperty(PropertyName ="patterns")]
         public SearchPattern[] Patterns { get; set; } = Array.Empty<SearchPattern>();
 
-        [JsonPropertyName("conditions")]
+        [JsonProperty(PropertyName ="conditions")]
         public SearchCondition[]? Conditions { get; set; }
     }
 }

--- a/RulesEngine/Ruleset.cs
+++ b/RulesEngine/Ruleset.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
-using System.Text.Json;
+
 using Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
+using Newtonsoft.Json;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
@@ -350,8 +351,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
 
         internal IEnumerable<Rule> StringToRules(string jsonstring, string sourcename, string? tag = null)
         {
-            List<Rule>? ruleList = JsonSerializer.Deserialize<List<Rule>>(jsonstring,
-                    new JsonSerializerOptions() {AllowTrailingCommas = true});
+            List<Rule>? ruleList = JsonConvert.DeserializeObject<List<Rule>>(jsonstring);
              
             if (ruleList is not null)
             {

--- a/RulesEngine/SearchCondition.cs
+++ b/RulesEngine/SearchCondition.cs
@@ -1,19 +1,19 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
 
     public class SearchCondition
     {
-        [JsonPropertyName("negate_finding")]
+        [JsonProperty(PropertyName ="negate_finding")]
         public bool NegateFinding { get; set; }
 
-        [JsonPropertyName("pattern")]
+        [JsonProperty(PropertyName ="pattern")]
         public SearchPattern? Pattern { get; set; }
 
-        [JsonPropertyName("search_in")]
+        [JsonProperty(PropertyName ="search_in")]
         public string? SearchIn { get; set; }
     }
 }

--- a/RulesEngine/SearchPattern.cs
+++ b/RulesEngine/SearchPattern.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
@@ -15,14 +16,14 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         private Dictionary<RegexOptions, Regex> _compiled = new();
         private string? _pattern;
 
-        [JsonPropertyName("confidence")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonProperty(PropertyName ="confidence")]
+        [JsonConverter(typeof(StringEnumConverter))]
         public Confidence Confidence { get; set; }
 
-        [JsonPropertyName("modifiers")]
+        [JsonProperty(PropertyName ="modifiers")]
         public string[]? Modifiers { get; set; }
 
-        [JsonPropertyName("pattern")]
+        [JsonProperty(PropertyName ="pattern")]
         public string? Pattern
         {
             get
@@ -36,11 +37,11 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             }
         }
 
-        [JsonPropertyName("type")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonProperty(PropertyName ="type")]
+        [JsonConverter(typeof(StringEnumConverter))]
         public PatternType? PatternType { get; set; }
 
-        [JsonPropertyName("scopes")]
+        [JsonProperty(PropertyName ="scopes")]
         public PatternScope[]? Scopes { get; set; }
     }
 }

--- a/RulesEngine/Severity.cs
+++ b/RulesEngine/Severity.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
@@ -10,7 +11,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
     ///     Issue severity
     /// </summary>
     [Flags]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum Severity
     {
         /// <summary>


### PR DESCRIPTION
It looks like recent changes for 1.5.x have the match objects as camelCase, where the references in appinspector.js are for PascalCase. This PR changes the JS references to camelCase -- feel free to change on the other end and ignore this PR.