### PR TITLE
Explicitly include version of newtonsoft with fix in tests.

### DIFF
--- a/AppInspector.Tests.CLI/AppInspector.Tests.CLI.csproj
+++ b/AppInspector.Tests.CLI/AppInspector.Tests.CLI.csproj
@@ -16,6 +16,7 @@
         <PackageReference Update="Nerdbank.GitVersioning">
           <Version>3.5.107</Version>
         </PackageReference>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 
 </Project>

--- a/Pipelines/core-pipeline.yml
+++ b/Pipelines/core-pipeline.yml
@@ -11,7 +11,6 @@ trigger:
     include:
     - AppInspector/*
     - AppInspector.CLI/*
-    - AppInspector.Commands/*
     - AppInspector.Common/*
     - AppInspector.Logging/*
     - RulesEngine/*
@@ -24,11 +23,12 @@ pr:
     - Pipelines
     - AppInspector/*
     - AppInspector.CLI/*
-    - AppInspector.Commands/*
     - AppInspector.Common/*
     - AppInspector.Logging/*
-    - RulesEngine/*
     - AppInspector.Tests/*
+    - AppInspector.Tests.CLI/*
+    - RulesEngine/*
+
 
 stages:
 - stage: Test


### PR DESCRIPTION
Test SDK was implicitly including Newtonsoft 10, newest is 13 which has a fix. This shouldn't trigger an actual release, its just a minor fix to the tests.