### PR TITLE
Add Support for Some DevSkim rule parameters

### DIFF
--- a/AppInspector.Tests/RuleProcessor/WithinClauseTests.cs
+++ b/AppInspector.Tests/RuleProcessor/WithinClauseTests.cs
@@ -23,6 +23,13 @@ namespace AppInspector.Tests.RuleProcessor
         [DataRow("WithinClauseWithoutInvertWithFindingRange")]
         [DataRow("WithinClauseWithInvertWithSameLine")]
         [DataRow("WithinClauseWithoutInvertWithSameLine")]
+        [DataRow("WithinClauseWithInvertWithBeforeOnly")]
+        [DataRow("WithinClauseWithoutInvertWithBeforeOnly")]
+        [DataRow("WithinClauseWithInvertWithAfterOnly")]
+        [DataRow("WithinClauseWithoutInvertWithAfterOnly")]
+        [DataRow("WithinClauseWithInvertWithSameFile")]
+        [DataRow("WithinClauseWithoutInvertWithSameFile")]
+
         [DataTestMethod]
         public void WithinClauseInvertTest(string testDataKey)
         {
@@ -219,6 +226,30 @@ namespace AppInspector.Tests.RuleProcessor
             {
                 "WithinClauseWithoutInvertWithSameLine",
                 (sameLineData, "same-line", false, 1, new[] { 14 })
+            },
+            {
+                "WithinClauseWithInvertWithBeforeOnly",
+                (beforeOnlyData, "only-before", true, 0, new int[] { })
+            },
+            {
+                "WithinClauseWithoutInvertWithBeforeOnly",
+                (beforeOnlyData, "only-before", false, 1, new[] { 3 })
+            },
+            {
+                "WithinClauseWithInvertWithAfterOnly",
+                (afterOnlyData, "only-after", true, 0, new int[] { })
+            },
+            {
+                "WithinClauseWithoutInvertWithAfterOnly",
+                (afterOnlyData, "only-after", false, 1, new[] { 2 })
+            },
+            {
+                "WithinClauseWithInvertWithSameFile",
+                (sameFileData, "same-file", true, 0, new int[] { })
+            },
+            {
+                "WithinClauseWithoutInvertWithSameFile",
+                (sameFileData, "same-file", false, 1, new[] { 2 })
             }
         };
 
@@ -370,6 +401,36 @@ int main(int argc, char **argv)
 }";
 
         const string sameLineData = @"#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+#define BUFSIZER1 512
+#define BUFSIZER2 ((BUFSIZER1 / 2) - 8)
+
+int main(int argc, char **argv)
+{
+    char *buf1R1;
+    char *buf2R1;
+    buf1R1 = (char *)malloc(BUFSIZER1);
+    buf2R1 = (char *)malloc(BUFSIZER1);free(buf2R1);
+    
+    strncpy(buf2R1, argv[1], BUFSIZER1 - 1);
+    free(buf1R1);
+}";
+        const string beforeOnlyData = @"#include <stdio.h>
+    free(buf2R1);
+    buf2R1 = (char *)malloc(BUFSIZER1);
+";
+        const string afterOnlyData = @"#include <stdio.h>
+    buf2R1 = (char *)malloc(BUFSIZER1);
+    free(buf2R1);";
+        
+        const string sameFileData = @"#include <stdio.h>
+    buf1R1 = (char *)malloc(BUFSIZER1);
+    free(buf1R1);";
+        
+        const string findingOnlyData = @"#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>

--- a/RulesEngine/OatExtensions/WithinClause.cs
+++ b/RulesEngine/OatExtensions/WithinClause.cs
@@ -13,6 +13,9 @@ namespace Microsoft.ApplicationInspector.RulesEngine.OatExtensions
 
         public int After { get; set; }
         public int Before { get; set; }
+        public bool OnlyBefore { get; set; }
+        public bool OnlyAfter { get; set; }
+        public bool SameFile { get; set; }
         public bool FindingOnly { get; set; }
         public bool SameLineOnly { get; set; }
         public PatternScope[] Scopes { get; set; } = new PatternScope[1] { PatternScope.All };

--- a/RulesEngine/OatExtensions/WithinOperation.cs
+++ b/RulesEngine/OatExtensions/WithinOperation.cs
@@ -93,6 +93,56 @@ namespace Microsoft.ApplicationInspector.RulesEngine.OatExtensions
                                     toRemove.Add((clauseNum, capture));
                                 }
                             }
+                            else if (wc.SameFile)
+                            {
+                                var start = tc.LineStarts[0];
+                                var end = tc.LineEnds[^1];
+                                var res = ProcessLambda(tc.FullContent[start..end], capture);
+                                if (res.Result)
+                                {
+                                    if (res.Capture is TypedClauseCapture<List<Boundary>> boundaryList)
+                                    {
+                                        passed.AddRange(boundaryList.Result);
+                                    }
+                                }
+                                else
+                                {
+                                    toRemove.Add((clauseNum, capture));
+                                }
+                            }
+                            else if (wc.OnlyBefore)
+                            {
+                                var start = tc.LineStarts[0];
+                                var end = capture.Index;
+                                var res = ProcessLambda(tc.FullContent[start..end], capture);
+                                if (res.Result)
+                                {
+                                    if (res.Capture is TypedClauseCapture<List<Boundary>> boundaryList)
+                                    {
+                                        passed.AddRange(boundaryList.Result);
+                                    }
+                                }
+                                else
+                                {
+                                    toRemove.Add((clauseNum, capture));
+                                }                            }
+                            else if (wc.OnlyAfter)
+                            {
+                                var start = capture.Index + capture.Length;
+                                var end = tc.LineEnds[^1];
+                                var res = ProcessLambda(tc.FullContent[start..end], capture);
+                                if (res.Result)
+                                {
+                                    if (res.Capture is TypedClauseCapture<List<Boundary>> boundaryList)
+                                    {
+                                        passed.AddRange(boundaryList.Result);
+                                    }
+                                }
+                                else
+                                {
+                                    toRemove.Add((clauseNum, capture));
+                                }                            
+                            }
                         }
                         tcc.Result.RemoveAll(x => toRemove.Contains(x));
                     }
@@ -137,9 +187,9 @@ namespace Microsoft.ApplicationInspector.RulesEngine.OatExtensions
         {
             if (clause is WithinClause wc)
             {
-                if (new bool[] {wc.FindingOnly, wc.SameLineOnly, wc.FindingRegion}.Count(x => x) != 1)
+                if (new bool[] {wc.FindingOnly, wc.SameLineOnly, wc.FindingRegion, wc.OnlyAfter, wc.OnlyBefore, wc.SameFile}.Count(x => x) != 1)
                 {
-                    yield return new Violation($"Exactly one of: FindingOnly, SameLineOnly or FindingRegion must be set", rule, clause);
+                    yield return new Violation($"Exactly one of: FindingOnly, SameLineOnly, OnlyAfter, OnlyBefore, SameFile or FindingRegion must be set", rule, clause);
                 }
 
                 if (wc.FindingRegion)

--- a/RulesEngine/Rule.cs
+++ b/RulesEngine/Rule.cs
@@ -35,19 +35,22 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         [JsonIgnore]
         public bool Disabled { get; set; }
 
-        [JsonProperty(PropertyName ="name")]
+        [JsonProperty(PropertyName = "name")] 
         public string Name { get; set; } = "";
 
-        [JsonProperty(PropertyName ="id")]
+        [JsonProperty(PropertyName = "id")] 
         public string Id { get; set; } = "";
 
-        [JsonProperty(PropertyName ="description")]
+        [JsonProperty(PropertyName = "description")]
         public string? Description { get; set; } = "";
 
-        [JsonProperty(PropertyName ="applies_to")]
+        [JsonProperty(PropertyName = "does_not_apply_to")]
+        public List<string>? DoesNotApplyTo { get; set; }
+
+        [JsonProperty(PropertyName = "applies_to")]
         public string[]? AppliesTo { get; set; }
 
-        [JsonProperty(PropertyName ="applies_to_file_regex")]
+        [JsonProperty(PropertyName = "applies_to_file_regex")]
         public string[]? FileRegexes
         {
             get => _fileRegexes;
@@ -70,6 +73,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                     _compiled = FileRegexes?.Select(x => new Regex(x, RegexOptions.Compiled)) ?? Array.Empty<Regex>();
                     _updateCompiledFileRegex = false;
                 }
+
                 return _compiled;
             }
         }
@@ -77,20 +81,20 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         private IEnumerable<Regex> _compiled = Array.Empty<Regex>();
         private bool _updateCompiledFileRegex = false;
 
-        [JsonProperty(PropertyName ="tags")]
+        [JsonProperty(PropertyName = "tags")] 
         public string[]? Tags { get; set; }
 
-        [JsonProperty(PropertyName ="severity")]
+        [JsonProperty(PropertyName = "severity")]
         [JsonConverter(typeof(StringEnumConverter))]
         public Severity Severity { get; set; } = Severity.Moderate;
 
-        [JsonProperty(PropertyName ="overrides")]
+        [JsonProperty(PropertyName = "overrides")]
         public string[]? Overrides { get; set; }
 
-        [JsonProperty(PropertyName ="patterns")]
+        [JsonProperty(PropertyName = "patterns")]
         public SearchPattern[] Patterns { get; set; } = Array.Empty<SearchPattern>();
 
-        [JsonProperty(PropertyName ="conditions")]
+        [JsonProperty(PropertyName = "conditions")]
         public SearchCondition[]? Conditions { get; set; }
     }
 }

--- a/RulesEngine/Ruleset.cs
+++ b/RulesEngine/Ruleset.cs
@@ -308,6 +308,48 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                         expression.Append(clauseNumber);
                         clauseNumber++;
                     }
+                    else if (condition.SearchIn.Equals("same-file", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        clauses.Add(new WithinClause()
+                        {
+                            Data = new List<string>() { condition.Pattern.Pattern },
+                            Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
+                            Invert = condition.NegateFinding,
+                            Arguments = condition.Pattern.Modifiers?.ToList() ?? new List<string>(),
+                            SameFile = true
+                        });
+                        expression.Append(" AND ");
+                        expression.Append(clauseNumber);
+                        clauseNumber++;
+                    }
+                    else if (condition.SearchIn.Equals("only-before", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        clauses.Add(new WithinClause()
+                        {
+                            Data = new List<string>() { condition.Pattern.Pattern },
+                            Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
+                            Invert = condition.NegateFinding,
+                            Arguments = condition.Pattern.Modifiers?.ToList() ?? new List<string>(),
+                            OnlyBefore = true
+                        });
+                        expression.Append(" AND ");
+                        expression.Append(clauseNumber);
+                        clauseNumber++;
+                    }
+                    else if (condition.SearchIn.Equals("only-after", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        clauses.Add(new WithinClause()
+                        {
+                            Data = new List<string>() { condition.Pattern.Pattern },
+                            Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
+                            Invert = condition.NegateFinding,
+                            Arguments = condition.Pattern.Modifiers?.ToList() ?? new List<string>(),
+                            OnlyAfter = true
+                        });
+                        expression.Append(" AND ");
+                        expression.Append(clauseNumber);
+                        clauseNumber++;
+                    }
                     else
                     {
                         _logger.LogWarning("Search condition {Condition} is not one of the accepted values and this condition will be ignored",condition.SearchIn);


### PR DESCRIPTION
Adds Support for the "does_not_apply_to" parameter, to exclude certain languages.
Adds support for OnlyBefore, OnlyAfter and SameFile conditions.

Adds tests for each newly added feature.