### PR TITLE
Add the ability for Rules to have built in test cases

### DIFF
--- a/AppInspector.Tests/Commands/TestExportTagsCmd.cs
+++ b/AppInspector.Tests/Commands/TestExportTagsCmd.cs
@@ -18,7 +18,7 @@ namespace AppInspector.Tests.Commands
         private LogOptions logOptions = new();
         private ILoggerFactory factory = new NullLoggerFactory();
 
-        [ClassInitialize]
+        [TestInitialize]
         public void InitOutput()
         {
             factory = logOptions.GetLoggerFactory();
@@ -28,7 +28,7 @@ namespace AppInspector.Tests.Commands
         }
 
         [ClassCleanup]
-        public void CleanUp()
+        public static void CleanUp()
         {
             Directory.Delete(TestHelpers.GetPath(TestHelpers.AppPath.testOutput), true);
         }

--- a/AppInspector.Tests/Commands/TestTagDiffCmd.cs
+++ b/AppInspector.Tests/Commands/TestTagDiffCmd.cs
@@ -44,7 +44,7 @@ namespace AppInspector.Tests.Commands
         }
 
         [ClassCleanup]
-        public void CleanUp()
+        public static void CleanUp()
         {
             Directory.Delete(TestHelpers.GetPath(TestHelpers.AppPath.testOutput), true);
         }

--- a/AppInspector.sln
+++ b/AppInspector.sln
@@ -21,8 +21,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks", "Benchmarks\Be
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AppInspector.Common", "AppInspector.Common\AppInspector.Common.csproj", "{B15415B6-6EC8-4AA1-B8AF-DF0ABE5F16DB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppInspector.Tests.CLI", "AppInspector.Tests.CLI\AppInspector.Tests.CLI.csproj", "{01D67C5A-6778-4F86-9D61-66EAFCE94763}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppInspector.Logging", "AppInspector.Logging\AppInspector.Logging.csproj", "{F3601CE3-0A97-4608-9A82-3F0E8D79AC5F}"
 EndProject
 Global
@@ -55,10 +53,6 @@ Global
 		{B15415B6-6EC8-4AA1-B8AF-DF0ABE5F16DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B15415B6-6EC8-4AA1-B8AF-DF0ABE5F16DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B15415B6-6EC8-4AA1-B8AF-DF0ABE5F16DB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{01D67C5A-6778-4F86-9D61-66EAFCE94763}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{01D67C5A-6778-4F86-9D61-66EAFCE94763}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{01D67C5A-6778-4F86-9D61-66EAFCE94763}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{01D67C5A-6778-4F86-9D61-66EAFCE94763}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F3601CE3-0A97-4608-9A82-3F0E8D79AC5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F3601CE3-0A97-4608-9A82-3F0E8D79AC5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F3601CE3-0A97-4608-9A82-3F0E8D79AC5F}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
-using System.Runtime.InteropServices.ComTypes;
+using System.Globalization;
 
 namespace Microsoft.ApplicationInspector.Commands
 {
@@ -30,19 +30,19 @@ namespace Microsoft.ApplicationInspector.Commands
         public IEnumerable<string> SourcePath { get; set; } = Array.Empty<string>();
         public string? CustomRulesPath { get; set; }
         public bool IgnoreDefaultRules { get; set; }
-        public IEnumerable<Confidence> ConfidenceFilters { get; set; } = new Confidence[] { Confidence.High, Confidence.Medium };
-        public IEnumerable<Severity> SeverityFilters { get; set; } = new Severity[] { Severity.Critical | Severity.Important | Severity.Moderate | Severity.BestPractice | Severity.ManualReview };
+        public IEnumerable<Confidence> ConfidenceFilters { get; set; } = new[] { Confidence.High, Confidence.Medium };
+        public IEnumerable<Severity> SeverityFilters { get; set; } = new[] { Severity.Critical | Severity.Important | Severity.Moderate | Severity.BestPractice | Severity.ManualReview };
         public IEnumerable<string> FilePathExclusions { get; set; } = Array.Empty<string>();
-        public bool SingleThread { get; set; } = false;
+        public bool SingleThread { get; set; }
         /// <summary>
         /// Treat <see cref="LanguageInfo.LangFileType.Build"/> files as if they were <see cref="LanguageInfo.LangFileType.Code"/> when determining if tags should apply.
         /// </summary>
-        public bool AllowAllTagsInBuildFiles { get; set; } = false;
+        public bool AllowAllTagsInBuildFiles { get; set; }
         /// <summary>
         /// If enabled, will not show the progress bar interface.
         /// </summary>
         public bool NoShowProgress { get; set; } = true;
-        public bool TagsOnly { get; set; } = false;
+        public bool TagsOnly { get; set; }
         /// <summary>
         /// Amount of time in ms to allow to process each file.  Not supported in async operations.
         /// </summary>
@@ -101,7 +101,7 @@ namespace Microsoft.ApplicationInspector.Commands
     }
 
     /// <summary>
-    /// Analyze operation for setup and processing of results from Rulesengine
+    /// Analyze operation for setup and processing of results from Rules Engine
     /// </summary>
     public class AnalyzeCommand
     {
@@ -111,8 +111,9 @@ namespace Microsoft.ApplicationInspector.Commands
         private MetaDataHelper _metaDataHelper; //wrapper containing MetaData object to be assigned to result
         private Languages _languages = new();
         private RuleProcessor _rulesProcessor;
-        private const int _sleepDelay = 100;
         private DateTime DateScanned { get; }
+        
+        private const int ProgressBarUpdateDelay = 100;
 
         private readonly List<Glob> _fileExclusionList = new();
         private readonly Confidence _confidence = Confidence.Unspecified;
@@ -130,13 +131,7 @@ namespace Microsoft.ApplicationInspector.Commands
             _logger = _loggerFactory?.CreateLogger<AnalyzeCommand>() ?? NullLogger<AnalyzeCommand>.Instance;
             _options = opt;
 
-            if (opt.FilePathExclusions.Any(x => !x.Equals("none"))){
-                _fileExclusionList = opt.FilePathExclusions.Select(x => new Glob(x)).ToList();
-            }
-            else
-            {
-                _fileExclusionList = new List<Glob>();
-            }
+            _fileExclusionList = opt.FilePathExclusions.Any(x => !x.Equals("none")) ? opt.FilePathExclusions.Select(x => new Glob(x)).ToList() : new List<Glob>();
 
             //create metadata helper to wrap and help populate metadata from scan
             _metaDataHelper = new MetaDataHelper(string.Join(',', _options.SourcePath));
@@ -170,14 +165,7 @@ namespace Microsoft.ApplicationInspector.Commands
             {
                 if (Directory.Exists(entry))
                 {
-                    try
-                    {
-                        _srcfileList.AddRange(Directory.EnumerateFiles(entry, "*.*", SearchOption.AllDirectories));
-                    }
-                    catch (Exception)
-                    {
-                        throw;
-                    }
+                    _srcfileList.AddRange(Directory.EnumerateFiles(entry, "*.*", SearchOption.AllDirectories));
                 }
                 else if (File.Exists(entry))
                 {
@@ -216,10 +204,7 @@ namespace Microsoft.ApplicationInspector.Commands
 
             if (!string.IsNullOrEmpty(_options.CustomRulesPath))
             {
-                if (rulesSet == null)
-                {
-                    rulesSet = new RuleSet(_loggerFactory);
-                }
+                rulesSet ??= new RuleSet(_loggerFactory);
 
                 if (Directory.Exists(_options.CustomRulesPath))
                 {
@@ -343,7 +328,7 @@ namespace Microsoft.ApplicationInspector.Commands
                             else
                             {
                                 _metaDataHelper.AddLanguage("Unknown");
-                                languageInfo = new LanguageInfo() { Extensions = new string[] { Path.GetExtension(file.FullPath) }, Name = "Unknown" };
+                                languageInfo = new LanguageInfo() { Extensions = new[] { Path.GetExtension(file.FullPath) }, Name = "Unknown" };
                                 if (!_options.ScanUnknownTypes)
                                 {
                                     fileRecord.Status = ScanState.Skipped;
@@ -487,7 +472,7 @@ namespace Microsoft.ApplicationInspector.Commands
                         else
                         {
                             _metaDataHelper.AddLanguage("Unknown");
-                            languageInfo = new LanguageInfo() { Extensions = new string[] { Path.GetExtension(file.FullPath) }, Name = "Unknown" };
+                            languageInfo = new LanguageInfo() { Extensions = new[] { Path.GetExtension(file.FullPath) }, Name = "Unknown" };
                             if (!_options.ScanUnknownTypes)
                             {
                                 fileRecord.Status = ScanState.Skipped;
@@ -602,7 +587,7 @@ namespace Microsoft.ApplicationInspector.Commands
             _logger.LogTrace("AnalyzeCommand::GetFileEntriesAsync");
 
             Extractor extractor = new();
-            foreach (var srcFile in _srcfileList ?? new List<string>())
+            foreach (string srcFile in _srcfileList)
             {
                 if (_fileExclusionList.Any(x => x.IsMatch(srcFile)))
                 {
@@ -672,7 +657,7 @@ namespace Microsoft.ApplicationInspector.Commands
                 AppVersion = Common.Utils.GetVersionString()
             };
 
-            AnalyzeResult.ExitCode exitCode = await PopulateRecordsAsync(cancellationToken.Value);
+            _ = await PopulateRecordsAsync(cancellationToken.Value);
 
             //wrapup result status
             if (!_options.NoFileMetadata && _metaDataHelper.Files.All(x => x.Status == ScanState.Skipped))
@@ -685,9 +670,9 @@ namespace Microsoft.ApplicationInspector.Commands
                 _logger.LogError(MsgHelp.GetString(MsgHelp.ID.ANALYZE_NOPATTERNS));
                 analyzeResult.ResultCode = AnalyzeResult.ExitCode.NoMatches;
             }
-            else if (_metaDataHelper != null && _metaDataHelper.Metadata != null)
+            else if (_metaDataHelper is {Metadata: { }})
             {
-                _metaDataHelper.Metadata.DateScanned = DateScanned.ToString();
+                _metaDataHelper.Metadata.DateScanned = DateScanned.ToString(CultureInfo.InvariantCulture);
                 _metaDataHelper.PrepareReport();
                 analyzeResult.Metadata = _metaDataHelper.Metadata; //replace instance with metadatahelper processed one
                 analyzeResult.ResultCode = AnalyzeResult.ExitCode.Success;
@@ -817,7 +802,7 @@ namespace Microsoft.ApplicationInspector.Commands
                 {
                     while (!doneEnumerating)
                     {
-                        Thread.Sleep(_sleepDelay);
+                        Thread.Sleep(ProgressBarUpdateDelay);
                         pbar.Message = $"Enumerating Files. {fileQueue.Count} Discovered so far.";
                     }
 
@@ -864,7 +849,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     
                     while (!doneProcessing)
                     {
-                        Thread.Sleep(_sleepDelay);
+                        Thread.Sleep(ProgressBarUpdateDelay);
                         var current = _metaDataHelper.Files.Count;
                         var timePerRecord = sw.Elapsed.TotalMilliseconds / current;
                         var millisExpected = (int)(timePerRecord * (fileQueue.Count - current));
@@ -899,12 +884,9 @@ namespace Microsoft.ApplicationInspector.Commands
                 analyzeResult.ResultCode = AnalyzeResult.ExitCode.Success;
             }
 
-            if (_metaDataHelper != null && _metaDataHelper.Metadata != null)
-            {
-                _metaDataHelper.Metadata.DateScanned = DateScanned.ToString();
-                _metaDataHelper.PrepareReport();
-                analyzeResult.Metadata = _metaDataHelper.Metadata; //replace instance with metadatahelper processed one
-            }
+            _metaDataHelper.Metadata.DateScanned = DateScanned.ToString(CultureInfo.InvariantCulture);
+            _metaDataHelper.PrepareReport();
+            analyzeResult.Metadata = _metaDataHelper.Metadata; //replace instance with metadatahelper processed one
 
             if (timedOut)
             {

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -329,6 +329,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     {
                         List<MatchRecord> results = new();
 
+                        // Reusable parsing logic that is used in an anonymous task or called directly depending on timeout preference.
                         void ProcessLambda()
                         {
                             _ = _metaDataHelper.FileExtensions.TryAdd(Path.GetExtension(file.FullPath).Replace('.', ' ').TrimStart(), 0);
@@ -587,7 +588,7 @@ namespace Microsoft.ApplicationInspector.Commands
                     }
 
                     // Be sure to close the stream after we are done processing it.
-                    contents?.Close();
+                    contents?.Dispose();
                 }
             }
         }
@@ -926,7 +927,7 @@ namespace Microsoft.ApplicationInspector.Commands
             cts ??= new CancellationTokenSource();
             if (_options.ProcessingTimeOut > 0)
             {
-                var t = Task.Run(() => PopulateRecords(cts.Token, fileEntries));
+                var t = Task.Run(() => PopulateRecords(cts.Token, fileEntries), cts.Token);
                 if (!t.Wait(new TimeSpan(0, 0, 0, 0, _options.ProcessingTimeOut)))
                 {
                     cts.Cancel();

--- a/RulesEngine/Rule.cs
+++ b/RulesEngine/Rule.cs
@@ -96,5 +96,11 @@ namespace Microsoft.ApplicationInspector.RulesEngine
 
         [JsonProperty(PropertyName = "conditions")]
         public SearchCondition[]? Conditions { get; set; }
+
+        [JsonProperty(PropertyName = "must-match")]
+        public string[]? MustMatch { get; set; }
+        
+        [JsonProperty(PropertyName = "must-not-match")]
+        public string[]? MustNotMatch { get; set; }
     }
 }

--- a/RulesEngine/TextContainer.cs
+++ b/RulesEngine/TextContainer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         /// </summary>
         /// <param name="content"> Text to work with </param>
         /// <param name="language"> The language of the test </param>
-        /// <param name="lineNumber"> The line number to specify. Leave empty for full file as target. </param>
+        /// <param name="languages">An instance of the <see cref="Languages"/> class containing the information for language mapping to use.</param>
         public TextContainer(string content, string language, Languages languages)
         {
             Language = language;


### PR DESCRIPTION
Added two optional test case fields to the Rule object which can contain any number of strings to aid when developing rules.

`must-match` (json) or `MustMatch` (.NET object) - the rule must match each of these samples.
`must-not-match` (json) or `MustNotMatch` (.NET object) - the rule must match not match any of these samples.

The RulesVerifier will check if these fields are populated, and if they are it will validate that the rule matches (or does not match as appropriate) the provided samples and provide error messages indicating the sample(s) which don't match.

If the fields are not populated, no action is taken.

Also adds tests to validate the new behavior and some minor formatting cleanup.

Fix #454.