### PR TITLE
Move RulesVerifier to the RulesEngine namespace

### DIFF
--- a/AppInspector.CLI/Writers/VerifyRulesTextWriter.cs
+++ b/AppInspector.CLI/Writers/VerifyRulesTextWriter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
+using Microsoft.ApplicationInspector.RulesEngine;
+
 namespace Microsoft.ApplicationInspector.CLI
 {
     using Microsoft.ApplicationInspector.Commands;

--- a/AppInspector.RulesEngine/RuleStatus.cs
+++ b/AppInspector.RulesEngine/RuleStatus.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CST.OAT;
+
+namespace Microsoft.ApplicationInspector.RulesEngine;
+
+public class RuleStatus
+{
+    public string? RulesId { get; set; }
+    public string? RulesName { get; set; }
+    public bool Verified => !Errors.Any() && !OatIssues.Any();
+    public IEnumerable<string> Errors { get; set; } = Enumerable.Empty<string>();
+    public IEnumerable<Violation> OatIssues { get; set; } = Enumerable.Empty<Violation>();
+}

--- a/AppInspector.RulesEngine/RulesVerifier.cs
+++ b/AppInspector.RulesEngine/RulesVerifier.cs
@@ -1,21 +1,19 @@
 ﻿// Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.ApplicationInspector.Common;
 using Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
+using Microsoft.CST.OAT;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
-namespace Microsoft.ApplicationInspector.Commands
+namespace Microsoft.ApplicationInspector.RulesEngine
 {
-    using Microsoft.ApplicationInspector.RulesEngine;
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using System.Text.RegularExpressions;
-    using Microsoft.ApplicationInspector.Common;
-    using Microsoft.Extensions.Logging;
-    using Microsoft.Extensions.Logging.Abstractions;
-    using Microsoft.CST.OAT;
-
     public class RulesVerifierResult
     {
         public RulesVerifierResult(List<RuleStatus> ruleStatuses, RuleSet compiledRuleSets)

--- a/AppInspector.RulesEngine/RulesVerifier.cs
+++ b/AppInspector.RulesEngine/RulesVerifier.cs
@@ -14,35 +14,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.ApplicationInspector.RulesEngine
 {
-    public class RulesVerifierResult
-    {
-        public RulesVerifierResult(List<RuleStatus> ruleStatuses, RuleSet compiledRuleSets)
-        {
-            RuleStatuses = ruleStatuses;
-            CompiledRuleSet = compiledRuleSets;
-        }
-        public List<RuleStatus> RuleStatuses { get; }
-        public RuleSet CompiledRuleSet { get; }
-        public  bool Verified => RuleStatuses.All(x => x.Verified);
-    }
-
-    public class RulesVerifierOptions
-    {
-        /// <summary>
-        /// If desired you may provide the analyzer to use. An analyzer with AI defaults will be created to use for validation.
-        /// </summary>
-        public Analyzer? Analyzer { get; set; }
-        /// <summary>
-        /// To receive log messages, provide a LoggerFactory with your preferred configuration.
-        /// </summary>
-        public ILoggerFactory? LoggerFactory { get; set; }
-        /// <summary>
-        /// If true, the verifier will stop on the first issue and will not continue reporting issues.
-        /// </summary>
-        public bool FailFast { get; set; }
-        public Languages LanguageSpecs { get; set; } = new Languages();
-    }
-
     /// <summary>
     /// Common helper used by VerifyRulesCommand and PackRulesCommand classes to reduce duplication
     /// </summary>
@@ -88,12 +59,12 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             return Verify(CompiledRuleset);
         }
 
-        public RulesVerifierResult Verify(RuleSet ruleset)
+        public RulesVerifierResult Verify(AbstractRuleSet ruleset)
         {
             return new RulesVerifierResult(CheckIntegrity(ruleset), ruleset);
         }
 
-        public List<RuleStatus> CheckIntegrity(RuleSet ruleSet)
+        public List<RuleStatus> CheckIntegrity(AbstractRuleSet ruleSet)
         {
             List<RuleStatus> ruleStatuses = new();
             foreach (ConvertedOatRule rule in ruleSet.GetOatRules() ?? Array.Empty<ConvertedOatRule>())
@@ -107,21 +78,18 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                     break;
                 }
             }
-            var duplicatedRules = ruleSet.GroupBy(x => x.Id).Where(y => y.Count() > 1);
-            if (duplicatedRules.Any())
+            var duplicatedRules = ruleSet.GetAppInspectorRules().GroupBy(x => x.Id).Where(y => y.Count() > 1);
+            foreach (var rule in duplicatedRules)
             {
-                foreach (var rule in duplicatedRules)
+                _logger.LogError(MsgHelp.GetString(MsgHelp.ID.VERIFY_RULES_DUPLICATEID_FAIL), rule.Key);
+                var relevantStati = ruleStatuses.Where(x => x.RulesId == rule.Key);
+                foreach(var status in relevantStati)
                 {
-                    _logger.LogError(MsgHelp.GetString(MsgHelp.ID.VERIFY_RULES_DUPLICATEID_FAIL), rule.Key);
-                    var relevantStati = ruleStatuses.Where(x => x.RulesId == rule.Key);
-                    foreach(var status in relevantStati)
-                    {
-                        status.Errors = status.Errors.Append(MsgHelp.FormatString(MsgHelp.ID.VERIFY_RULES_DUPLICATEID_FAIL, rule.Key));
-                    }
-                    if (_failFast)
-                    {
-                        break;
-                    }
+                    status.Errors = status.Errors.Append(MsgHelp.FormatString(MsgHelp.ID.VERIFY_RULES_DUPLICATEID_FAIL, rule.Key));
+                }
+                if (_failFast)
+                {
+                    break;
                 }
             }
 

--- a/AppInspector.RulesEngine/RulesVerifierOptions.cs
+++ b/AppInspector.RulesEngine/RulesVerifierOptions.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.CST.OAT;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.ApplicationInspector.RulesEngine;
+
+public class RulesVerifierOptions
+{
+    /// <summary>
+    /// If desired you may provide the analyzer to use. An analyzer with AI defaults will be created to use for validation.
+    /// </summary>
+    public Analyzer? Analyzer { get; set; }
+    /// <summary>
+    /// To receive log messages, provide a LoggerFactory with your preferred configuration.
+    /// </summary>
+    public ILoggerFactory? LoggerFactory { get; set; }
+    /// <summary>
+    /// If true, the verifier will stop on the first issue and will not continue reporting issues.
+    /// </summary>
+    public bool FailFast { get; set; }
+    public Languages LanguageSpecs { get; set; } = new Languages();
+}

--- a/AppInspector.RulesEngine/RulesVerifierResult.cs
+++ b/AppInspector.RulesEngine/RulesVerifierResult.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.ApplicationInspector.RulesEngine;
+
+public class RulesVerifierResult
+{
+    public RulesVerifierResult(List<RuleStatus> ruleStatuses, AbstractRuleSet compiledRuleSets)
+    {
+        RuleStatuses = ruleStatuses;
+        CompiledRuleSet = compiledRuleSets;
+    }
+    public List<RuleStatus> RuleStatuses { get; }
+    public AbstractRuleSet CompiledRuleSet { get; }
+    public  bool Verified => RuleStatuses.All(x => x.Verified);
+}

--- a/AppInspector.Tests/DefaultRules/TestDefaultRules.cs
+++ b/AppInspector.Tests/DefaultRules/TestDefaultRules.cs
@@ -1,6 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.ApplicationInspector.Commands;
 using Microsoft.ApplicationInspector.Logging;
+using Microsoft.ApplicationInspector.RulesEngine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Serilog.Events;
 
@@ -26,6 +28,21 @@ namespace AppInspector.Tests.DefaultRules
             VerifyRulesResult result = command.GetResult();
 
             Assert.AreEqual(VerifyRulesResult.ExitCode.Verified, result.ResultCode);
+            Assert.AreNotEqual(0, result.RuleStatusList.Count);
+        }
+
+        [TestMethod]
+        public void VerifyNonZeroDefaultRules()
+        {
+            RuleSet set = RuleSetUtils.GetDefaultRuleSet();
+            Assert.IsTrue(set.Any());
+
+            RulesVerifier verifier = new(new RulesVerifierOptions());
+            RulesVerifierResult result = verifier.Verify(set);
+            
+            Assert.IsTrue(result.Verified);
+            Assert.AreNotEqual(0, result.RuleStatuses.Count);
+            Assert.AreNotEqual(0, result.CompiledRuleSet.GetAppInspectorRules().Count());
         }
     }
 }

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -225,7 +225,7 @@ namespace Microsoft.ApplicationInspector.Commands
                         throw new OpException(MsgHelp.FormatString(MsgHelp.ID.VERIFY_RULE_LOADFILE_FAILED, _options.CustomRulesPath));
                     }
 
-                    rulesSet.AddRange(verification.CompiledRuleSet);
+                    rulesSet.AddRange(verification.CompiledRuleSet.GetAppInspectorRules());
                 }
                 else
                 {

--- a/AppInspector/Commands/VerifyRulesCommand.cs
+++ b/AppInspector/Commands/VerifyRulesCommand.cs
@@ -9,13 +9,11 @@ namespace Microsoft.ApplicationInspector.Commands
 {
     using Microsoft.ApplicationInspector.Common;
     using Microsoft.ApplicationInspector.RulesEngine;
-    using Microsoft.CST.OAT;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
     
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
 
     public class VerifyRulesOptions
     {
@@ -24,15 +22,6 @@ namespace Microsoft.ApplicationInspector.Commands
         public bool Failfast { get; set; }
         public string? CustomCommentsPath { get; set; }
         public string? CustomLanguagesPath { get; set; }
-    }
-
-    public class RuleStatus
-    {
-        public string? RulesId { get; set; }
-        public string? RulesName { get; set; }
-        public bool Verified => !Errors.Any() && !OatIssues.Any();
-        public IEnumerable<string> Errors { get; set; } = Enumerable.Empty<string>();
-        public IEnumerable<Violation> OatIssues { get; set; } = Enumerable.Empty<Violation>();
     }
 
     public class VerifyRulesResult : Result

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.5",
+  "version": "1.6-beta",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Also moves RuleStatus used by the Verifier to the RuleEngine namespace.
The RulesVerifierResult object now contains an AbstractRuleSet object to allow verification of rulesets with inherited objects.

SemVer relevant change. This is marked as a Beta in case additional changes need to be made to complete the DevSkim refactor work.