### PR TITLE
Adds a "SuccessCodeOnNoMatches" Option

### DIFF
--- a/AppInspector.CLI/AppInspector.CLI.csproj
+++ b/AppInspector.CLI/AppInspector.CLI.csproj
@@ -67,7 +67,7 @@
   
   <ItemGroup>
     <PackageReference Include="DotLiquid" Version="2.2.656" />
-    <PackageReference Include="Sarif.Sdk" Version="2.4.15" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.16" />
     <PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -37,6 +37,12 @@ namespace Microsoft.ApplicationInspector.CLI
         
         [Option("disable-require-unique-ids", Required = false, HelpText = "Allow rules with duplicate IDs.")]
         public bool DisableRequireUniqueIds { get; set; }
+        /// <summary>
+        /// Return a success error code when no matches were found but operation was apparently successful. Useful for CI scenarios
+        /// </summary>
+        [Option("success-error-code-with-no-matches", Required = false, HelpText = "When processing is apparently successful but there are no matches return a success error code - useful for CI.")]
+        public bool SuccessErrorCodeOnNoMatches { get; set; }
+
     }
 
     public record CLIAnalysisSharedCommandOptions : CLICustomRulesCommandOptions

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -292,7 +292,8 @@ namespace Microsoft.ApplicationInspector.CLI
                 DisableCrawlArchives = cliOptions.DisableArchiveCrawling,
                 EnumeratingTimeout = cliOptions.EnumeratingTimeout,
                 DisableCustomRuleVerification = cliOptions.DisableCustomRuleValidation,
-                DisableRequireUniqueIds = cliOptions.DisableRequireUniqueIds
+                DisableRequireUniqueIds = cliOptions.DisableRequireUniqueIds,
+                SuccessErrorCodeOnNoMatches = cliOptions.SuccessErrorCodeOnNoMatches
             }, adjustedFactory);
 
             AnalyzeResult analyzeResult = command.GetResult();
@@ -359,7 +360,8 @@ namespace Microsoft.ApplicationInspector.CLI
                 ScanUnknownTypes = cliOptions.ScanUnknownTypes,
                 SingleThread = cliOptions.SingleThread,
                 DisableCustomRuleValidation = cliOptions.DisableCustomRuleValidation,
-                DisableRequireUniqueIds = cliOptions.DisableRequireUniqueIds
+                DisableRequireUniqueIds = cliOptions.DisableRequireUniqueIds,
+                SuccessErrorCodeOnNoMatches = cliOptions.SuccessErrorCodeOnNoMatches
             }, loggerFactory);
 
             TagDiffResult tagDiffResult = command.GetResult();

--- a/AppInspector.Tests/Commands/TestAnalyzeCmd.cs
+++ b/AppInspector.Tests/Commands/TestAnalyzeCmd.cs
@@ -613,6 +613,42 @@ windows
             Assert.AreEqual(AnalyzeResult.ExitCode.NoMatches, result.ResultCode);
             Assert.AreEqual(0, result.Metadata.TotalMatchesCount);
         }
+        
+        [TestMethod]
+        public void TestNoMatchesOkay()
+        {
+            AnalyzeOptions options = new()
+            {
+                SourcePath = new string[1] { testFilePath },
+                FilePathExclusions = new[] { "**/TestFile.js" },
+                CustomRulesPath = testRulesPath,
+                IgnoreDefaultRules = true,
+                SuccessErrorCodeOnNoMatches = true
+            };
+
+            AnalyzeCommand command = new(options, factory);
+            AnalyzeResult result = command.GetResult();
+            Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
+            Assert.AreEqual(0, result.Metadata.TotalMatchesCount);
+        }
+        
+        [TestMethod]
+        public async Task TestNoMatchesOkayAsync()
+        {
+            AnalyzeOptions options = new()
+            {
+                SourcePath = new string[1] { testFilePath },
+                FilePathExclusions = new[] { "**/TestFile.js" },
+                CustomRulesPath = testRulesPath,
+                IgnoreDefaultRules = true,
+                SuccessErrorCodeOnNoMatches = true
+            };
+
+            AnalyzeCommand command = new(options, factory);
+            AnalyzeResult result = await command.GetResultAsync();
+            Assert.AreEqual(AnalyzeResult.ExitCode.Success, result.ResultCode);
+            Assert.AreEqual(0, result.Metadata.TotalMatchesCount);
+        }
 
         [TestMethod]
         public async Task ExpectedResultCountsAsync()

--- a/AppInspector/Commands/TagDiffCommand.cs
+++ b/AppInspector/Commands/TagDiffCommand.cs
@@ -30,6 +30,11 @@ namespace Microsoft.ApplicationInspector.Commands
         public string? CustomLanguagesPath { get; set; }
         public bool DisableCustomRuleValidation { get; set; }
         public bool DisableRequireUniqueIds { get; set; }
+        /// <summary>
+        /// Return a success error code when no matches were found but operation was apparently successful. Useful for CI scenarios
+        /// </summary>
+        public bool SuccessErrorCodeOnNoMatches { get; set; }
+
     }
 
     /// <summary>
@@ -156,7 +161,8 @@ namespace Microsoft.ApplicationInspector.Commands
                     CustomCommentsPath = _options.CustomCommentsPath,
                     CustomLanguagesPath = _options.CustomLanguagesPath,
                     DisableCustomRuleVerification = _options.DisableCustomRuleValidation,
-                    DisableRequireUniqueIds = _options.DisableRequireUniqueIds
+                    DisableRequireUniqueIds = _options.DisableRequireUniqueIds,
+                    SuccessErrorCodeOnNoMatches = _options.SuccessErrorCodeOnNoMatches
                 }, _factory);
                 AnalyzeCommand cmd2 = new(new AnalyzeOptions()
                 {
@@ -175,7 +181,8 @@ namespace Microsoft.ApplicationInspector.Commands
                     SingleThread = _options.SingleThread,
                     CustomCommentsPath = _options.CustomCommentsPath,
                     CustomLanguagesPath = _options.CustomLanguagesPath,
-                    DisableCustomRuleVerification = true // Rules are already validated by the first command
+                    DisableCustomRuleVerification = true, // Rules are already validated by the first command
+                    SuccessErrorCodeOnNoMatches = _options.SuccessErrorCodeOnNoMatches
                 }, _factory);
 
                 AnalyzeResult analyze1 = cmd1.GetResult();


### PR DESCRIPTION
Useful for CI scenarios where a lack of detections is not an "error" perse that should stop execution. See https://github.com/microsoft/ApplicationInspector-Action/issues/8

Adds tests for same.