### PR TITLE
Fix #493

### DIFF
--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ApplicationInspector.CLI
         [Option('u', "scan-unknown-filetypes", Required = false, HelpText = "Scan files of unknown types.")]
         public bool ScanUnknownTypes { get; set; }
 
-        [Option('c', "confidence-filters", Required = false, Separator = ',', HelpText = "Output only matches with specified confidence <value>,<value>. Default: Medium,High. [High|Medium|Low]", Default = new Confidence[]{Confidence.High, Confidence.Medium})]
+        [Option('c', "confidence-filters", Required = false, Separator = ',', HelpText = "Output only matches with specified confidence <value>,<value>. Default: Medium,High. [High|Medium|Low]", Default = new Confidence[]{ Confidence.High, Confidence.Medium })]
         public IEnumerable<Confidence> ConfidenceFilters { get; set; } = new Confidence[] { Confidence.High, Confidence.Medium };
 
         [Option("severity-filters", Required = false, Separator = ',',

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -1,6 +1,7 @@
 ﻿//Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
+using CommandLine.Text;
 using Microsoft.ApplicationInspector.Logging;
 
 namespace Microsoft.ApplicationInspector.CLI
@@ -33,21 +34,29 @@ namespace Microsoft.ApplicationInspector.CLI
             Exception? exception = null;
             try
             {
-                var argsResult = new Parser(settings => settings.CaseInsensitiveEnumValues = true).ParseArguments<CLIAnalyzeCmdOptions,
+                var argsResult = new Parser(settings =>
+                {
+                    settings.CaseInsensitiveEnumValues = true;
+                }).ParseArguments<CLIAnalyzeCmdOptions,
                     CLITagDiffCmdOptions,
                     CLIExportTagsCmdOptions,
                     CLIVerifyRulesCmdOptions,
-                    CLIPackRulesCmdOptions>(args)
-                  .MapResult(
+                    CLIPackRulesCmdOptions>(args);
+                if (argsResult.Errors.Any())
+                {
+                    Console.WriteLine(HelpText.AutoBuild(argsResult));
+                    finalResult = (int)Common.Utils.ExitCode.CriticalError;
+                }
+                else
+                {
+                    finalResult = argsResult.MapResult(
                     (CLIAnalyzeCmdOptions cliAnalyzeCmdOptions) => VerifyOutputArgsRun(cliAnalyzeCmdOptions),
                     (CLITagDiffCmdOptions cliTagDiffCmdOptions) => VerifyOutputArgsRun(cliTagDiffCmdOptions),
                     (CLIExportTagsCmdOptions cliExportTagsCmdOptions) => VerifyOutputArgsRun(cliExportTagsCmdOptions),
                     (CLIVerifyRulesCmdOptions cliVerifyRulesCmdOptions) => VerifyOutputArgsRun(cliVerifyRulesCmdOptions),
                     (CLIPackRulesCmdOptions cliPackRulesCmdOptions) => VerifyOutputArgsRun(cliPackRulesCmdOptions),
-                    errs => (int)Common.Utils.ExitCode.CriticalError
-                  );
-
-                finalResult = argsResult;
+                    errs => (int)Common.Utils.ExitCode.CriticalError);
+                }
             }
             catch (Exception e)
             {

--- a/AppInspector.CLI/Program.cs
+++ b/AppInspector.CLI/Program.cs
@@ -42,16 +42,16 @@ namespace Microsoft.ApplicationInspector.CLI
                     CLIVerifyRulesCmdOptions,
                     CLIPackRulesCmdOptions>(args);
                 return argsResult.MapResult(
-                (CLIAnalyzeCmdOptions cliAnalyzeCmdOptions) => VerifyOutputArgsRun(cliAnalyzeCmdOptions),
-                (CLITagDiffCmdOptions cliTagDiffCmdOptions) => VerifyOutputArgsRun(cliTagDiffCmdOptions),
-                (CLIExportTagsCmdOptions cliExportTagsCmdOptions) => VerifyOutputArgsRun(cliExportTagsCmdOptions),
-                (CLIVerifyRulesCmdOptions cliVerifyRulesCmdOptions) => VerifyOutputArgsRun(cliVerifyRulesCmdOptions),
-                (CLIPackRulesCmdOptions cliPackRulesCmdOptions) => VerifyOutputArgsRun(cliPackRulesCmdOptions),
-                errs =>
-                {
-                    Console.WriteLine(HelpText.AutoBuild(argsResult));
-                    return (int)Common.Utils.ExitCode.CriticalError;
-                });
+                    (CLIAnalyzeCmdOptions cliAnalyzeCmdOptions) => VerifyOutputArgsAndRunAnalyze(cliAnalyzeCmdOptions),
+                    (CLITagDiffCmdOptions cliTagDiffCmdOptions) => VerifyOutputArgsAndRunTagDiff(cliTagDiffCmdOptions),
+                    (CLIExportTagsCmdOptions cliExportTagsCmdOptions) => VerifyOutputArgsAndRunExportTags(cliExportTagsCmdOptions),
+                    (CLIVerifyRulesCmdOptions cliVerifyRulesCmdOptions) => VerifyOutputArgsAndRunVerifyRules(cliVerifyRulesCmdOptions),
+                    (CLIPackRulesCmdOptions cliPackRulesCmdOptions) => VerifyOutputArgsAndRunPackRules(cliPackRulesCmdOptions),
+                    errs =>
+                    {
+                        Console.WriteLine(HelpText.AutoBuild(argsResult));
+                        return (int)Common.Utils.ExitCode.CriticalError;
+                    });
             }
             catch (Exception e)
             {
@@ -63,17 +63,15 @@ namespace Microsoft.ApplicationInspector.CLI
             return finalResult;
         }
 
-
-        //idea is to check output args which are not applicable to NuGet callers before the command operation is run for max efficiency
-
-        private static int VerifyOutputArgsRun(CLITagDiffCmdOptions options)
+        private static int VerifyOutputArgsAndRunTagDiff(CLITagDiffCmdOptions options)
         {
             loggerFactory = options.GetLoggerFactory();
 
             CommonOutputChecks(options);
             return RunTagDiffCommand(options);
         }
-        private static int VerifyOutputArgsRun(CLIExportTagsCmdOptions options)
+        
+        private static int VerifyOutputArgsAndRunExportTags(CLIExportTagsCmdOptions options)
         {
             loggerFactory = options.GetLoggerFactory();
 
@@ -81,7 +79,7 @@ namespace Microsoft.ApplicationInspector.CLI
             return RunExportTagsCommand(options);
         }
 
-        private static int VerifyOutputArgsRun(CLIVerifyRulesCmdOptions options)
+        private static int VerifyOutputArgsAndRunVerifyRules(CLIVerifyRulesCmdOptions options)
         {
             loggerFactory = options.GetLoggerFactory();
 
@@ -89,7 +87,7 @@ namespace Microsoft.ApplicationInspector.CLI
             return RunVerifyRulesCommand(options);
         }
 
-        private static int VerifyOutputArgsRun(CLIPackRulesCmdOptions options)
+        private static int VerifyOutputArgsAndRunPackRules(CLIPackRulesCmdOptions options)
         {
             loggerFactory = options.GetLoggerFactory();
             ILogger logger = loggerFactory.CreateLogger("Program");
@@ -107,7 +105,7 @@ namespace Microsoft.ApplicationInspector.CLI
             return RunPackRulesCommand(options);
         }
 
-        private static int VerifyOutputArgsRun(CLIAnalyzeCmdOptions options)
+        private static int VerifyOutputArgsAndRunAnalyze(CLIAnalyzeCmdOptions options)
         {
             loggerFactory = options.GetLoggerFactory();
 


### PR DESCRIPTION
When using a created parser instance instead of the Parser.Default it appears it is requisite to print out the errors manually if desired. This PR adds printing when errors are encountered in parsing arguments.