### PR TITLE
Fix Returning Correct Number of Results From Conditions

### DIFF
--- a/AppInspector.Tests/Commands/TestVerifyRulesCmd.cs
+++ b/AppInspector.Tests/Commands/TestVerifyRulesCmd.cs
@@ -421,22 +421,6 @@ namespace AppInspector.Tests.Commands
         }
         
         [TestMethod]
-        public void MustMatch2()
-        {
-            string path = Path.GetTempFileName();
-            File.WriteAllText(path, _mustMatchRule2);
-            VerifyRulesOptions options = new()
-            {
-                CustomRulesPath = path,
-            };
-
-            VerifyRulesCommand command = new(options, _factory);
-            VerifyRulesResult result = command.GetResult();
-            File.Delete(path);
-            Assert.AreEqual(VerifyRulesResult.ExitCode.Verified, result.ResultCode);
-        }
-        
-        [TestMethod]
         public void MustMatch()
         {
             string path = Path.GetTempFileName();
@@ -450,6 +434,22 @@ namespace AppInspector.Tests.Commands
             VerifyRulesResult result = command.GetResult();
             File.Delete(path);
             Assert.AreEqual(VerifyRulesResult.ExitCode.Verified, result.ResultCode);
+        }
+        
+        [TestMethod]
+        public void MustMatchDetectIncorrect()
+        {
+            string path = Path.GetTempFileName();
+            File.WriteAllText(path, _mustMatchRuleFail);
+            VerifyRulesOptions options = new()
+            {
+                CustomRulesPath = path,
+            };
+
+            VerifyRulesCommand command = new(options, _factory);
+            VerifyRulesResult result = command.GetResult();
+            File.Delete(path);
+            Assert.AreEqual(VerifyRulesResult.ExitCode.NotVerified, result.ResultCode);
         }
         
         [TestMethod]

--- a/AppInspector.Tests/Commands/TestVerifyRulesCmd.cs
+++ b/AppInspector.Tests/Commands/TestVerifyRulesCmd.cs
@@ -180,28 +180,6 @@ namespace AppInspector.Tests.Commands
     ]
 }
 ]";
-        readonly string _mustMatchRule2 = @"[
-{
-    ""name"": ""Platform: Microsoft Windows"",
-    ""id"": ""AI_TEST_WINDOWS"",
-    ""description"": ""This rule checks for the string 'windows'"",
-    ""tags"": [
-      ""Test.Tags.Windows""
-    ],
-    ""severity"": ""Important"",
-    ""patterns"": [
-      {
-        ""confidence"": ""Medium"",
-        ""modifiers"": [
-          ""i""
-        ],
-        ""pattern"": ""http://"",
-        ""type"": ""String"",
-      }
-    ],
-    ""must-match"" : [ ""http://contoso.com""]
-}
-]";
         
         // MustMatch if specified must be matched
         readonly string _mustMatchRule = @"[
@@ -472,22 +450,6 @@ namespace AppInspector.Tests.Commands
             VerifyRulesResult result = command.GetResult();
             File.Delete(path);
             Assert.AreEqual(VerifyRulesResult.ExitCode.Verified, result.ResultCode);
-        }
-        
-        [TestMethod]
-        public void MustMatchDetectIncorrect()
-        {
-            string path = Path.GetTempFileName();
-            File.WriteAllText(path, _mustMatchRuleFail);
-            VerifyRulesOptions options = new()
-            {
-                CustomRulesPath = path,
-            };
-
-            VerifyRulesCommand command = new(options, _factory);
-            VerifyRulesResult result = command.GetResult();
-            File.Delete(path);
-            Assert.AreEqual(VerifyRulesResult.ExitCode.NotVerified, result.ResultCode);
         }
         
         [TestMethod]

--- a/AppInspector.Tests/Commands/TestVerifyRulesCmd.cs
+++ b/AppInspector.Tests/Commands/TestVerifyRulesCmd.cs
@@ -180,6 +180,28 @@ namespace AppInspector.Tests.Commands
     ]
 }
 ]";
+        readonly string _mustMatchRule2 = @"[
+{
+    ""name"": ""Platform: Microsoft Windows"",
+    ""id"": ""AI_TEST_WINDOWS"",
+    ""description"": ""This rule checks for the string 'windows'"",
+    ""tags"": [
+      ""Test.Tags.Windows""
+    ],
+    ""severity"": ""Important"",
+    ""patterns"": [
+      {
+        ""confidence"": ""Medium"",
+        ""modifiers"": [
+          ""i""
+        ],
+        ""pattern"": ""http://"",
+        ""type"": ""String"",
+      }
+    ],
+    ""must-match"" : [ ""http://contoso.com""]
+}
+]";
         
         // MustMatch if specified must be matched
         readonly string _mustMatchRule = @"[
@@ -418,6 +440,22 @@ namespace AppInspector.Tests.Commands
             VerifyRulesResult result = command.GetResult();
             File.Delete(path);
             Assert.AreEqual(VerifyRulesResult.ExitCode.NotVerified, result.ResultCode);
+        }
+        
+        [TestMethod]
+        public void MustMatch2()
+        {
+            string path = Path.GetTempFileName();
+            File.WriteAllText(path, _mustMatchRule2);
+            VerifyRulesOptions options = new()
+            {
+                CustomRulesPath = path,
+            };
+
+            VerifyRulesCommand command = new(options, _factory);
+            VerifyRulesResult result = command.GetResult();
+            File.Delete(path);
+            Assert.AreEqual(VerifyRulesResult.ExitCode.Verified, result.ResultCode);
         }
         
         [TestMethod]


### PR DESCRIPTION
Using multiple conditions was causing return of duplicate results because each condition now reports the matches that passed the condition, and the output would enumerate all of them.  Now deduplicate those matches and ensure results returned have passed all conditions.