### PR TITLE
Workaround for namespace based parsing.

### DIFF
--- a/AppInspector.RulesEngine/TextContainer.cs
+++ b/AppInspector.RulesEngine/TextContainer.cs
@@ -148,8 +148,13 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                 {
                     if (nodeIter.Current is not null)
                     {
-                        var outerLoc = FullContent[minIndex..].IndexOf(nodeIter.Current.OuterXml);
-                        var offset = FullContent[outerLoc..].IndexOf(nodeIter.Current.InnerXml) + outerLoc + minIndex;
+                        // First we find the name
+                        var nameIndex = FullContent[minIndex..].IndexOf(nodeIter.Current.Name);
+                        // Then we grab the index of the end of this tag.
+                        // We can't use OuterXML because the parser will inject the namespace if present into the OuterXML so it doesn't match the original text.
+                        var endTagIndex = FullContent[nameIndex..].IndexOf('>');
+                        var totalOffset = nameIndex + endTagIndex + minIndex;
+                        var offset = FullContent[totalOffset..].IndexOf(nodeIter.Current.InnerXml) + totalOffset;
                         // Move the minimum index up in case there are multiple instances of identical OuterXML
                         // This ensures we won't re-find the same one
                         minIndex = offset;

--- a/AppInspector.Tests/RuleProcessor/WithinClauseTests.cs
+++ b/AppInspector.Tests/RuleProcessor/WithinClauseTests.cs
@@ -223,10 +223,28 @@ http://
         }
         
         [TestMethod]
-        public void Things()
+        public void TestXmlWithAndWithoutNamespace()
         {
             var content = @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <project xmlns=""http://maven.apache.org/POM/4.0.0"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>xxx</groupId>
+  <artifactId>xxx</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description />
+
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+
+</project>";
+            // The same as above but with no namespace specified
+            var noNamespaceContent = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<project>
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>xxx</groupId>
@@ -275,6 +293,8 @@ http://
             if (_languages.FromFileNameOut("pom.xml", out LanguageInfo info))
             {
                 var matches = analyzer.AnalyzeFile(content, new Microsoft.CST.RecursiveExtractor.FileEntry("pom.xml", new MemoryStream()), info);
+                Assert.AreEqual(1, matches.Count);
+                matches = analyzer.AnalyzeFile(noNamespaceContent, new Microsoft.CST.RecursiveExtractor.FileEntry("pom.xml", new MemoryStream()), info);
                 Assert.AreEqual(1, matches.Count);
             }
         }

--- a/AppInspector.Tests/RuleProcessor/WithinClauseTests.cs
+++ b/AppInspector.Tests/RuleProcessor/WithinClauseTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -218,6 +219,63 @@ http://
                 List<MatchRecord> matches = processor.AnalyzeFile(testData,
                     new Microsoft.CST.RecursiveExtractor.FileEntry("test.cs", new MemoryStream()), info);
                 Assert.AreEqual(2, matches.Count);
+            }
+        }
+        
+        [TestMethod]
+        public void Things()
+        {
+            var content = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<project xmlns=""http://maven.apache.org/POM/4.0.0"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>xxx</groupId>
+  <artifactId>xxx</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description />
+
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+
+</project>";
+            var rule = @"[{
+    ""name"": ""Source code: Java 17"",
+    ""id"": ""CODEJAVA000000"",
+    ""description"": ""Java 17 maven configuration"",
+    ""applies_to_file_regex"": [
+      ""pom.xml""
+    ],
+    ""tags"": [
+      ""Code.Java.17""
+    ],
+    ""severity"": ""critical"",
+    ""patterns"": [
+      {
+        ""pattern"": ""17"",
+        ""xpaths"" : [""/*[local-name(.)='project']/*[local-name(.)='properties']/*[local-name(.)='java.version']""],
+        ""type"": ""regex"",
+        ""scopes"": [
+          ""code""
+        ],
+        ""modifiers"": [
+          ""i""
+        ],
+        ""confidence"": ""high""
+      }
+    ]
+  }]";
+            RuleSet rules = new(null);
+            var originalSource = "TestRules";
+            rules.AddString(rule, originalSource);
+            var analyzer = new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(rules, new RuleProcessorOptions(){Parallel = false, AllowAllTagsInBuildFiles = true});
+            if (_languages.FromFileNameOut("pom.xml", out LanguageInfo info))
+            {
+                var matches = analyzer.AnalyzeFile(content, new Microsoft.CST.RecursiveExtractor.FileEntry("pom.xml", new MemoryStream()), info);
+                Assert.AreEqual(1, matches.Count);
             }
         }
 


### PR DESCRIPTION
Fix #497

This makes some changes to the XML parsing so you can use the xpath `local-name` method.

Also adds a test using the below rule and sample xml to ensure matching works the same both with and without namespace when using local-name. 

This rule will match the following sample file now.
```json
[{
    "name": "Source code: Java 17",
    "id": "CODEJAVA000000",
    "description": "Java 17 maven configuration",
    "applies_to_file_regex": [
      "pom.xml"
    ],
    "tags": [
      "Code.Java.17"
    ],
    "severity": "critical",
    "patterns": [
      {
        "pattern": "17",
        "xpaths" : ["/*[local-name(.)='project']/*[local-name(.)='properties']/*[local-name(.)='java.version']"],
        "type": "regex",
        "scopes": [
          "code"
        ],
        "modifiers": [
          "i"
        ],
        "confidence": "high"
      }
    ]
  }]
```
Content reported as not working from #420 which now works:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>

  <groupId>xxx</groupId>
  <artifactId>xxx</artifactId>
  <version>0.1.0-SNAPSHOT</version>
  <packaging>pom</packaging>

  <name>${project.groupId}:${project.artifactId}</name>
  <description />

  <properties>
    <java.version>17</java.version>
  </properties>

</project>
```