### PR TITLE
Fix #511

### DIFF
--- a/AppInspector.RulesEngine/OatExtensions/OatRegexWithIndexOperation.cs
+++ b/AppInspector.RulesEngine/OatExtensions/OatRegexWithIndexOperation.cs
@@ -93,7 +93,7 @@ public class OatRegexWithIndexOperation : OatOperation
                                 foreach (var target in targets)
                                 {
                                     var matches = GetMatches(regex, tc, clause, src.Scopes, target.Item2);
-                                    foreach (var match in matches) outmatches.Add(match);
+                                    outmatches.AddRange(matches);
                                 }
                             }
 

--- a/AppInspector.RulesEngine/OatExtensions/OatSubstringIndexOperation.cs
+++ b/AppInspector.RulesEngine/OatExtensions/OatSubstringIndexOperation.cs
@@ -107,6 +107,7 @@ public class OatSubstringIndexOperation : OatOperation
                                 var matches = GetMatches(target.Item1, stringList[i], comparisonType, tc, src);
                                 foreach (var match in matches)
                                 {
+                                    match.Index += target.Item2.Index;
                                     outmatches.Add((i, match));
                                 }
                             }

--- a/AppInspector.RulesEngine/TextContainer.cs
+++ b/AppInspector.RulesEngine/TextContainer.cs
@@ -306,9 +306,8 @@ public class TextContainer
     /// <summary>
     ///     Check whether the boundary in a text matches the scope of a search pattern (code, comment etc.)
     /// </summary>
-    /// <param name="pattern"> The scopes to check </param>
+    /// <param name="scopes"> The scopes to check </param>
     /// <param name="boundary"> Boundary in the text </param>
-    /// <param name="text"> Text </param>
     /// <returns> True if boundary is in a provided scope </returns>
     public bool ScopeMatch(IEnumerable<PatternScope> scopes, Boundary boundary)
     {
@@ -324,6 +323,7 @@ public class TextContainer
     internal IEnumerable<(string, Boundary)> GetStringFromYmlPath(string Path)
     {
         if (!_triedToConstructYmlDocument)
+        {
             try
             {
                 _triedToConstructYmlDocument = true;
@@ -335,8 +335,9 @@ public class TextContainer
                 _logger.LogError("Failed to parse as a YML document: {0}", e.Message);
                 _ymlDocument = null;
             }
+        }
 
-        if (_ymlDocument is not null)
+        if (_ymlDocument?.Documents.Count > 0)
         {
             var matches = _ymlDocument.Documents[0].RootNode.Query(Path);
             foreach (var match in matches)

--- a/AppInspector.RulesEngine/TextContainer.cs
+++ b/AppInspector.RulesEngine/TextContainer.cs
@@ -339,12 +339,16 @@ public class TextContainer
 
         if (_ymlDocument?.Documents.Count > 0)
         {
-            var matches = _ymlDocument.Documents[0].RootNode.Query(Path);
-            foreach (var match in matches)
+            foreach (var document in _ymlDocument.Documents)
             {
-                yield return (match.ToString(),
-                    new Boundary() { Index = match.Start.Index, Length = match.End.Index - match.Start.Index });
+                var matches = document.RootNode.Query(Path);
+                foreach (var match in matches)
+                {
+                    yield return (match.ToString(),
+                        new Boundary() { Index = match.Start.Index, Length = match.End.Index - match.Start.Index });
+                }
             }
+
         }
     }
 }

--- a/AppInspector.Tests/RuleProcessor/XmlAndJsonTests.cs
+++ b/AppInspector.Tests/RuleProcessor/XmlAndJsonTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Microsoft.ApplicationInspector.RulesEngine;
 using Microsoft.CST.RecursiveExtractor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -300,6 +301,103 @@ public class XmlAndJsonTests
         {
             var matches = analyzer.AnalyzeFile(content, new FileEntry("test.yml", new MemoryStream()), info3);
             Assert.AreEqual(1, matches.Count);
+        }
+    }
+
+    [TestMethod]
+    public void TestYamlWithIndexLocation()
+    {
+        string content =
+            @"test:
+  test1:
+    - something
+    - other
+  test2: true
+  test3:
+    test:
+      other:
+        - other1:
+          property1: 1
+          property2: 2
+      tested: ok
+";
+        string rule =
+            @"[
+    {
+      ""name"": ""Yaml test"",
+        ""id"": ""00000001"",
+        ""applies_to_file_regex"": [
+        ""test.yml""
+            ],
+        ""tags"": [
+        ""MyTest""
+            ],
+        ""severity"": ""moderate"",
+        ""patterns"": [
+        {
+            ""pattern"": ""ok"",
+            ""ymlpaths"": [""/test/test3/test/tested""],
+            ""type"": ""string"",
+            ""scopes"": [
+            ""code""
+                ],
+            ""modifiers"": [
+            ""m""
+                ],
+            ""confidence"": ""high""
+        }
+        ]
+    }
+    ]";
+        string rule2 =
+            @"[
+    {
+      ""name"": ""Yaml test"",
+        ""id"": ""00000001"",
+        ""applies_to_file_regex"": [
+        ""test.yml""
+            ],
+        ""tags"": [
+        ""MyTest""
+            ],
+        ""severity"": ""moderate"",
+        ""patterns"": [
+        {
+            ""pattern"": ""ok"",
+            ""ymlpaths"": [""/test/test3/test/tested""],
+            ""type"": ""regex"",
+            ""scopes"": [
+            ""code""
+                ],
+            ""modifiers"": [
+            ""m""
+                ],
+            ""confidence"": ""high""
+        }
+        ]
+    }
+    ]";
+        RuleSet rules = new();
+        var originalSource = "TestRules";
+        rules.AddString(rule, originalSource);
+        RuleSet rules2 = new();
+        rules.AddString(rule2, originalSource);
+        var analyzer = new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(rules,
+            new RuleProcessorOptions { Parallel = false, AllowAllTagsInBuildFiles = true });
+        var analyzer2 = new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(rules,
+            new RuleProcessorOptions { Parallel = false, AllowAllTagsInBuildFiles = true });
+        if (_languages.FromFileNameOut("test.yml", out var info))
+        {
+            var matches = analyzer.AnalyzeFile(content, new FileEntry("test.yml", new MemoryStream()), info);
+            Assert.AreEqual(1, matches.Count);
+            Assert.AreEqual("ok", matches[0].Sample);
+            Assert.AreEqual(178, matches[0].Boundary.Index);
+            Assert.AreEqual(2, matches[0].Boundary.Length);
+            var matches2 = analyzer2.AnalyzeFile(content, new FileEntry("test.yml", new MemoryStream()), info);
+            Assert.AreEqual(1, matches2.Count);
+            Assert.AreEqual("ok", matches2[0].Sample);
+            Assert.AreEqual(178, matches2[0].Boundary.Index);
+            Assert.AreEqual(2, matches2[0].Boundary.Length);
         }
     }
 


### PR DESCRIPTION
Fixes #511.

AI was not appropriately adjusting the Index of the pattern match by the index of the yaml element like it did for XML and JSON. Adds a new test case to ensure the index matched is correct using sample from the linked bug.