### PR TITLE
Automatically gather Git information

### DIFF
--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -166,10 +166,10 @@ public record CLIAnalyzeCmdOptions : CLIAnalysisSharedCommandOptions
         HelpText = "If set, when outputting sarif, will have paths made relative to the provided path.")]
     public string? BasePath { get; set; } = null;
 
-    [Option("repository-uri", Required = false, HelpText = "If set, when outputting sarif, include this information.")]
+    [Option("repository-uri", Required = false, HelpText = "If set, override any automatically detected RepositoryUri in Sarif report.")]
     public string? RepositoryUri { get; set; } = null;
 
-    [Option("commit-hash", Required = false, HelpText = "If set, when outputting sarif, include this information.")]
+    [Option("commit-hash", Required = false, HelpText = "If set, override any automatically detected CommitHash in Sarif report.")]
     public string? CommitHash { get; set; } = null;
 }
 

--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -56,7 +56,7 @@ public record CLICustomRulesCommandOptions : CLICommandOptions
     public bool RequireMustNotMatch { get; set; }
 
     [Option('R', "non-backtracking-regex", Required = false,
-    HelpText = "Enables non-backtracking regex for all rules. A warning will be displayed for all regular expressions that require backtracking support. Default: Off.",
+    HelpText = "Prefer non-backtracking regex for all rules unless they require the backtracking engine. A warning will be displayed for all regular expressions that require backtracking support. Default: Off.",
     Default = false),]
     public bool EnableNonBacktrackingRegex { get; set; }
 }

--- a/AppInspector.CLI/Writers/AnalyzeSarifWriter.cs
+++ b/AppInspector.CLI/Writers/AnalyzeSarifWriter.cs
@@ -74,6 +74,18 @@ public class AnalyzeSarifWriter : CommandResultsWriter
                         }
                     };
                 }
+                else if (analyzeResult.Metadata.RepositoryUri is { })
+                {
+                    run.VersionControlProvenance = new List<VersionControlDetails>
+                    {
+                        new()
+                        {
+                            RepositoryUri = analyzeResult.Metadata.RepositoryUri,
+                            RevisionId = analyzeResult.Metadata.CommitHash ?? string.Empty,
+                            Branch = analyzeResult.Metadata.Branch ?? string.Empty
+                        }
+                    };
+                }
 
                 var artifacts = new List<Artifact>();
                 run.Tool = new Tool

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -394,9 +394,7 @@ public class AnalyzeCommand
             RemoveDependsOnNotPresent();
         }
 
-        GitInformation? information = GenerateGitInformation(Path.GetFullPath(_options.SourcePath.FirstOrDefault()));
-
-        _metaDataHelper.AddGitInformation(information);
+        _metaDataHelper.AddGitInformation(GenerateGitInformation(Path.GetFullPath(_options.SourcePath.FirstOrDefault())));
 
         return AnalyzeResult.ExitCode.Success;
 
@@ -633,6 +631,8 @@ public class AnalyzeCommand
         {
             RemoveDependsOnNotPresent();
         }
+
+        _metaDataHelper.AddGitInformation(GenerateGitInformation(Path.GetFullPath(_options.SourcePath.FirstOrDefault())));
 
         return AnalyzeResult.ExitCode.Success;
 

--- a/AppInspector/GitInformation.cs
+++ b/AppInspector/GitInformation.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.ApplicationInspector.Commands
+{
+    using System;
+    
+    public record GitInformation
+    {
+        public Uri? RepositoryUri { get; set; }
+        public string? CommitHash { get; set; }
+        public string? Branch { get; set; }
+    }
+}

--- a/AppInspector/MetaData.cs
+++ b/AppInspector/MetaData.cs
@@ -28,6 +28,24 @@ public class MetaData
     public string? ApplicationName { get; set; }
 
     /// <summary>
+    ///     Detected repository uri
+    /// </summary>
+    [JsonPropertyName("repositoryUri")]
+    public Uri? RepositoryUri { get; set; }
+
+    /// <summary>
+    ///     Detected CommitHash
+    /// </summary>
+    [JsonPropertyName("commitHash")]
+    public string? CommitHash { get; set; }
+
+    /// <summary>
+    ///     Detected Branch Name
+    /// </summary>
+    [JsonPropertyName("branch")]
+    public string? Branch { get; set; }
+
+    /// <summary>
     ///     Source path provided argument
     /// </summary>
     [JsonPropertyName("sourcePath")]

--- a/AppInspector/MetaDataHelper.cs
+++ b/AppInspector/MetaDataHelper.cs
@@ -344,4 +344,11 @@ public class MetaDataHelper
             Languages = Languages
         };
     }
+
+    internal void AddGitInformation(GitInformation? information)
+    {
+        Metadata.RepositoryUri = information?.RepositoryUri;
+        Metadata.CommitHash = information?.CommitHash;
+        Metadata.Branch = information?.Branch;
+    }
 }


### PR DESCRIPTION
Fix #427 

Adds LibGit2Sharp to attempt to automatically gather Git repository and commit information from the first source path argument.