### PR TITLE
Add Support for Xpath Queries with Namespaces

### DIFF
--- a/AppInspector.RulesEngine/AbstractRuleSet.cs
+++ b/AppInspector.RulesEngine/AbstractRuleSet.cs
@@ -260,7 +260,7 @@ public abstract class AbstractRuleSet
             if (pattern.PatternType is PatternType.String or PatternType.Substring)
             {
                 return new OatSubstringIndexClause(scopes, useWordBoundaries: pattern.PatternType == PatternType.String,
-                    xPaths: pattern.XPaths, jsonPaths: pattern.JsonPaths, yamlPaths: pattern.YamlPaths)
+                    xPaths: pattern.XPaths, jsonPaths: pattern.JsonPaths, yamlPaths: pattern.YamlPaths, xPathNameSpaces: pattern.XPathNamespaces)
                 {
                     Label = clauseNumber.ToString(CultureInfo
                         .InvariantCulture), //important to pattern index identification
@@ -272,7 +272,7 @@ public abstract class AbstractRuleSet
 
             if (pattern.PatternType == PatternType.Regex)
             {
-                return new OatRegexWithIndexClause(scopes, null, pattern.XPaths, pattern.JsonPaths, pattern.YamlPaths)
+                return new OatRegexWithIndexClause(scopes, null, pattern.XPaths, pattern.JsonPaths, pattern.YamlPaths, pattern.XPathNamespaces)
                 {
                     Label = clauseNumber.ToString(CultureInfo
                         .InvariantCulture), //important to pattern index identification
@@ -284,7 +284,7 @@ public abstract class AbstractRuleSet
 
             if (pattern.PatternType == PatternType.RegexWord)
             {
-                return new OatRegexWithIndexClause(scopes, null, pattern.XPaths, pattern.JsonPaths)
+                return new OatRegexWithIndexClause(scopes, null, pattern.XPaths, pattern.JsonPaths, pattern.YamlPaths, pattern.XPathNamespaces)
                 {
                     Label = clauseNumber.ToString(CultureInfo
                         .InvariantCulture), //important to pattern index identification

--- a/AppInspector.RulesEngine/AbstractRuleSet.cs
+++ b/AppInspector.RulesEngine/AbstractRuleSet.cs
@@ -51,7 +51,7 @@ public abstract class AbstractRuleSet
     {
         if (!string.IsNullOrEmpty(input))
         {
-            return _oatRules.Where(x => x.AppInspectorRule.CompiledFileRegexes.Any(y => y.IsMatch(input)));
+            return _oatRules.Where(x => x.AppInspectorRule.CompiledFileRegexes.Any(y => y.IsMatch(input) && !x.AppInspectorRule.CompiledExcludeFileRegexes.Any(z => z.IsMatch(input))));
         }
 
         return Array.Empty<ConvertedOatRule>();

--- a/AppInspector.RulesEngine/OatExtensions/OatRegexWithIndexClause.cs
+++ b/AppInspector.RulesEngine/OatExtensions/OatRegexWithIndexClause.cs
@@ -8,18 +8,21 @@ namespace Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
 public class OatRegexWithIndexClause : Clause
 {
     public OatRegexWithIndexClause(PatternScope[] scopes, string? field = null, string[]? xPaths = null,
-        string[]? jsonPaths = null, string[]? ymlPaths = null) : base(Operation.Custom, field)
+        string[]? jsonPaths = null, string[]? ymlPaths = null, Dictionary<string, string>? xPathNameSpaces = null) : base(Operation.Custom, field)
     {
         Scopes = scopes;
         CustomOperation = "RegexWithIndex";
         XPaths = xPaths;
         JsonPaths = jsonPaths;
         YmlPaths = ymlPaths;
+        XPathNameSpaces = xPathNameSpaces ?? new();
     }
 
     public string[]? JsonPaths { get; }
 
     public string[]? XPaths { get; }
+
+    public Dictionary<string, string> XPathNameSpaces { get; }
 
     public PatternScope[] Scopes { get; }
     public string[]? YmlPaths { get; }

--- a/AppInspector.RulesEngine/OatExtensions/OatRegexWithIndexOperation.cs
+++ b/AppInspector.RulesEngine/OatExtensions/OatRegexWithIndexOperation.cs
@@ -99,7 +99,7 @@ public class OatRegexWithIndexOperation : OatOperation
                         {
                             foreach (var xmlPath in src.XPaths)
                             {
-                                var targets = tc.GetStringFromXPath(xmlPath);
+                                var targets = tc.GetStringFromXPath(xmlPath, src.XPathNameSpaces);
                                 foreach (var target in targets)
                                 {
                                     var matches = GetMatches(regex, tc, clause, src.Scopes, target.Item2);

--- a/AppInspector.RulesEngine/OatExtensions/OatSubstringIndexClause.cs
+++ b/AppInspector.RulesEngine/OatExtensions/OatSubstringIndexClause.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Microsoft.CST.OAT;
 
 namespace Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
@@ -7,7 +8,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
 public class OatSubstringIndexClause : Clause
 {
     public OatSubstringIndexClause(PatternScope[] scopes, string? field = null, bool useWordBoundaries = false,
-        string[]? xPaths = null, string[]? jsonPaths = null, string[]? yamlPaths = null) : base(Operation.Custom, field)
+        string[]? xPaths = null, string[]? jsonPaths = null, string[]? yamlPaths = null, Dictionary<string, string>? xPathNameSpaces = null) : base(Operation.Custom, field)
     {
         Scopes = scopes;
         CustomOperation = "SubstringIndex";
@@ -15,7 +16,10 @@ public class OatSubstringIndexClause : Clause
         XPaths = xPaths;
         JsonPaths = jsonPaths;
         YmlPaths = yamlPaths;
+        XPathNameSpaces = xPathNameSpaces ?? new();
     }
+
+    public Dictionary<string, string> XPathNameSpaces { get; }
 
     public string[]? YmlPaths { get; }
 

--- a/AppInspector.RulesEngine/OatExtensions/OatSubstringIndexOperation.cs
+++ b/AppInspector.RulesEngine/OatExtensions/OatSubstringIndexOperation.cs
@@ -79,7 +79,7 @@ public class OatSubstringIndexOperation : OatOperation
                     {
                         foreach (var xmlPath in src.XPaths)
                         {
-                            var targets = tc.GetStringFromXPath(xmlPath);
+                            var targets = tc.GetStringFromXPath(xmlPath, src.XPathNameSpaces);
                             foreach (var target in targets)
                             {
                                 var matches = GetMatches(target.Item1, stringList[i], comparisonType, tc, src);

--- a/AppInspector.RulesEngine/Resources/comments.json
+++ b/AppInspector.RulesEngine/Resources/comments.json
@@ -59,5 +59,12 @@
     "inline": "#",
     "prefix": "=begin",
     "suffix": "=end"
+  },
+  {
+    "language": [
+      "XML"
+    ],
+    "prefix": "<!--",
+    "suffix": "-->"
   }
 ]

--- a/AppInspector.RulesEngine/Resources/languages.json
+++ b/AppInspector.RulesEngine/Resources/languages.json
@@ -383,5 +383,12 @@
       ".xml"
     ],
     "type": "build"
+  },
+  {
+    "name": "Rule Verifier Default Value",
+    "extensions": [
+      ".ruleverifiertestcase"
+    ],
+    "type": "code"
   }
 ]

--- a/AppInspector.RulesEngine/Rule.cs
+++ b/AppInspector.RulesEngine/Rule.cs
@@ -18,6 +18,8 @@ namespace Microsoft.ApplicationInspector.RulesEngine
 
         private IList<string>? _fileRegexes;
         private bool _updateCompiledFileRegex;
+        private IList<string>? _excludeFileRegexes;
+        private bool _updateCompiledExcludeFileRegex;
 
         /// <summary>
         ///     Name of the source where the rule definition came from.
@@ -87,7 +89,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                 _updateCompiledFileRegex = true;
             }
         }
-
+        
         /// <summary>
         ///     Internal API to cache construction of <see cref="FileRegexes"/>
         /// </summary>
@@ -105,6 +107,39 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                 return _compiled;
             }
         }
+        
+        /// <summary>
+        ///     Regular expressions for file names that the Rule applies to
+        /// </summary>
+        [JsonPropertyName("exclude_file_regex")]
+        public IList<string>? DoesNotApplyFileRegex
+        {
+            get => _excludeFileRegexes;
+            set
+            {
+                _excludeFileRegexes = value;
+                _updateCompiledExcludeFileRegex = true;
+            }
+        }
+
+        /// <summary>
+        ///     Internal API to cache construction of <see cref="FileRegexes"/>
+        /// </summary>
+        [JsonIgnore]
+        internal IEnumerable<Regex> CompiledExcludeFileRegexes
+        {
+            get
+            {
+                if (_updateCompiledExcludeFileRegex)
+                {
+                    _compiled = (IList<Regex>?)DoesNotApplyFileRegex?.Select(x => new Regex(x, RegexOptions.Compiled)).ToList() ?? Array.Empty<Regex>();
+                    _updateCompiledFileRegex = false;
+                }
+
+                return _compiled;
+            }
+        }
+
 
         /// <summary>
         ///     The Tags the rule provides

--- a/AppInspector.RulesEngine/Rule.cs
+++ b/AppInspector.RulesEngine/Rule.cs
@@ -20,6 +20,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         private bool _updateCompiledFileRegex;
         private IList<string>? _excludeFileRegexes;
         private bool _updateCompiledExcludeFileRegex;
+        private IList<Regex> _compiledExclusions = Array.Empty<Regex>();
 
         /// <summary>
         ///     Name of the source where the rule definition came from.
@@ -132,11 +133,11 @@ namespace Microsoft.ApplicationInspector.RulesEngine
             {
                 if (_updateCompiledExcludeFileRegex)
                 {
-                    _compiled = (IList<Regex>?)DoesNotApplyFileRegex?.Select(x => new Regex(x, RegexOptions.Compiled)).ToList() ?? Array.Empty<Regex>();
+                    _compiledExclusions = (IList<Regex>?)DoesNotApplyFileRegex?.Select(x => new Regex(x, RegexOptions.Compiled)).ToList() ?? Array.Empty<Regex>();
                     _updateCompiledFileRegex = false;
                 }
 
-                return _compiled;
+                return _compiledExclusions;
             }
         }
 

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -285,11 +285,11 @@ public class RuleProcessor
         IEnumerable<string>? tagsToIgnore)
     {
         return GetRulesByLanguage(languageInfo.Name)
-            .Union(GetRulesByFileName(fileEntry.FullPath))
-            .Union(GetUniversalRules()
-                .Where(x => !x.AppInspectorRule.DoesNotApplyTo?.Contains(languageInfo.Name) ?? true))
-            .Where(x => !x.AppInspectorRule.Tags?.Any(y => tagsToIgnore?.Contains(y) ?? false) ?? true)
-            .Where(x => !x.AppInspectorRule.Disabled && SeverityLevel.HasFlag(x.AppInspectorRule.Severity));
+            .Concat(GetRulesByFileName(fileEntry.FullPath))
+            .Concat(GetUniversalRules())
+                .Where(x => !x.AppInspectorRule.DoesNotApplyTo?.Contains(languageInfo.Name) ?? true)
+                .Where(x => !x.AppInspectorRule.Tags?.Any(y => tagsToIgnore?.Contains(y) ?? false) ?? true)
+                .Where(x => !x.AppInspectorRule.Disabled && SeverityLevel.HasFlag(x.AppInspectorRule.Severity));
     }
 
     /// <summary>

--- a/AppInspector.RulesEngine/RulesVerifier.cs
+++ b/AppInspector.RulesEngine/RulesVerifier.cs
@@ -312,10 +312,11 @@ public class RulesVerifier
         // We need to provide a language for the TextContainer, which will later be referenced by the Rule when executed.
         // We can grab any Language that the rule applies to, if there are none, it means it applies to all languages, except any in DoesNotApplyTo.
         // Then we fall back to grab any language from the languages configuration that isn't DoesNotApplyTo for this rule.
+        // Finally we fall back to a default value that has no comment styling
         var language = convertedOatRule.AppInspectorRule.AppliesTo?.FirstOrDefault() ??
                        _options.LanguageSpecs.GetNames().FirstOrDefault(x =>
                            !convertedOatRule.AppInspectorRule.DoesNotApplyTo?.Contains(x,
-                               StringComparer.InvariantCultureIgnoreCase) ?? true) ?? "csharp";
+                               StringComparer.InvariantCultureIgnoreCase) ?? true) ?? "Rule Verifier Default Value";
 
         // validate all must match samples are matched
         foreach (var mustMatchElement in (IList<string>?)rule.MustMatch ?? Array.Empty<string>())

--- a/AppInspector.RulesEngine/SearchPattern.cs
+++ b/AppInspector.RulesEngine/SearchPattern.cs
@@ -38,6 +38,8 @@ public class SearchPattern
     ///     Set of mappings between namespace name as used in the xml document as the key
     ///     and the uri for the schema as the value
     /// </summary>
+    ///
+    [JsonPropertyName("xpathnamespaces")]
     public Dictionary<string, string> XPathNamespaces { get; set; } = new();
 
     /// <summary>

--- a/AppInspector.RulesEngine/SearchPattern.cs
+++ b/AppInspector.RulesEngine/SearchPattern.cs
@@ -35,6 +35,12 @@ public class SearchPattern
     public string[]? XPaths { get; set; }
 
     /// <summary>
+    ///     Set of mappings between namespace name as used in the xml document as the key
+    ///     and the uri for the schema as the value
+    /// </summary>
+    public Dictionary<string, string> XPathNamespaces { get; set; } = new();
+
+    /// <summary>
     ///     If set, attempt to parse the file as JSON and if that is possible,
     ///     before running the pattern, select down to the JsonPath provided
     /// </summary>

--- a/AppInspector.RulesEngine/TextContainer.cs
+++ b/AppInspector.RulesEngine/TextContainer.cs
@@ -225,7 +225,11 @@ public class TextContainer
             // Then we grab the index of the end of this tag.
             // We can't use OuterXML because the parser will inject the namespace if present into the OuterXML so it doesn't match the original text.
             var endTagIndex = FullContent[nameIndex..].IndexOf('>');
-            var offset = FullContent[nameIndex..].IndexOf(nodeIter.Current.InnerXml, StringComparison.Ordinal) + nameIndex;
+            // We also look for self-closing tag
+            var selfClosedTag = FullContent[endTagIndex-1] == '/';
+            // If the tag is self closing innerxml will be empty string, so the finding is located at the end of the tag and is empty string
+            // Otherwise the finding is the content of the xml tag
+            var offset = selfClosedTag ? endTagIndex : FullContent[nameIndex..].IndexOf(nodeIter.Current.InnerXml, StringComparison.Ordinal) + nameIndex;
             // Move the minimum index up in case there are multiple instances of identical OuterXML
             // This ensures we won't re-find the same one
             var totalOffset = minIndex + nameIndex + endTagIndex;

--- a/AppInspector.Tests/Commands/TestAnalyzeCmd.cs
+++ b/AppInspector.Tests/Commands/TestAnalyzeCmd.cs
@@ -408,6 +408,7 @@ buy@tacos.com
     ],
     ""severity"": ""Important"",
     ""applies_to_file_regex"": [""afile.js""],
+    ""exclude_file_regex"": [""afile.js.cs""],
     ""patterns"": [
       {
                 ""confidence"": ""Medium"",
@@ -931,6 +932,7 @@ windows
     }
 
     [DataRow("afile.js", AnalyzeResult.ExitCode.Success, 4, 1)]
+    [DataRow("afile.js.cs", AnalyzeResult.ExitCode.NoMatches, 0, 0)]
     [DataRow("adifferentfile.js", AnalyzeResult.ExitCode.Success, 1, 1)]
     [DataTestMethod]
     public void AppliesToFileName(string testFileName, AnalyzeResult.ExitCode expectedExitCode,

--- a/AppInspector.Tests/RuleProcessor/XmlAndJsonTests.cs
+++ b/AppInspector.Tests/RuleProcessor/XmlAndJsonTests.cs
@@ -153,6 +153,65 @@ public class XmlAndJsonTests
   </bookstore>
 ";
 
+    private const string NamespacedXmlData = @"
+[
+    {
+        ""name"": ""Android debug is enabled."",
+        ""id"": ""DS180000"",
+        ""description"": ""The android:debuggable element is set to true, which should be disabled for release builds."",
+        ""recommendation"": ""Set android:debuggable to false for release builds."",
+        ""applies_to_file_regex"": [
+            ""AndroidManifest.xml""
+        ],
+        ""applies_to"":[
+            ""XML""
+        ],
+        ""tags"": [
+            ""Framework.Android""
+        ],
+        ""severity"": ""BestPractice"",
+        ""rule_info"": ""DS180000.md"",
+        ""patterns"": [
+            {
+                ""xpaths"": [""//default:application/@android:debuggable""],
+                ""pattern"": ""true"",
+                ""type"": ""regex"",
+                ""scopes"": [
+                    ""code""
+                ],
+                ""modifiers"" : [""i""],
+                ""xpathnamespaces"": {
+                    ""default"": ""http://maven.apache.org/POM/4.0.0"",
+                    ""android"": ""http://schemas.android.com/apk/res/android""
+                }
+            }
+        ],
+        ""must-match"": [
+            ""<?xml version=\""1.0\"" encoding=\""utf-8\""?><manifest xmlns=\""http://maven.apache.org/POM/4.0.0\"" xmlns:android=\""http://schemas.android.com/apk/res/android\""><application android:debuggable='true' /></manifest>""
+        ],
+        ""must-not-match"": [
+            ""<?xml version=\""1.0\"" encoding=\""utf-8\""?><manifest xmlns=\""http://maven.apache.org/POM/4.0.0\"" xmlns:android=\""http://schemas.android.com/apk/res/android\""><application android:debuggable='false' /></manifest>""
+        ]
+    }
+]";
+
+    [TestMethod]
+    public void XmlWithNamespaces()
+    {
+        RuleSet rules = new();
+        rules.AddString(NamespacedXmlData, "JsonTestRules");
+        RulesVerifier verifier = new RulesVerifier(new RulesVerifierOptions());
+        //var verification= verifier.Verify(rules);
+        //Assert.AreEqual(true,verification.Verified);
+        Microsoft.ApplicationInspector.RulesEngine.RuleProcessor processor = new(rules,
+            new RuleProcessorOptions { AllowAllTagsInBuildFiles = true });
+        if (_languages.FromFileNameOut("AndroidManifest.xml", out var info))
+        {
+            var matches = processor.AnalyzeFile(@"<?xml version=""1.0"" encoding=""utf-8""?><manifest xmlns=""http://maven.apache.org/POM/4.0.0"" xmlns:android=""http://schemas.android.com/apk/res/android""><application android:debuggable='true' /></manifest>", new FileEntry("AndroidManifest.xml", new MemoryStream()), info);
+            Assert.AreEqual(1, matches.Count);
+        }
+    }
+
     [TestMethod]
     public void XmlAttributeTest()
     {

--- a/AppInspector.Tests/RuleProcessor/XmlAndJsonTests.cs
+++ b/AppInspector.Tests/RuleProcessor/XmlAndJsonTests.cs
@@ -163,9 +163,6 @@ public class XmlAndJsonTests
         ""applies_to_file_regex"": [
             ""AndroidManifest.xml""
         ],
-        ""applies_to"":[
-            ""XML""
-        ],
         ""tags"": [
             ""Framework.Android""
         ],


### PR DESCRIPTION
Fixes an issue calculating the correct set of rules for a filename in some cases.
Fixes XPATH parsing with self closing tags
Adds comment style support for xml language.
Adds test for XML query with namespace.
Adds support for excluding files from a rule based on regular expressions.
