### PR TITLE
Adds Always Commented Option to Support DevSkim Scenarios

### DIFF
--- a/AppInspector.RulesEngine/Comment.cs
+++ b/AppInspector.RulesEngine/Comment.cs
@@ -21,4 +21,10 @@ internal class Comment
 
     [JsonPropertyName("suffix")]
     public string? Suffix { get; set; }
+
+    /// <summary>
+    /// Set to true when these languages should always be considered comments (i.e. Plaintext files)
+    /// </summary>
+    [JsonPropertyName("always")] 
+    public bool AlwaysCommented { get; set; }
 }

--- a/AppInspector.RulesEngine/LanguageInfo.cs
+++ b/AppInspector.RulesEngine/LanguageInfo.cs
@@ -13,7 +13,8 @@ public class LanguageInfo
     public enum LangFileType
     {
         Code,
-        Build
+        Build,
+        Docs
     }
 
     [JsonPropertyName("name")]

--- a/AppInspector.RulesEngine/Languages.cs
+++ b/AppInspector.RulesEngine/Languages.cs
@@ -221,4 +221,26 @@ public sealed class Languages
 
         return names.ToArray();
     }
+
+    /// <summary>
+    /// Check if the given language is marked to always be commented
+    /// </summary>
+    /// <param name="language"></param>
+    /// <returns></returns>
+    public bool IsAlwaysCommented(string language)
+    {
+        if (language != null)
+        {
+            foreach (var comment in _comments)
+            {
+                if (Array.Exists(comment.Languages ?? new[] { "" },
+                        x => x.Equals(language, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    return comment.AlwaysCommented;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/AppInspector.RulesEngine/Resources/comments.json
+++ b/AppInspector.RulesEngine/Resources/comments.json
@@ -66,5 +66,11 @@
     ],
     "prefix": "<!--",
     "suffix": "-->"
+  },
+  {
+    "language": [
+      "plaintext"
+    ],
+    "always": true
   }
 ]

--- a/AppInspector.RulesEngine/Resources/languages.json
+++ b/AppInspector.RulesEngine/Resources/languages.json
@@ -385,6 +385,13 @@
     "type": "build"
   },
   {
+    "name": "plaintext",
+    "extensions": [
+      ".txt"
+    ],
+    "type": "docs"
+  },
+  {
     "name": "Rule Verifier Default Value",
     "extensions": [
       ".ruleverifiertestcase"

--- a/AppInspector.RulesEngine/TextContainer.cs
+++ b/AppInspector.RulesEngine/TextContainer.cs
@@ -444,6 +444,11 @@ public class TextContainer
             return true;
         }
 
+        if (Languages.IsAlwaysCommented(Language))
+        {
+            return scopes.Contains(PatternScope.Comment);
+        }
+        
         if (scopes.Contains(PatternScope.All) || string.IsNullOrEmpty(prefix))
         {
             return true;

--- a/AppInspector.Tests/Languages/LanguagesTests.cs
+++ b/AppInspector.Tests/Languages/LanguagesTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
 using Microsoft.ApplicationInspector.Logging;
+using Microsoft.ApplicationInspector.RulesEngine;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -115,5 +117,17 @@ public class LanguagesTests
             Microsoft.ApplicationInspector.RulesEngine.Languages.FromConfigurationFiles(_factory, testCommentsPath,
                 testLanguagesPath);
         Assert.AreEqual(expected, languages.FromFileNameOut(filename!, out _));
+    }
+    
+        
+    [TestMethod]
+    public void ScopeMatchAlwaysCommented()
+    {
+        var _languages = new Microsoft.ApplicationInspector.RulesEngine.Languages();
+        var textContainer = new TextContainer("Hello this is some content", "plaintext", _languages);
+        var boundary = new Boundary() { Index = 1, Length = 2 };
+        Assert.IsTrue(textContainer.ScopeMatch(new List<PatternScope>() { PatternScope.All }, boundary));
+        Assert.IsFalse(textContainer.ScopeMatch(new List<PatternScope>() { PatternScope.Code }, boundary));
+        Assert.IsTrue(textContainer.ScopeMatch(new List<PatternScope>() { PatternScope.Comment }, boundary));
     }
 }

--- a/AppInspector.Tests/RuleProcessor/QuotedStringsTests.cs
+++ b/AppInspector.Tests/RuleProcessor/QuotedStringsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.ApplicationInspector.Logging;
 using Microsoft.ApplicationInspector.RulesEngine;


### PR DESCRIPTION
Some languages may never be considered code (for example plaintext files). Application Inspector doesn't tend to parse those but DevSkim can. Since those scenarios don't have any "code" they are always commented, but because they did not have a specific comment format defined they instead came through as scope code.

This adds the "Always" field to comments.json to support those DevSkim scenarios and updates ScopeMatch to use the new field, as well as a new Document type called "Docs" alongside "Code" and "Build" for any future languages we would declare documentation only.