### PR TITLE
Adds numbering to issue results

### DIFF
--- a/AppInspector.CLI/html/resources/js/appinspector.js
+++ b/AppInspector.CLI/html/resources/js/appinspector.js
@@ -41,7 +41,9 @@
         const endLocationLine = $(e.target).data('endLocationLine');
         const editor = ace.edit("editor");
 
-        editor.setOption('firstLineNumber', startLocationLine - 3);
+        // Assume that the default context of 3 is used, the minimum line number is 1
+        const actualStartNumber = Math.max(1, startLocationLine - 3);
+        editor.setOption('firstLineNumber', actualStartNumber);
 
         // Decode the content (HTML encoded) for Ace to display
         // Disabled, needs better testing, since it's prone to XSS if content contains JS.
@@ -58,7 +60,7 @@
         editor.getSession().setValue(content);
         editor.resize();
         editor.scrollToLine(0);
-        editor.gotoLine(endLocationLine - startLocationLine + 1 + 3);
+        editor.gotoLine(startLocationLine);
 
         $('editor-container').removeClass('d-none');
         $('#match-line-number').text('Line number: ' + startLocationLine.toString());

--- a/AppInspector.CLI/html/resources/js/appinspector.js
+++ b/AppInspector.CLI/html/resources/js/appinspector.js
@@ -175,7 +175,7 @@ class TemplateInsertion {
             }
             return fn.slice($this.mt.sourcePath.length);
         };
-
+        var matchCount = 1;
         for (let match of $this.md) {
             let excerpt = (match.excerpt || '') || match.sample;
             if (match.ruleId === ruleId || match.ruleName === ruleId) {
@@ -190,6 +190,8 @@ class TemplateInsertion {
                     .data('startLocationLine', $l)
                     .data('endLocationLine', $e)
                     .text(removePrefix(match.fileName));
+                $li.append(matchCount++);
+                $li.append(". ");
                 $li.append($a);
                 $('#file_listing_modal ul').append($li);
 

--- a/AppInspector.CLI/html/resources/js/appinspector.js
+++ b/AppInspector.CLI/html/resources/js/appinspector.js
@@ -45,18 +45,18 @@
         // TODO: Better handle context that isn't 3 length
         const actualStartNumber = Math.max(1, startLocationLine - 3);
         editor.setOption('firstLineNumber', actualStartNumber);
-
         // Decode the content (HTML encoded) for Ace to display
         // Disabled, needs better testing, since it's prone to XSS if content contains JS.
-        // Maybe there is a better way of doing this.
-        if (false) {
-            const htmlEntityDecoder = (content) => {
-                const textArea = document.createElement('textarea');
-                textArea.innerHTML = content;
-                return textArea.value;
-            }
-            content = htmlEntityDecoder(content);
-        }
+        // TODO: Can this be rewritten to properly escape in a more limited fashion and use something like a <pre> tag?
+
+        // if (false) {
+        //     const htmlEntityDecoder = (content) => {
+        //         const textArea = document.createElement('textarea');
+        //         textArea.innerHTML = content;
+        //         return textArea.value;
+        //     }
+        //     content = htmlEntityDecoder(content);
+        // }
         editor.getSession().setValue(content);
         editor.resize();
         editor.scrollToLine(0);

--- a/AppInspector.CLI/html/resources/js/appinspector.js
+++ b/AppInspector.CLI/html/resources/js/appinspector.js
@@ -42,6 +42,7 @@
         const editor = ace.edit("editor");
 
         // Assume that the default context of 3 is used, the minimum line number is 1
+        // TODO: Better handle context that isn't 3 length
         const actualStartNumber = Math.max(1, startLocationLine - 3);
         editor.setOption('firstLineNumber', actualStartNumber);
 
@@ -56,14 +57,15 @@
             }
             content = htmlEntityDecoder(content);
         }
-
         editor.getSession().setValue(content);
         editor.resize();
         editor.scrollToLine(0);
-        editor.gotoLine(startLocationLine);
-
+        // We need to calculate the number relative to the number of lines in the content available
+        // This assumes the first line is 1, even though we have explicitly numbered the lines otherwise
+        editor.gotoLine(startLocationLine - actualStartNumber + 1);
         $('editor-container').removeClass('d-none');
-        $('#match-line-number').text('Line number: ' + startLocationLine.toString());
+        const locationString = startLocationLine < endLocationLine ? (startLocationLine.toString() + " - " + endLocationLine.toString()) : startLocationLine.toString();
+        $('#match-line-number').text('Line number: ' + locationString);
     });
 
     const templateInsertion = new TemplateInsertion(data);


### PR DESCRIPTION
Fix #556.

Now display a count for the issue results when drilling down into a finding in the key features tab.
Also should fix an issue with the line numbers displayed on the sidebar for findings in the first few lines of a file.

Example:
![image](https://github.com/microsoft/ApplicationInspector/assets/98900/509784c9-5aed-4355-89cf-e59912feffc2)
