### PR TITLE
JSON rules cleanup

### DIFF
--- a/AppInspector/rules/default/cloud_services/cloud_hosting.json
+++ b/AppInspector/rules/default/cloud_services/cloud_hosting.json
@@ -197,7 +197,6 @@
       "CloudServices.Hosting.DigitalOcean"
     ],
     "severity": "moderate",
-    "rule_info": "",
     "patterns": [
       {
         "pattern": "digitalocean.com",

--- a/AppInspector/rules/default/cryptography/external_libraries.json
+++ b/AppInspector/rules/default/cryptography/external_libraries.json
@@ -175,7 +175,7 @@
         "scopes": [
           "code"
         ],
-        "modified": [
+        "modifiers": [
           "i"
         ],
         "confidence": "high"

--- a/AppInspector/rules/default/cryptography/protocol.json
+++ b/AppInspector/rules/default/cryptography/protocol.json
@@ -113,8 +113,7 @@
         "confidence": "high",
         "modifiers": [
           "i"
-        ],
-        "_comment": "e.g. ssl_crl, ssl_ecdh_curve, others"
+        ]
       },
       {
         "pattern": "SSLCADNRequest|SSLCARevocation|SSLCompression|SSLEngine|SSLFIPS|SSLInsecureRenegotiation",
@@ -194,8 +193,7 @@
         ],
         "confidence": "high",
         "modifiers": [
-          "i",
-          "comment"
+          "i"
         ]
       }
     ]

--- a/AppInspector/rules/default/cryptography/weakssl.json
+++ b/AppInspector/rules/default/cryptography/weakssl.json
@@ -13,7 +13,6 @@
       "Cryptography.Protocol.TLS.WeakSSL"
     ],
     "severity": "critical",
-    "rule_info": "",
     "patterns": [
       {
         "pattern": "^iv.*=| +iv.*=",

--- a/AppInspector/rules/default/device_permissions/UWP.json
+++ b/AppInspector/rules/default/device_permissions/UWP.json
@@ -199,7 +199,6 @@
   {
     "name": "Declared Capabilities: VoipCall (Microsoft UWP)",
     "id": "AI016752",
-    "VoipCall": null,
     "description": "Declared Capabilities:  VoipCall (Microsoft UWP)",
     "applies_to": [
       "Package.appxmanifest"

--- a/AppInspector/rules/default/frameworks/java.json
+++ b/AppInspector/rules/default/frameworks/java.json
@@ -367,10 +367,7 @@
         "modifiers": [
           "i"
         ],
-        "confidence": "high",
-        "modifiers": [
-          "i"
-        ]
+        "confidence": "high"
       }
     ]
   },

--- a/AppInspector/rules/default/general/dependencies.json
+++ b/AppInspector/rules/default/general/dependencies.json
@@ -11,7 +11,6 @@
       "cpp"
     ],
     "severity": "moderate",
-    "confidence": "high",
     "patterns": [
       {
         "pattern": "#include ?[\\\"<]([A-Za-z])[\\\">]",


### PR DESCRIPTION
The JSON rules are not always consistent. There are rules with unused fields, rules with fields being encountered twice or just completely wrong fields that don't have any meaning in the context of ApplicationInspector. This is not a big issue let alone a issue at all for appinspect itself. However if one is parsing the JSON rules with a stricter JSON parser which has more validation enabled this becomes an issue.