### PR TITLE
Fixes JSONPath boundary finding for booleans

### DIFF
--- a/AppInspector.Benchmarks/AppInspector.Benchmarks.csproj
+++ b/AppInspector.Benchmarks/AppInspector.Benchmarks.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.6" />
-        <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.6" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
+        <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.8" />
 
     </ItemGroup>
     <ItemGroup>

--- a/AppInspector.CLI/AppInspector.CLI.csproj
+++ b/AppInspector.CLI/AppInspector.CLI.csproj
@@ -67,7 +67,7 @@
 
     <ItemGroup>
         <PackageReference Include="DotLiquid" Version="2.2.692" />
-        <PackageReference Include="Sarif.Sdk" Version="4.2.2" />
+        <PackageReference Include="Sarif.Sdk" Version="4.3.1" />
         <PackageReference Include="Serilog" Version="3.0.1" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />

--- a/AppInspector.RulesEngine/AppInspector.RulesEngine.csproj
+++ b/AppInspector.RulesEngine/AppInspector.RulesEngine.csproj
@@ -32,10 +32,10 @@
     <ItemGroup>
         <PackageReference Include="gstocco.YamlDotNet.YamlPath" Version="1.0.16" />
         <PackageReference Include="JsonCons.JsonPath" Version="1.1.0" />
-        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.49" />
-        <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.16" />
+        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.51" />
+        <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.17" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-        <PackageReference Include="YamlDotNet" Version="13.1.1" />
+        <PackageReference Include="YamlDotNet" Version="13.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/AppInspector.RulesEngine/AppInspector.RulesEngine.csproj
+++ b/AppInspector.RulesEngine/AppInspector.RulesEngine.csproj
@@ -32,7 +32,7 @@
     <ItemGroup>
         <PackageReference Include="gstocco.YamlDotNet.YamlPath" Version="1.0.16" />
         <PackageReference Include="JsonCons.JsonPath" Version="1.1.0" />
-        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.51" />
+        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.54" />
         <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.17" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
         <PackageReference Include="YamlDotNet" Version="13.3.1" />

--- a/AppInspector.RulesEngine/TextContainer.cs
+++ b/AppInspector.RulesEngine/TextContainer.cs
@@ -155,7 +155,8 @@ public class TextContainer
                 // The idx field is the start of the JSON element, including markup that isn't directly part of the element itself
                 if (field.GetValue(ele) is int idx)
                 {
-                    var eleString = ele.ToString();
+                    // ele.ToString doesn't return the raw string from the json for booleans, it returns a capitalized False/True but JSON requires lower case false/true to parse
+                    var eleString = ele.ValueKind is JsonValueKind.False ? "false" : ele.ValueKind is JsonValueKind.True ? "true" : ele.ToString();
                     if (eleString is { } denulledString)
                     {
                         var location = new Boundary

--- a/AppInspector.Tests/AppInspector.Tests.csproj
+++ b/AppInspector.Tests/AppInspector.Tests.csproj
@@ -18,7 +18,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
         <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />

--- a/AppInspector.Tests/RuleProcessor/XmlAndJsonTests.cs
+++ b/AppInspector.Tests/RuleProcessor/XmlAndJsonTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Linq;
 using Microsoft.ApplicationInspector.RulesEngine;
 using Microsoft.CST.RecursiveExtractor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -337,7 +336,7 @@ public class XmlAndJsonTests
         {
             var matches = analyzer.AnalyzeFile(testContent, new FileEntry("test.json", new MemoryStream()), info);
             Assert.AreEqual(1, matches.Count);
-            Assert.AreEqual(237, matches.First().Boundary.Index);
+            Assert.AreEqual(237, matches[0].Boundary.Index);
         }
     }
 

--- a/AppInspector/AppInspector.Commands.csproj
+++ b/AppInspector/AppInspector.Commands.csproj
@@ -55,8 +55,8 @@
         <PackageReference Include="DotLiquid" Version="2.2.692" />
         <PackageReference Include="Glob" Version="1.1.9" />
         <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
-        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.49" />
-        <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.16" />
+        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.51" />
+        <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.17" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
         <PackageReference Include="ShellProgressBar" Version="5.2.0" />
         <PackageReference Include="System.Reflection.Metadata" Version="7.0.2" />

--- a/AppInspector/AppInspector.Commands.csproj
+++ b/AppInspector/AppInspector.Commands.csproj
@@ -55,7 +55,7 @@
         <PackageReference Include="DotLiquid" Version="2.2.692" />
         <PackageReference Include="Glob" Version="1.1.9" />
         <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
-        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.51" />
+        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.54" />
         <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.17" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
         <PackageReference Include="ShellProgressBar" Version="5.2.0" />


### PR DESCRIPTION
Boundary detection for boolean values was off because proper JSON requires booleans to be lower case in the raw text, but JsonElement.ToString() returns capitalized boolean names.