### PR TITLE
Bump Newtonsoft.Json to 13.0.3

### DIFF
--- a/AppInspector.CLI/AppInspector.CLI.csproj
+++ b/AppInspector.CLI/AppInspector.CLI.csproj
@@ -73,8 +73,11 @@
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
         <PackageReference Include="ShellProgressBar" Version="5.2.0" />
-
     </ItemGroup>
 
+    <ItemGroup>
+        <!-- Update Sarif.Sdk -->
+        <PackageReference Include="Newtonsoft.Json" Version="[13.0.3, 14.0.0)" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The Sarif.Sdk package depends on Newtonsoft.Json 9.0.1+, and NuGet chooses the oldest version by default. This change pushes us up to 13.0.3 (latest current).

Ref: https://github.com/microsoft/sarif-sdk/issues/2673