### PR TITLE
Add Exception Handling Around More Recursive Extractor Calls

### DIFF
--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -566,11 +566,11 @@ public class RuleProcessor
 
         int startLineNumber =
             start.Line < 0 ? 0 : start.Line > text.LineEnds.Count ? text.LineEnds.Count - 1 : start.Line;
-        int endLineNUmber =
+        int endLineNumber =
             end.Line < 0 ? 0 : end.Line > text.LineEnds.Count ? text.LineEnds.Count - 1 : end.Line;
         // First we try to include the number of lines of context requested
         var excerptStartLine = Math.Max(0, startLineNumber - context);
-        var excerptEndLine = Math.Min(text.LineEnds.Count - 1, endLineNUmber + context);
+        var excerptEndLine = Math.Min(text.LineEnds.Count - 1, endLineNumber + context);
         var startIndex = text.LineStarts[excerptStartLine];
         var endIndex = text.LineEnds[excerptEndLine] + 1;
         // Maximum number of characters to capture on each side

--- a/AppInspector.RulesEngine/TextContainer.cs
+++ b/AppInspector.RulesEngine/TextContainer.cs
@@ -449,12 +449,14 @@ public class TextContainer
 
     /// <summary>
     ///     Returns location (Line, Column) for given index in text
+    ///     If the index is beyond the end of the file, clamps to the end
     /// </summary>
     /// <param name="index"> Position in text (line is one-indexed)</param>
     /// <returns> Location </returns>
     public Location GetLocation(int index)
     {
         for (var i = 1; i < LineEnds.Count; i++)
+        {
             if (LineEnds[i] >= index)
             {
                 return new Location
@@ -463,6 +465,17 @@ public class TextContainer
                     Line = i
                 };
             }
+        }
+
+        // If the index is beyond the end of the file, clamp to the end of the file
+        if (index > LineEnds[^1])
+        {
+            return new Location()
+            {
+                Column = LineEnds[^1] - LineStarts[^1],
+                Line = LineEnds.Count
+            };
+        }
 
         return new Location();
     }


### PR DESCRIPTION
* Try to fix #598. I wasn't able to reproduce the exact exception thrown in the report, but did identify cases where the calls now wrapped in a try/catch block could throw and stop enumeration and believe this may be the root cause. 
* Also adds better handling for edge case where index is beyond end of file.
* No-op cleanup of capitalization of a variable name.