### PR TITLE
Test-related improvements

### DIFF
--- a/AppInspector.Tests/AppInspector.Tests.csproj
+++ b/AppInspector.Tests/AppInspector.Tests.csproj
@@ -151,9 +151,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.13.1" />
-        <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.6.3" />
         <PackageReference Include="MSTest" Version="3.8.3" />
+        <PackageReference Include="Combinatorial.MSTest" Version="1.0.0" />
         <PackageReference Include="System.Reflection" Version="4.3.0" />
         <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
     </ItemGroup>

--- a/AppInspector.Tests/Commands/TestAnalyzeCmd.cs
+++ b/AppInspector.Tests/Commands/TestAnalyzeCmd.cs
@@ -95,7 +95,7 @@ buy@tacos.com
         factory = new LogOptions().GetLoggerFactory();
     }
 
-    [DataTestMethod]
+    [TestMethod]
     public void Overrides()
     {
         AnalyzeOptions options = new()
@@ -126,7 +126,7 @@ buy@tacos.com
         Assert.AreEqual(2, result.Metadata.UniqueMatchesCount);
     }
 
-    [DataTestMethod]
+    [TestMethod]
     public async Task OverridesAsync()
     {
         AnalyzeOptions options = new()
@@ -242,7 +242,7 @@ buy@tacos.com
     [DataRow(3, 3)]
     [DataRow(4, 4)]
     [DataRow(9999, 4)] // 9999 is larger than 4, but there are only 4 to find.
-    [DataTestMethod]
+    [TestMethod]
     public void MaxNumMatches(int MaxNumberOfMatchesParameter, int ActualExpectedNumberOfMatches)
     {
         AnalyzeOptions options = new()
@@ -272,7 +272,7 @@ buy@tacos.com
     [DataRow(3, 3)]
     [DataRow(4, 4)]
     [DataRow(9999, 4)] // 9999 is larger than 4, but there are only 4 to find.
-    [DataTestMethod]
+    [TestMethod]
     public async Task MaxNumMatchesAsync(int MaxNumberOfMatchesParameter, int ActualExpectedNumberOfMatches)
     {
         AnalyzeOptions options = new()
@@ -410,7 +410,7 @@ buy@tacos.com
         Assert.AreEqual(2, result.Metadata.UniqueMatchesCount);
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(true, 0, 0)]
     [DataRow(false, 2, 5)]
     public void ExpectedResultCounts(bool disableArchive, int expectedUniqueCount, int expectedCount)
@@ -452,7 +452,7 @@ buy@tacos.com
     [DataRow("afile.js", AnalyzeResult.ExitCode.Success, 4, 1)]
     [DataRow("afile.js.cs", AnalyzeResult.ExitCode.NoMatches, 0, 0)]
     [DataRow("adifferentfile.js", AnalyzeResult.ExitCode.Success, 1, 1)]
-    [DataTestMethod]
+    [TestMethod]
     public void AppliesToFileName(string testFileName, AnalyzeResult.ExitCode expectedExitCode,
         int expectedTotalMatches, int expectedUniqueMatches)
     {
@@ -583,7 +583,7 @@ buy@tacos.com
     [DataRow(new[] { Severity.Moderate }, 1)]
     [DataRow(new[] { Severity.Important }, 4)]
     [DataRow(new[] { Severity.Important | Severity.Moderate }, 5)]
-    [DataTestMethod]
+    [TestMethod]
     public void SeverityFilters(Severity[] severityFilter, int ActualExpectedNumberOfMatches)
     {
         AnalyzeOptions options = new()
@@ -604,7 +604,7 @@ buy@tacos.com
     [DataRow(new[] { Confidence.High }, 1)]
     [DataRow(new[] { Confidence.Medium }, 4)]
     [DataRow(new[] { Confidence.Medium | Confidence.High }, 5)]
-    [DataTestMethod]
+    [TestMethod]
     public void ConfidenceFilters(Confidence[] confidenceFilter, int ActualExpectedNumberOfMatches)
     {
         AnalyzeOptions options = new()
@@ -661,7 +661,7 @@ buy@tacos.com
     [DataRow(3, 5)]
     [DataRow(50, 5)]
     [DataRow(0, 0)]
-    [DataTestMethod]
+    [TestMethod]
     public void ContextLines(int numLinesContextArgument, int expectedNewLinesInResult)
     {
         AnalyzeOptions options = new()

--- a/AppInspector.Tests/Commands/TestAnalyzeCmd.cs
+++ b/AppInspector.Tests/Commands/TestAnalyzeCmd.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Combinatorial.MSTest;
 using Microsoft.ApplicationInspector.Commands;
 using Microsoft.ApplicationInspector.Common;
 using Microsoft.ApplicationInspector.Logging;
@@ -164,11 +165,8 @@ buy@tacos.com
     /// <summary>
     ///     Checks that the enumeration timeout works
     /// </summary>
-    [DataRow(true, true)]
-    [DataRow(true, false)]
-    [DataRow(false, true)]
-    [DataRow(false, false)]
-    [DataTestMethod]
+    [TestMethod]
+    [CombinatorialData]
     public void EnumeratingTimeoutTimesOut(bool singleThread, bool noShowProgress)
     {
         AnalyzeOptions options = new()
@@ -190,11 +188,8 @@ buy@tacos.com
     /// <summary>
     ///     Checks that the overall processing timeout works
     /// </summary>
-    [DataRow(true, true)]
-    [DataRow(true, false)]
-    [DataRow(false, true)]
-    [DataRow(false, false)]
-    [DataTestMethod]
+    [TestMethod]
+    [CombinatorialData]
     public void ProcessingTimeoutTimesOut(bool singleThread, bool noShowProgress)
     {
         AnalyzeOptions options = new()
@@ -216,11 +211,8 @@ buy@tacos.com
     /// <summary>
     ///     Checks that the individual file timeout times out
     /// </summary>
-    [DataRow(true, true)]
-    [DataRow(true, false)]
-    [DataRow(false, true)]
-    [DataRow(false, false)]
-    [DataTestMethod]
+    [TestMethod]
+    [CombinatorialData]
     public void FileTimeoutTimesOut(bool singleThread, bool noShowProgress)
     {
         AnalyzeOptions options = new()

--- a/AppInspector.Tests/Languages/LanguagesTests.cs
+++ b/AppInspector.Tests/Languages/LanguagesTests.cs
@@ -49,10 +49,10 @@ public class LanguagesTests
     [TestMethod]
     public void EmptyLanguagesOnInvalidCommentsAndLanguages()
     {
-        Assert.ThrowsException<JsonException>(() =>
+        Assert.ThrowsExactly<JsonException>(() =>
             Microsoft.ApplicationInspector.RulesEngine.Languages.FromConfigurationFiles(_factory,
                 invalidTestCommentsPath));
-        Assert.ThrowsException<JsonException>(() =>
+        Assert.ThrowsExactly<JsonException>(() =>
             Microsoft.ApplicationInspector.RulesEngine.Languages.FromConfigurationFiles(_factory, null,
                 invalidTestLanguagesPath));
     }

--- a/AppInspector.Tests/RuleProcessor/ExtractSamplesTests.cs
+++ b/AppInspector.Tests/RuleProcessor/ExtractSamplesTests.cs
@@ -46,7 +46,7 @@ public class ExtractSamplesTests
     // Third line is 10 character, context is set to 500 (specified as 5 lines then multiplied by 100) so 500 before, 10 after (clamped on end)
     [DataRow(longTestStringShortThirdLine, 1, 3, 5, 3, 2000, 5, 5, 510)]
 
-    [DataTestMethod]
+    [TestMethod]
     public void ExtractExcerptClampingTests(string testText, int StartCol, int StartLine, int EndCol, int EndLine, int Idx, int Length, int context, int expectedLength)
     {
         // Extract excerpt requires a text container

--- a/AppInspector.Tests/RuleProcessor/QuotedStringsTests.cs
+++ b/AppInspector.Tests/RuleProcessor/QuotedStringsTests.cs
@@ -101,7 +101,7 @@ end
     [DataRow(testMultiLineWithResultFollowingCommentEnd,1)]
     [DataRow(testSingleLineWithQuotesInComment,0)]
     [DataRow(testSingleLineWithDoubleQuotesInComment,0)]
-    [DataTestMethod]
+    [TestMethod]
     public void QuotedStrings(string content, int numIssues)
     {
         RuleSet rules = new(_loggerFactory);
@@ -121,7 +121,7 @@ end
     /// <param name="numIssues"></param>
     
     [DataRow(testRubyInterpolatedStrings, 5)]
-    [DataTestMethod]
+    [TestMethod]
     public void QuotedStringsRuby(string content, int numIssues)
     {
         RuleSet rules = new(_loggerFactory);

--- a/AppInspector.Tests/RuleProcessor/RegexModifiersTests.cs
+++ b/AppInspector.Tests/RuleProcessor/RegexModifiersTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.ApplicationInspector.RulesEngine;
+﻿using Combinatorial.MSTest;
+using Microsoft.ApplicationInspector.RulesEngine;
 using Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
 using Microsoft.CST.OAT;
 using Microsoft.CST.RecursiveExtractor;
@@ -133,9 +134,8 @@ namespace AppInspector.Tests.RuleProcessor
             Assert.AreEqual(expectedModifiers, actualModifiers);
         }
 
-        [DataRow(false)]
-        [DataRow(true)]
         [TestMethod]
+        [CombinatorialData]
         public void RegexWithLookBehind(bool enableNonBacktracking)
         {
             RuleSet rules = new() { EnableNonBacktrackingRegex = enableNonBacktracking };
@@ -158,9 +158,8 @@ namespace AppInspector.Tests.RuleProcessor
             }
         }
 
-        [DataRow(false)]
-        [DataRow(true)]
         [TestMethod]
+        [CombinatorialData]
         public void RegexWithoutLookBehind(bool enableNonBacktracking)
         {
             RuleSet rules = new() { EnableNonBacktrackingRegex = enableNonBacktracking };

--- a/AppInspector.Tests/RuleProcessor/RegexWithIndexTests.cs
+++ b/AppInspector.Tests/RuleProcessor/RegexWithIndexTests.cs
@@ -371,7 +371,7 @@ racecar";
 
     [DataRow(jsonRule)]
     [DataRow(jsonAndXmlRule)]
-    [DataTestMethod]
+    [TestMethod]
     public void JsonRule(string rule)
     {
         RuleSet rules = new();
@@ -391,7 +391,7 @@ racecar";
 
     [DataRow(xmlRule)]
     [DataRow(jsonAndXmlRule)]
-    [DataTestMethod]
+    [TestMethod]
     public void XmlRule(string rule)
     {
         RuleSet rules = new();

--- a/AppInspector.Tests/RuleProcessor/WithinClauseTests.cs
+++ b/AppInspector.Tests/RuleProcessor/WithinClauseTests.cs
@@ -359,7 +359,7 @@ int main(int argc, char **argv)
     [DataRow("WithinClauseWithoutInvertWithAfterOnly")]
     [DataRow("WithinClauseWithInvertWithSameFile")]
     [DataRow("WithinClauseWithoutInvertWithSameFile")]
-    [DataTestMethod]
+    [TestMethod]
     public void WithinClauseInvertTest(string testDataKey)
     {
         WithinClauseInvertTest(testData[testDataKey].testData, testData[testDataKey].conditionRegion,
@@ -395,7 +395,7 @@ int main(int argc, char **argv)
 
     [DataRow(true, 1, new[] { 2 })]
     [DataRow(false, 1, new[] { 3 })]
-    [DataTestMethod]
+    [TestMethod]
     public void WithinClauseInvertTestForSameLine(bool invert, int expectedMatches, int[] expectedMatchesLineStarts)
     {
         RuleSet rules = new(_loggerFactory);
@@ -430,7 +430,7 @@ int main(int argc, char **argv)
     [DataRow(false, true, false, 0, 1, 1)]
     [DataRow(false, true, false, 1, -1, 0)]
     [DataRow(false, true, false, -1, 0, 1)]
-    [DataTestMethod]
+    [TestMethod]
     public void WithinClauseValidationTests(bool findingOnlySetting, bool findingRegionSetting,
         bool sameLineOnlySetting, int afterSetting, int beforeSetting, int expectedNumIssues)
     {
@@ -558,7 +558,7 @@ http://
 
     [DataRow(true, 1, new[] { 2 })]
     [DataRow(false, 1, new[] { 3 })]
-    [DataTestMethod]
+    [TestMethod]
     public void WithinClauseInvertTestForFindingRange0(bool invert, int expectedMatches,
         int[] expectedMatchesLineStarts)
     {

--- a/AppInspector.Tests/RuleProcessor/XmlAndJsonTests.cs
+++ b/AppInspector.Tests/RuleProcessor/XmlAndJsonTests.cs
@@ -327,7 +327,7 @@ public class XmlAndJsonTests
     
     [DataRow(jsonStringRule)]
     [DataRow(jsonAndXmlStringRule)]
-    [DataTestMethod]
+    [TestMethod]
     public void JsonStringRule(string rule)
     {
         RuleSet rules = new();
@@ -346,7 +346,7 @@ public class XmlAndJsonTests
     }
     [DataRow(xmlStringRuleForPropWithDataForData, "Franklin", 209)]
     [DataRow(xmlStringRuleForPropWithData, "true", 173)]
-    [DataTestMethod]
+    [TestMethod]
     public void XmlTagWithPropsAndValue(string rule, string expectedValue, int expectedIndex)
     {
         RuleSet rules = new();
@@ -369,7 +369,7 @@ public class XmlAndJsonTests
 
     [DataRow(xmlStringRule)]
     [DataRow(jsonAndXmlStringRule)]
-    [DataTestMethod]
+    [TestMethod]
     public void XmlStringRule(string rule)
     {
         RuleSet rules = new();


### PR DESCRIPTION
- TrxReport and CodeCoverage extensions are already dependencies of MSTest metapackage. So, removed those unnecessary `PackageReference`s.
- Using [Combinatorial.MSTest](https://github.com/Youssef1313/Combinatorial.MSTest) to simplify some usages of `DataRow`s (NOTE: it's mostly an adjusted copy of xunit.combinatorial done under the same license, MS-PL).
- Fix analyzer warnings to use ThrowsExactly
- Use TestMethodAttribute instead of DataTestMethodAttribute

@danfiedler-msft @gfs for review please.

FYI @Evangelink as parts of this PR is a follow-up to #603