### PR TITLE
Migrate GitHub release task to explicit release job

### DIFF
--- a/Pipelines/appinspector-release.yml
+++ b/Pipelines/appinspector-release.yml
@@ -132,7 +132,7 @@ extends:
           outputs:
           - output: pipelineArtifact
             path: '$(Build.StagingDirectory)'
-            artifact: 'Signed_Binaries_$(System.JobId)_$(System.JobAttempt)'
+            artifact: 'Signed_Binaries'
           # see https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/outputs/nuget-packages
           - output: nuget
             useDotNetTask: false
@@ -597,6 +597,18 @@ extends:
             script: |
               mv $env:BUILD_BINARIESDIRECTORY/*.nupkg $env:BUILD_STAGINGDIRECTORY/
               mv $env:BUILD_BINARIESDIRECTORY/*.snupkg $env:BUILD_STAGINGDIRECTORY/
+      - job: gitHubReleaseJob
+        # Based on Documentation: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/releasepipelines/releaseworkflows/releasejob?tabs=standardreleasejob
+        displayName: GitHub Release Job
+        # pool: you can optionally specify pool as you would normally do for a standard job
+        templateContext:
+          type: releaseJob  # Required, this indicates this job is a release job
+          isProduction: true  # Required, must be 'true' or 'false'
+          inputs:  # All input build artifacts must be declared here
+          - input: pipelineArtifact  # Required, type of the input artifact
+            artifactName: Signed_Binaries  # Required, name of the pipeline artifact
+            targetPath: $(Pipeline.Workspace)/drop  # Optional, specifies where the artifact is downloaded
+        steps:
         - task: GitHubRelease@1
           displayName: Release to GitHub
           inputs:
@@ -609,7 +621,7 @@ extends:
             title: 'Release v$(ReleaseVersion)'
             releaseNotesSource: 'inline'
             assets: |
-              $(Build.StagingDirectory)/*.zip
-              $(Build.StagingDirectory)/HASHES.txt
+              $(Pipeline.Workspace)/drop/*.zip
+              $(Pipeline.Workspace)/drop/HASHES.txt
             changeLogCompareToRelease: 'lastNonDraftRelease'
             changeLogType: 'commitBased'

--- a/Pipelines/appinspector-release.yml
+++ b/Pipelines/appinspector-release.yml
@@ -609,6 +609,7 @@ extends:
             artifactName: Signed_Binaries  # Required, name of the pipeline artifact
             targetPath: $(Pipeline.Workspace)/drop  # Optional, specifies where the artifact is downloaded
         steps:
+        - template: nbgv-set-version-steps.yml@templates
         - task: GitHubRelease@1
           displayName: Release to GitHub
           inputs:


### PR DESCRIPTION
Introduces a new gitHubReleaseJob to the release pipeline for publishing artifacts to GitHub. Updates artifact naming and asset paths to align with the new job structure.