### PR TITLE
Add dependency on sign_hash_release for GitHub release job

### DIFF
--- a/Pipelines/appinspector-release.yml
+++ b/Pipelines/appinspector-release.yml
@@ -600,6 +600,7 @@ extends:
       - job: gitHubReleaseJob
         # Based on Documentation: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/releasepipelines/releaseworkflows/releasejob?tabs=standardreleasejob
         displayName: GitHub Release Job
+        dependsOn: sign_hash_release
         # pool: you can optionally specify pool as you would normally do for a standard job
         templateContext:
           type: releaseJob  # Required, this indicates this job is a release job


### PR DESCRIPTION
Updated the appinspector-release.yml pipeline to ensure the gitHubReleaseJob depends on the sign_hash_release job.