### PR TITLE
Update NuGet package dependencies to latest versions

### DIFF
--- a/AppInspector.Common/AppInspector.Common.csproj
+++ b/AppInspector.Common/AppInspector.Common.csproj
@@ -30,7 +30,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
 
 
     </ItemGroup>

--- a/AppInspector.RulesEngine/AppInspector.RulesEngine.csproj
+++ b/AppInspector.RulesEngine/AppInspector.RulesEngine.csproj
@@ -32,9 +32,9 @@
     <ItemGroup>
         <PackageReference Include="gstocco.YamlDotNet.YamlPath" Version="1.0.26" />
         <PackageReference Include="JsonCons.JsonPath" Version="1.1.0" />
-        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.79" />
-        <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.41" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
+        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.87" />
+        <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.45" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
         <PackageReference Include="YamlDotNet" Version="16.3.0" />
     </ItemGroup>
 

--- a/AppInspector.Tests/AppInspector.Tests.csproj
+++ b/AppInspector.Tests/AppInspector.Tests.csproj
@@ -149,12 +149,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
         <PackageReference Include="System.Reflection" Version="4.3.0" />
         <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/AppInspector/AppInspector.Commands.csproj
+++ b/AppInspector/AppInspector.Commands.csproj
@@ -55,11 +55,11 @@
         <PackageReference Include="DotLiquid" Version="2.3.197" />
         <PackageReference Include="Glob" Version="1.1.9" />
         <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
-        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.79" />
-        <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.41" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
+        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.87" />
+        <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.45" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
         <PackageReference Include="ShellProgressBar" Version="5.2.0" />
-        <PackageReference Include="System.Reflection.Metadata" Version="9.0.7" />
+        <PackageReference Include="System.Reflection.Metadata" Version="9.0.8" />
 
 
     </ItemGroup>


### PR DESCRIPTION
Bump versions of Microsoft.Extensions.Logging.Abstractions, Microsoft.CST.OAT, Microsoft.CST.RecursiveExtractor, System.Reflection.Metadata, Microsoft.Extensions.Logging, and xunit.runner.visualstudio across project files to address bug fixes and improvements in dependencies.