### PR TITLE
Fix JSON serialization for Result-derived classes

### DIFF
--- a/AppInspector.CLI/Properties/AssemblyInfo.cs
+++ b/AppInspector.CLI/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AppInspector.Tests")]

--- a/AppInspector.CLI/Writers/JsonWriter.cs
+++ b/AppInspector.CLI/Writers/JsonWriter.cs
@@ -39,7 +39,7 @@ internal class JsonWriter : CommandResultsWriter
                 case TagDiffResult:
                 case ExportTagsResult:
                 case VerifyRulesResult:
-                    JsonSerializer.Serialize(StreamWriter.BaseStream, result, options);
+                    JsonSerializer.Serialize(StreamWriter.BaseStream, result, result.GetType(), options);
                     break;
                 case PackRulesResult prr:
                     JsonSerializer.Serialize(StreamWriter.BaseStream, prr.Rules, options);          


### PR DESCRIPTION
* Fix exporttags JSON output bug by using runtime type for serialization
* Improve test to exercise actual JsonWriter code path
  - Modified ExportJsonSerialization test to use JsonWriter.WriteResults
  - Added InternalsVisibleTo attribute to expose JsonWriter to tests
  - Test validates production code path instead of direct serialization
  
  
  Fixes: #641 

