### PR TITLE
Fix typo in Report - tagreportgroups.json

### DIFF
--- a/AppInspector.CLI/preferences/tagreportgroups.json
+++ b/AppInspector.CLI/preferences/tagreportgroups.json
@@ -321,8 +321,8 @@
         ]
       },
       {
-        "title": "Miscellenous",
-        "dataRef": "Miscellenous",
+        "title": "Miscellaneous",
+        "dataRef": "Miscellaneous",
         "patterns": [
           {
             "searchPattern": "^Data.Media.*",

--- a/AppInspector/RuleSetUtils.cs
+++ b/AppInspector/RuleSetUtils.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.ApplicationInspector.Commands;
 
-//Miscellenous common methods needed from several places throughout
+//Miscellaneous common methods needed from several places throughout
 public static class RuleSetUtils
 {
     /// <summary>


### PR DESCRIPTION
* Spelling correction for report:
  * Fixed the spelling of "Miscellenous" to "Miscellaneous" in both the `title` and `dataRef` fields in `tagreportgroups.json`.
  
  (discovered while parsing the tags groups via another project)

Matches existing tags:

```
Miscellaneous.CodeHygiene.Comment.Fix
Miscellaneous.CodeHygiene.Comment.Suspicious
Miscellaneous.CodeHygiene.Comment.Todo
Miscellaneous.OpenSourceLicense.Apache
Miscellaneous.OpenSourceLicense.BSD
Miscellaneous.OpenSourceLicense.CreativeCommons
Miscellaneous.OpenSourceLicense.Eclipse
Miscellaneous.OpenSourceLicense.GPL
Miscellaneous.OpenSourceLicense.LGPL
Miscellaneous.OpenSourceLicense.Microsoft
Miscellaneous.OpenSourceLicense.MIT
Miscellaneous.OpenSourceLicense.Mozilla
```