### PR TITLE
Fix JSON serialization for Result-derived classes

### DIFF
--- a/AppInspector.CLI/Properties/AssemblyInfo.cs
+++ b/AppInspector.CLI/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AppInspector.Tests")]

--- a/AppInspector.CLI/Properties/AssemblyInfo.cs
+++ b/AppInspector.CLI/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("AppInspector.Tests")]

--- a/AppInspector.CLI/Writers/JsonWriter.cs
+++ b/AppInspector.CLI/Writers/JsonWriter.cs
@@ -39,7 +39,7 @@ internal class JsonWriter : CommandResultsWriter
                 case TagDiffResult:
                 case ExportTagsResult:
                 case VerifyRulesResult:
-                    JsonSerializer.Serialize(StreamWriter.BaseStream, result, options);
+                    JsonSerializer.Serialize(StreamWriter.BaseStream, result, result.GetType(), options);
                     break;
                 case PackRulesResult prr:
                     JsonSerializer.Serialize(StreamWriter.BaseStream, prr.Rules, options);          

--- a/AppInspector.Tests/Commands/TestExportTagsCmd.cs
+++ b/AppInspector.Tests/Commands/TestExportTagsCmd.cs
@@ -59,41 +59,4 @@ public class TestExportTagsCmd
         };
         Assert.Throws<OpException>(() => new ExportTagsCommand(options));
     }
-
-    [Fact]
-    public void ExportJsonSerialization()
-    {
-        ExportTagsOptions options = new()
-        {
-            IgnoreDefaultRules = true,
-            CustomRulesPath = testRulesPath
-        };
-        ExportTagsCommand command = new(options, factory);
-        var result = command.GetResult();
-        
-        // Test JSON serialization via the production JsonWriter to ensure tags are included
-        using var memoryStream = new MemoryStream();
-        using var streamWriter = new StreamWriter(memoryStream);
-        
-        // Use the JsonWriter that production code uses
-        var jsonWriter = new Microsoft.ApplicationInspector.CLI.Writers.JsonWriter(streamWriter, factory);
-        var cliOptions = new Microsoft.ApplicationInspector.CLI.CLIExportTagsCmdOptions
-        {
-            IgnoreDefaultRules = true,
-            CustomRulesPath = testRulesPath
-        };
-        
-        jsonWriter.WriteResults(result, cliOptions, autoClose: false);
-        streamWriter.Flush();
-        
-        memoryStream.Position = 0;
-        using var reader = new StreamReader(memoryStream);
-        string json = reader.ReadToEnd();
-        
-        // Verify tags are present in JSON output from JsonWriter
-        Assert.Contains("Test.Tags.Linux", json);
-        Assert.Contains("Test.Tags.Windows", json);
-        Assert.Contains("tagsList", json);
-        Assert.Contains("appVersion", json);
-    }
 }

--- a/AppInspector.Tests/Commands/TestJsonWriter.cs
+++ b/AppInspector.Tests/Commands/TestJsonWriter.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.ApplicationInspector.CLI;
+using Microsoft.ApplicationInspector.Commands;
+using Microsoft.ApplicationInspector.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace AppInspector.Tests.Commands;
+
+/// <summary>
+///     Regression coverage for the shared JsonWriter path used by exporttags, tagdiff and verifyrules.
+///     Results were previously serialized against the <see cref="Result" /> base type, so every property
+///     declared on the derived result was dropped and the output contained only appVersion.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class TestJsonWriter
+{
+    private readonly ILoggerFactory _factory = new LogOptions().GetLoggerFactory();
+
+    [Fact]
+    public void ExportTagsWritesTagsList()
+    {
+        var rulesPath = Path.Combine("TestData", "TestExportTagsCmd", "Rules", "TestRules.json");
+        ExportTagsOptions options = new()
+        {
+            IgnoreDefaultRules = true,
+            CustomRulesPath = rulesPath
+        };
+        var result = new ExportTagsCommand(options, _factory).GetResult();
+
+        var json = WriteAsJson(result, new CLIExportTagsCmdOptions
+        {
+            IgnoreDefaultRules = true,
+            CustomRulesPath = rulesPath
+        });
+
+        var written = JsonSerializer.Deserialize<ExportTagsResult>(json);
+        Assert.NotNull(written);
+        Assert.Equal(result.TagsList.OrderBy(x => x), written!.TagsList.OrderBy(x => x));
+        Assert.Contains("Test.Tags.Linux", written.TagsList);
+        Assert.Contains("Test.Tags.Windows", written.TagsList);
+        Assert.False(string.IsNullOrEmpty(written.AppVersion));
+    }
+
+    /// <summary>
+    ///     Guards <see cref="TagDiffResult.TagDiffList" /> staying a property. As a field it was invisible to
+    ///     System.Text.Json and silently omitted from the report.
+    /// </summary>
+    [Fact]
+    public void TagDiffWritesTagDiffList()
+    {
+        var rulesPath = Path.Combine("TestData", "TestTagDiffCmd", "Rules", "FindWindows.json");
+        var sourceWithLinux = Path.Combine("TestData", "TestTagDiffCmd", "Samples", "FourWindowsOneLinux.js");
+        var sourceWithoutLinux = Path.Combine("TestData", "TestTagDiffCmd", "Samples", "FourWindowsNoLinux.js");
+
+        TagDiffOptions options = new()
+        {
+            SourcePath1 = new[] { sourceWithLinux },
+            SourcePath2 = new[] { sourceWithoutLinux },
+            FilePathExclusions = Array.Empty<string>(), //allow source under unittest path
+            IgnoreDefaultRules = true,
+            TestType = TagTestType.Equality,
+            CustomRulesPath = rulesPath
+        };
+        var result = new TagDiffCommand(options, _factory).GetResult();
+        Assert.NotEmpty(result.TagDiffList);
+
+        var json = WriteAsJson(result, new CLITagDiffCmdOptions
+        {
+            SourcePath1 = options.SourcePath1,
+            SourcePath2 = options.SourcePath2,
+            IgnoreDefaultRules = true,
+            CustomRulesPath = rulesPath
+        });
+
+        var written = JsonSerializer.Deserialize<TagDiffResult>(json);
+        Assert.NotNull(written);
+        Assert.Equal(
+            result.TagDiffList.Select(x => (x.Tag, x.Source)).OrderBy(x => x.Tag),
+            written!.TagDiffList.Select(x => (x.Tag, x.Source)).OrderBy(x => x.Tag));
+        Assert.Equal(result.ResultCode, written.ResultCode);
+    }
+
+    [Fact]
+    public void VerifyRulesWritesRuleStatusList()
+    {
+        var rulesPath = Path.Combine("TestData", "TestVerifyRulesCmd", "Rules", "ValidRules.json");
+        VerifyRulesOptions options = new()
+        {
+            CustomRulesPath = rulesPath
+        };
+        var result = new VerifyRulesCommand(options, _factory).GetResult();
+        Assert.NotEmpty(result.RuleStatusList);
+
+        var json = WriteAsJson(result, new CLIVerifyRulesCmdOptions
+        {
+            CustomRulesPath = rulesPath
+        });
+
+        // RuleStatus exposes computed and OAT-owned members that do not round-trip, so assert on the
+        // parsed document rather than deserializing back into VerifyRulesResult.
+        using var document = JsonDocument.Parse(json);
+        var ruleStatusList = document.RootElement.GetProperty("ruleStatusList");
+        Assert.Equal(JsonValueKind.Array, ruleStatusList.ValueKind);
+        Assert.Equal(result.RuleStatusList.Count, ruleStatusList.GetArrayLength());
+
+        var writtenIds = ruleStatusList.EnumerateArray().Select(x => x.GetProperty("RulesId").GetString());
+        Assert.Equal(result.RuleStatusList.Select(x => x.RulesId).OrderBy(x => x), writtenIds.OrderBy(x => x));
+    }
+
+    /// <summary>
+    ///     Writes a result to a temporary file through the same public entry point the CLI uses, so the test
+    ///     covers writer selection as well as serialization.
+    /// </summary>
+    private string WriteAsJson(Result result, CLICommandOptions options)
+    {
+        var outputFilePath = Path.Combine(Path.GetTempPath(), $"test_json_{Guid.NewGuid()}.json");
+        options.OutputFilePath = outputFilePath;
+        options.OutputFileFormat = "json";
+
+        try
+        {
+            new ResultsWriter(_factory).Write(result, options);
+            Assert.True(File.Exists(outputFilePath));
+            return File.ReadAllText(outputFilePath);
+        }
+        finally
+        {
+            if (File.Exists(outputFilePath))
+            {
+                File.Delete(outputFilePath);
+            }
+        }
+    }
+}

--- a/AppInspector/Commands/TagDiffCommand.cs
+++ b/AppInspector/Commands/TagDiffCommand.cs
@@ -85,8 +85,10 @@ public class TagDiffResult : Result
     /// <summary>
     ///     List of tags which differ between src1 and src2
     /// </summary>
+    // Declared as a property, not a field: System.Text.Json ignores public fields unless
+    // JsonSerializerOptions.IncludeFields is set, which silently dropped this from the json report.
     [JsonPropertyName("tagDiffList")]
-    public List<TagDiff> TagDiffList;
+    public List<TagDiff> TagDiffList { get; set; }
 
     public TagDiffResult()
     {


### PR DESCRIPTION
Fixes #641. Supersedes #642.

This carries @felickz's commit from #642 unchanged, plus two follow-up commits from review. #642 can't be merged from its fork — the fork is organization-owned (so `maintainer_can_modify` is unavailable) and the required Azure pipelines don't run on forks, leaving the PR permanently blocked. Rebasing it here is the only way to land it. Original authorship and `Co-authored-by` trailers are preserved on `e561b9b`.

## Commits

**`e561b9b` — Fix JSON serialization for Result-derived classes** (@felickz, unchanged from #642)

`JsonSerializer.Serialize(stream, result, options)` bound `TValue` to the static type `Result`, so only `appVersion` was emitted for `exporttags`, `tagdiff`, and `verifyrules`. Passing `result.GetType()` selects the runtime converter.

**`be00ce7` — Serialize `tagDiffList` by making `TagDiffList` a property**

The runtime-type fix alone doesn't repair `tagdiff --output-file-format json`. `TagDiffResult.TagDiffList` was declared as a public *field*, and System.Text.Json skips public fields unless `IncludeFields` is set, so the output was still:

```json
{ "resultCode": 1, "appVersion": "..." }
```

Declaring it as a property matches every other `Result`-derived class and is narrower than enabling `IncludeFields` globally, which would start emitting any other public field on any serialized type.

**`3fd93a9` — Cover the json writers through the public `ResultsWriter` path**

Consolidates the regression tests into `TestJsonWriter`, following the existing `TestMarkdownWriter` pattern, covering all three commands that share the `JsonWriter` path rather than `exporttags` alone.

The tests now go through `ResultsWriter.Write` — what `Program.cs` calls — so writer selection is exercised alongside serialization. That's reachable without widening the CLI assembly's internal surface, so the `InternalsVisibleTo` added in #642 for direct `JsonWriter` construction is removed.

Assertions compare the written document against the in-memory result instead of substring-matching raw JSON, which would have passed on malformed output. `VerifyRulesResult` is asserted via `JsonDocument` because `RuleStatus` exposes a computed `Verified` and OAT-owned `Violation` members that don't round-trip.

## Verification

- Solution builds across net8.0 / net9.0 / net10.0.
- Full suite: 350/350 pass (348 baseline + 3 new − 1 replaced).
- Reverting the `JsonWriter` line fails all three new tests; reverting the field-to-property change fails `TagDiffWritesTagDiffList` specifically.

## Not addressed

`DefaultIgnoreCondition = WhenWritingDefault` drops `resultCode` from JSON output whenever it's `0` (`Success` / `Verified` / `TestPassed`). Pre-existing and unrelated to the base-type bug, so left alone here.