### PR TITLE
Report skipped symlinks instead of dropping them silently

### DIFF
--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -105,7 +105,8 @@ public record CLIAnalysisSharedCommandOptions : CLICustomRulesCommandOptions
     public bool ScanUnknownTypes { get; set; }
 
     [Option("follow-symlinks", Required = false,
-        HelpText = "Follow symbolic links while enumerating source files.")]
+        HelpText =
+            "Follow symbolic links found while traversing a source directory. Skipped links are reported as skipped files. A link named directly on the command line is always scanned. On Windows this option also applies to other reparse points, including NTFS junctions and cloud placeholder files such as OneDrive Files On-Demand.")]
     public bool FollowSymlinks { get; set; }
 
     [Option('c', "confidence-filters", Required = false, Separator = ',',

--- a/AppInspector.Tests/CLI/TestFollowSymlinksOption.cs
+++ b/AppInspector.Tests/CLI/TestFollowSymlinksOption.cs
@@ -1,0 +1,55 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using CommandLine;
+using Microsoft.ApplicationInspector.CLI;
+using Xunit;
+
+namespace AppInspector.Tests.CLI;
+
+/// <summary>
+///     Verifies that the symlink command line option is wired to the commands that accept a source path.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class TestFollowSymlinksOption
+{
+    [Fact]
+    public void AnalyzeDefaultsToSkippingSymlinks()
+    {
+        var options = Parse<CLIAnalyzeCmdOptions>("analyze", "-s", "sourcePath");
+
+        Assert.False(options.FollowSymlinks);
+    }
+
+    [Fact]
+    public void AnalyzeAcceptsFollowSymlinks()
+    {
+        var options = Parse<CLIAnalyzeCmdOptions>("analyze", "-s", "sourcePath", "--follow-symlinks");
+
+        Assert.True(options.FollowSymlinks);
+    }
+
+    [Fact]
+    public void TagDiffDefaultsToSkippingSymlinks()
+    {
+        var options = Parse<CLITagDiffCmdOptions>("tagdiff", "--src1", "one", "--src2", "two");
+
+        Assert.False(options.FollowSymlinks);
+    }
+
+    [Fact]
+    public void TagDiffAcceptsFollowSymlinks()
+    {
+        var options = Parse<CLITagDiffCmdOptions>("tagdiff", "--src1", "one", "--src2", "two", "--follow-symlinks");
+
+        Assert.True(options.FollowSymlinks);
+    }
+
+    private static T Parse<T>(params string[] args) where T : class
+    {
+        T? parsed = null;
+        Parser.Default.ParseArguments<CLIAnalyzeCmdOptions, CLITagDiffCmdOptions>(args)
+            .WithParsed<T>(options => parsed = options);
+
+        Assert.NotNull(parsed);
+        return parsed!;
+    }
+}

--- a/AppInspector.Tests/Commands/TestAnalyzeCmd.cs
+++ b/AppInspector.Tests/Commands/TestAnalyzeCmd.cs
@@ -16,65 +16,6 @@ using Assert = Xunit.Assert;
 
 namespace AppInspector.Tests.Commands;
 
-internal static class SymlinkTestSupport
-{
-    public static string? SkipReason { get; } = GetSkipReason();
-
-    private static string? GetSkipReason()
-    {
-        var testRoot = Path.Combine(Path.GetTempPath(), $"ApplicationInspector-SymlinkTest-{Guid.NewGuid()}");
-
-        try
-        {
-            Directory.CreateDirectory(testRoot);
-            var fileTarget = Path.Combine(testRoot, "target.txt");
-            var directoryTarget = Path.Combine(testRoot, "target-directory");
-            File.WriteAllText(fileTarget, string.Empty);
-            Directory.CreateDirectory(directoryTarget);
-            File.CreateSymbolicLink(Path.Combine(testRoot, "file-link"), fileTarget);
-            Directory.CreateSymbolicLink(Path.Combine(testRoot, "directory-link"), directoryTarget);
-            return null;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return "Symlink creation is not permitted on this machine.";
-        }
-        catch (PlatformNotSupportedException)
-        {
-            return "Symlinks are not supported on this platform.";
-        }
-        catch (IOException ex)
-        {
-            return $"Symlink creation is not supported by the test file system: {ex.Message}";
-        }
-        finally
-        {
-            if (Directory.Exists(testRoot))
-            {
-                Directory.Delete(testRoot, true);
-            }
-        }
-    }
-}
-
-[AttributeUsage(AttributeTargets.Method)]
-internal sealed class SymlinkFactAttribute : FactAttribute
-{
-    public SymlinkFactAttribute()
-    {
-        Skip = SymlinkTestSupport.SkipReason;
-    }
-}
-
-[AttributeUsage(AttributeTargets.Method)]
-internal sealed class SymlinkTheoryAttribute : TheoryAttribute
-{
-    public SymlinkTheoryAttribute()
-    {
-        Skip = SymlinkTestSupport.SkipReason;
-    }
-}
-
 public class TestAnalyzeCmdFixture : IDisposable
 {
     public TestAnalyzeCmdFixture()
@@ -194,11 +135,11 @@ buy@tacos.com
     }
 
     [SymlinkTheory]
-    [InlineData(false, 4)]
-    [InlineData(true, 6)]
-    public void FollowSymlinks(bool followSymlinks, int expectedFiles)
+    [InlineData(false)]
+    [InlineData(true)]
+    public void FollowSymlinks(bool followSymlinks)
     {
-        var testRoot = Path.Combine("TestOutput", $"SymlinkTest-{Guid.NewGuid()}");
+        var testRoot = SymlinkTestSupport.CreateTestRoot("SymlinkTest");
         var sourcePath = Path.Combine(testRoot, "source");
         var linkedDirectoryTarget = Path.Combine(testRoot, "linked-directory-target");
         Directory.CreateDirectory(sourcePath);
@@ -206,17 +147,27 @@ buy@tacos.com
 
         try
         {
+            // A plain file that is always scanned.
             File.WriteAllText(Path.Combine(sourcePath, "regular.js"), "windows");
+
+            // Link targets, deliberately outside the scanned source directory.
             var linkedFileTarget = Path.Combine(testRoot, "linked-file-target.js");
             File.WriteAllText(linkedFileTarget, "windows");
             File.WriteAllText(Path.Combine(linkedDirectoryTarget, "linked-directory-file.js"), "windows");
+
+            // Links reached by traversing the source directory. These are the ones the default skips.
             File.CreateSymbolicLink(Path.Combine(sourcePath, "linked-file.js"), Path.GetFullPath(linkedFileTarget));
             Directory.CreateSymbolicLink(Path.Combine(sourcePath, "linked-directory"),
                 Path.GetFullPath(linkedDirectoryTarget));
+
+            // Links named directly in SourcePath. These are always scanned, because refusing a path the caller
+            // asked for by name would be more surprising than following it.
             var directLinkedFile = Path.Combine(testRoot, "direct-linked-file.js");
             var directLinkedDirectory = Path.Combine(testRoot, "direct-linked-directory");
             File.CreateSymbolicLink(directLinkedFile, Path.GetFullPath(linkedFileTarget));
             Directory.CreateSymbolicLink(directLinkedDirectory, Path.GetFullPath(linkedDirectoryTarget));
+
+            // A source path that reaches its directory through a linked ancestor. Also always scanned.
             var linkedAncestorTarget = Path.Combine(testRoot, "linked-ancestor-target");
             var sourceThroughLinkedAncestor = Path.Combine(testRoot, "linked-ancestor", "source");
             Directory.CreateDirectory(Path.Combine(linkedAncestorTarget, "source"));
@@ -235,25 +186,55 @@ buy@tacos.com
             var result = command.GetResult();
 
             Assert.Equal(AnalyzeResult.ExitCode.Success, result.ResultCode);
-            Assert.Equal(expectedFiles, result.Metadata.TotalFiles);
+
+            var analyzed = FileNamesWithStatus(result, ScanState.Analyzed)
+                .Concat(FileNamesWithStatus(result, ScanState.Affected)).OrderBy(x => x).ToArray();
+            var skipped = FileNamesWithStatus(result, ScanState.Skipped).OrderBy(x => x).ToArray();
+
+            if (followSymlinks)
+            {
+                Assert.Equal(new[]
+                {
+                    "direct-linked-file.js",
+                    "linked-ancestor-file.js",
+                    // Reached twice: once through the directly named link and once through the traversed link.
+                    "linked-directory-file.js",
+                    "linked-directory-file.js",
+                    "linked-file.js",
+                    "regular.js"
+                }, analyzed);
+                Assert.Empty(skipped);
+            }
+            else
+            {
+                Assert.Equal(new[]
+                {
+                    "direct-linked-file.js",
+                    "linked-ancestor-file.js",
+                    "linked-directory-file.js",
+                    "regular.js"
+                }, analyzed);
+
+                // The traversed file link is reported rather than silently dropped. The traversed directory link
+                // is not recursed into, so linked-directory-file.js is reached only via the directly named link.
+                Assert.Equal(new[] { "linked-file.js" }, skipped);
+            }
         }
         finally
         {
-            Directory.Delete(testRoot, true);
+            SymlinkTestSupport.TryDeleteTestRoot(testRoot);
         }
     }
 
     [SymlinkFact]
     public void SkipsDanglingSymlinksByDefault()
     {
-        var testRoot = Path.Combine("TestOutput", $"DanglingSymlinkTest-{Guid.NewGuid()}");
-        Directory.CreateDirectory(testRoot);
+        var testRoot = SymlinkTestSupport.CreateTestRoot("DanglingSymlinkTest");
 
         try
         {
             File.WriteAllText(Path.Combine(testRoot, "regular.js"), "windows");
-            var danglingLink = Path.Combine(testRoot, "dangling.js");
-            File.CreateSymbolicLink(danglingLink, Path.Combine(testRoot, "missing.js"));
+            File.CreateSymbolicLink(Path.Combine(testRoot, "dangling.js"), Path.Combine(testRoot, "missing.js"));
             AnalyzeCommand command = new(new AnalyzeOptions
             {
                 SourcePath = new[] { testRoot },
@@ -264,12 +245,23 @@ buy@tacos.com
             var result = command.GetResult();
 
             Assert.Equal(AnalyzeResult.ExitCode.Success, result.ResultCode);
-            Assert.Equal(1, result.Metadata.TotalFiles);
+            Assert.Equal(new[] { "regular.js" },
+                FileNamesWithStatus(result, ScanState.Analyzed)
+                    .Concat(FileNamesWithStatus(result, ScanState.Affected)).OrderBy(x => x).ToArray());
+
+            // A dangling link cannot be opened, so skipping it keeps it out of the error count.
+            Assert.Equal(new[] { "dangling.js" }, FileNamesWithStatus(result, ScanState.Skipped).ToArray());
+            Assert.Empty(FileNamesWithStatus(result, ScanState.Error));
         }
         finally
         {
-            Directory.Delete(testRoot, true);
+            SymlinkTestSupport.TryDeleteTestRoot(testRoot);
         }
+    }
+
+    private static IEnumerable<string> FileNamesWithStatus(AnalyzeResult result, ScanState status)
+    {
+        return result.Metadata.Files.Where(x => x.Status == status).Select(x => Path.GetFileName(x.FileName));
     }
 
     [Fact]

--- a/AppInspector.Tests/Commands/TestTagDiffCmd.cs
+++ b/AppInspector.Tests/Commands/TestTagDiffCmd.cs
@@ -107,4 +107,52 @@ public class TestTagDiffCmd
         var command = new TagDiffCommand(options, loggerFactory);
         Assert.Throws<OpException>(() => command.GetResult());
     }
+
+    /// <summary>
+    ///     TagDiff builds two AnalyzeOptions internally, so FollowSymlinks has to reach both of them. With the
+    ///     option off, the linked copy of the source is not traversed and the two sides differ.
+    /// </summary>
+    [SymlinkTheory]
+    [InlineData(false, TagDiffResult.ExitCode.TestFailed)]
+    [InlineData(true, TagDiffResult.ExitCode.TestPassed)]
+    public void FollowSymlinksIsPassedToBothScans(bool followSymlinks, TagDiffResult.ExitCode expectedExitCode)
+    {
+        var testRoot = SymlinkTestSupport.CreateTestRoot("TagDiffSymlinkTest");
+
+        try
+        {
+            // Side 1 contains the Windows sample directly.
+            var sideOne = Path.Combine(testRoot, "side-one");
+            Directory.CreateDirectory(sideOne);
+            File.Copy(testFileFourWindowsOneLinuxPath, Path.Combine(sideOne, "FourWindowsOneLinux.js"));
+
+            // Side 2 reaches the same content only through a symbolic link.
+            var sideTwo = Path.Combine(testRoot, "side-two");
+            var linkTarget = Path.Combine(testRoot, "link-target");
+            Directory.CreateDirectory(sideTwo);
+            Directory.CreateDirectory(linkTarget);
+            File.Copy(testFileFourWindowsOneLinuxPath, Path.Combine(linkTarget, "FourWindowsOneLinux.js"));
+            File.WriteAllText(Path.Combine(sideTwo, "placeholder.txt"), string.Empty);
+            Directory.CreateSymbolicLink(Path.Combine(sideTwo, "linked"), Path.GetFullPath(linkTarget));
+
+            TagDiffOptions options = new()
+            {
+                SourcePath1 = new[] { sideOne },
+                SourcePath2 = new[] { sideTwo },
+                FilePathExclusions = Array.Empty<string>(), //allow source under unittest path
+                IgnoreDefaultRules = true,
+                TestType = TagTestType.Equality,
+                CustomRulesPath = testRulesPath,
+                FollowSymlinks = followSymlinks
+            };
+
+            TagDiffCommand command = new(options, loggerFactory);
+
+            Assert.Equal(expectedExitCode, command.GetResult().ResultCode);
+        }
+        finally
+        {
+            SymlinkTestSupport.TryDeleteTestRoot(testRoot);
+        }
+    }
 }

--- a/AppInspector.Tests/SymlinkTestSupport.cs
+++ b/AppInspector.Tests/SymlinkTestSupport.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.IO;
+using Xunit;
+
+namespace AppInspector.Tests;
+
+/// <summary>
+///     Detects whether the machine running the tests can create symbolic links. Creating a symbolic link on Windows
+///     requires either Developer Mode or the SeCreateSymbolicLinkPrivilege, and some file systems do not support
+///     links at all, so symlink tests are skipped rather than failed in those environments.
+/// </summary>
+internal static class SymlinkTestSupport
+{
+    private static readonly Lazy<string?> LazySkipReason = new(GetSkipReason);
+
+    /// <summary>
+    ///     The reason symlink tests cannot run here, or null when they can run.
+    /// </summary>
+    public static string? SkipReason => LazySkipReason.Value;
+
+    /// <summary>
+    ///     Creates a uniquely named directory for a symlink test under the same root the probe uses, so that the
+    ///     skip decision and the test itself exercise the same file system.
+    /// </summary>
+    /// <param name="prefix">A short prefix describing the test, used in the directory name.</param>
+    /// <returns>The path of the created directory.</returns>
+    public static string CreateTestRoot(string prefix)
+    {
+        var testRoot = Path.Combine(TestRootParent, $"{prefix}-{Guid.NewGuid()}");
+        Directory.CreateDirectory(testRoot);
+        return testRoot;
+    }
+
+    /// <summary>
+    ///     Deletes a directory created by <see cref="CreateTestRoot" />. Cleanup failures are ignored so that they
+    ///     cannot replace a genuine assertion failure when called from a finally block.
+    /// </summary>
+    /// <param name="testRoot">The directory to delete.</param>
+    public static void TryDeleteTestRoot(string testRoot)
+    {
+        try
+        {
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, true);
+            }
+        }
+        catch (Exception)
+        {
+            // Cleanup is best effort. Leaving a directory behind in TestOutput must not mask a test result.
+        }
+    }
+
+    // The tests write beneath the working directory, not the system temp directory, and the two can be different
+    // file systems with different symlink support. Probing here keeps the skip decision accurate.
+    private static string TestRootParent => "TestOutput";
+
+    private static string? GetSkipReason()
+    {
+        string testRoot;
+
+        try
+        {
+            Directory.CreateDirectory(TestRootParent);
+            testRoot = Path.Combine(TestRootParent, $"SymlinkProbe-{Guid.NewGuid()}");
+            Directory.CreateDirectory(testRoot);
+        }
+        catch (Exception ex)
+        {
+            return $"Could not create a directory to probe for symlink support: {ex.GetType().Name}: {ex.Message}";
+        }
+
+        try
+        {
+            var fileTarget = Path.Combine(testRoot, "target.txt");
+            var directoryTarget = Path.Combine(testRoot, "target-directory");
+            File.WriteAllText(fileTarget, string.Empty);
+            Directory.CreateDirectory(directoryTarget);
+            File.CreateSymbolicLink(Path.Combine(testRoot, "file-link"), fileTarget);
+            Directory.CreateSymbolicLink(Path.Combine(testRoot, "directory-link"), directoryTarget);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            // Catching broadly on purpose: this runs from a lazy initializer, and an unexpected exception type
+            // would otherwise surface as an opaque TypeInitializationException instead of a readable skip reason.
+            return $"Symlink creation is not available here: {ex.GetType().Name}: {ex.Message}";
+        }
+        finally
+        {
+            TryDeleteTestRoot(testRoot);
+        }
+    }
+}
+
+/// <summary>
+///     A <see cref="FactAttribute" /> that skips when the machine cannot create symbolic links.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class SymlinkFactAttribute : FactAttribute
+{
+    public SymlinkFactAttribute()
+    {
+        Skip = SymlinkTestSupport.SkipReason;
+    }
+}
+
+/// <summary>
+///     A <see cref="TheoryAttribute" /> that skips when the machine cannot create symbolic links.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class SymlinkTheoryAttribute : TheoryAttribute
+{
+    public SymlinkTheoryAttribute()
+    {
+        Skip = SymlinkTestSupport.SkipReason;
+    }
+}

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.IO.Enumeration;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -56,7 +57,11 @@ public class AnalyzeOptions
     /// </summary>
     public IEnumerable<string> FilePathExclusions { get; set; } = Array.Empty<string>();
     /// <summary>
-    ///     Follow symbolic links while enumerating source files.
+    ///     Follow symbolic links while enumerating source files. When false (the default), symbolic links found
+    ///     while traversing a source directory are skipped and recorded as skipped in the scan metadata. A link
+    ///     named directly in <see cref="SourcePath" /> is always scanned regardless of this setting.
+    ///     On Windows this also applies to other reparse points, including NTFS junctions and cloud placeholder
+    ///     files such as OneDrive Files On-Demand, which are skipped rather than rehydrated.
     /// </summary>
     public bool FollowSymlinks { get; set; }
     /// <summary>
@@ -198,6 +203,21 @@ public class AnalyzeResult : Result
 public class AnalyzeCommand
 {
     private const int ProgressBarUpdateDelay = 100;
+
+    /// <summary>
+    ///     Mirrors the behavior of <see cref="SearchOption.AllDirectories" />: recurse everywhere, surface
+    ///     inaccessible entries instead of hiding them, and do not filter on file attributes. Reparse points are
+    ///     handled by the predicates in <see cref="EnumerateSourceFiles" /> rather than by
+    ///     <see cref="EnumerationOptions.AttributesToSkip" />, so that skipped entries can still be reported.
+    /// </summary>
+    private static readonly EnumerationOptions SourceEnumerationOptions = new()
+    {
+        RecurseSubdirectories = true,
+        IgnoreInaccessible = false,
+        MatchType = MatchType.Win32,
+        AttributesToSkip = 0
+    };
+
     private readonly Confidence _confidence = Confidence.Unspecified;
 
     private readonly List<Glob> _fileExclusionList = new();
@@ -207,6 +227,7 @@ public class AnalyzeCommand
     private readonly Severity _severity = Severity.Unspecified;
     private readonly List<string> _srcfileList = new();
     private readonly Languages _languages = new();
+    private int _skippedLinkCount;
     private MetaDataHelper _metaDataHelper; //wrapper containing MetaData object to be assigned to result
     private readonly RuleProcessor _rulesProcessor;
 
@@ -242,23 +263,14 @@ public class AnalyzeCommand
         {
             // Turn any relative paths into absolute paths for consistent behavior with file name regexes in rules
             var entryFullPath = Path.GetFullPath(entry);
-            var directoryExists = Directory.Exists(entryFullPath);
-            var fileExists = File.Exists(entryFullPath);
-            if (directoryExists)
+            // Directory.Exists and File.Exists resolve links, so a link named directly in SourcePath is always
+            // scanned, even when FollowSymlinks is false. Refusing to scan a path the caller asked for by name
+            // would be more surprising than following it; only links reached by traversal are skipped.
+            if (Directory.Exists(entryFullPath))
             {
-                _srcfileList.AddRange(Directory.EnumerateFiles(entryFullPath, "*.*", new EnumerationOptions
-                {
-                    RecurseSubdirectories = true,
-                    IgnoreInaccessible = false,
-                    MatchType = MatchType.Win32,
-#if NETSTANDARD2_1
-                    AttributesToSkip = _options.FollowSymlinks ? 0 : FileAttributes.ReparsePoint
-#else
-                    AttributesToSkip = _options.FollowSymlinks ? FileAttributes.None : FileAttributes.ReparsePoint
-#endif
-                }));
+                _srcfileList.AddRange(EnumerateSourceFiles(entryFullPath));
             }
-            else if (fileExists)
+            else if (File.Exists(entryFullPath))
             {
                 _srcfileList.Add(entryFullPath);
             }
@@ -270,6 +282,13 @@ public class AnalyzeCommand
 
         if (_srcfileList.Count == 0)
         {
+            if (_skippedLinkCount > 0)
+            {
+                _logger.LogWarning(
+                    "No files to scan. {Count} symbolic link(s) or reparse point(s) were skipped; enable FollowSymlinks to include them.",
+                    _skippedLinkCount);
+            }
+
             throw new OpException(MsgHelp.FormatString(MsgHelp.ID.CMD_NO_FILES_IN_SOURCE,
                 string.Join(',', _options.SourcePath)));
         }
@@ -364,6 +383,83 @@ public class AnalyzeCommand
         };
 
         _rulesProcessor = new RuleProcessor(rulesSet, rpo);
+    }
+
+    /// <summary>
+    ///     Enumerates every file beneath <paramref name="directoryFullPath" />, skipping reparse points unless
+    ///     <see cref="AnalyzeOptions.FollowSymlinks" /> is set.
+    /// </summary>
+    /// <remarks>
+    ///     Filtering with <see cref="EnumerationOptions.AttributesToSkip" /> would discard the entries inside the
+    ///     runtime, leaving the scan unable to report what it skipped. Enumerating with explicit predicates keeps
+    ///     the skipped entries observable: skipped files are recorded as <see cref="ScanState.Skipped" /> and
+    ///     skipped directories are logged.
+    /// </remarks>
+    /// <param name="directoryFullPath">The absolute path of the directory to enumerate.</param>
+    /// <returns>The absolute paths of the files to scan.</returns>
+    private List<string> EnumerateSourceFiles(string directoryFullPath)
+    {
+        if (_options.FollowSymlinks)
+        {
+            return Directory.EnumerateFiles(directoryFullPath, "*.*", SourceEnumerationOptions).ToList();
+        }
+
+        // A "*.*" Win32 pattern matches every name, including names without a dot, so the enumerable applies no
+        // name filter and relies on the predicates below instead.
+        FileSystemEnumerable<string> enumerable = new(directoryFullPath,
+            static (ref FileSystemEntry entry) => entry.ToFullPath(),
+            SourceEnumerationOptions)
+        {
+            ShouldIncludePredicate = (ref FileSystemEntry entry) =>
+            {
+                if (entry.IsDirectory)
+                {
+                    return false;
+                }
+
+                if (!IsReparsePoint(ref entry))
+                {
+                    return true;
+                }
+
+                var fullPath = entry.ToFullPath();
+                _logger.LogDebug(
+                    "File skipped: symbolic link or other reparse point. Enable FollowSymlinks to scan it. {Path}",
+                    fullPath);
+                // Added to the helper's bag rather than Metadata.Files, because Metadata.Files is replaced from
+                // the bag when the report is prepared.
+                _metaDataHelper.Files.Add(new FileRecord { FileName = fullPath, Status = ScanState.Skipped });
+                _skippedLinkCount++;
+                return false;
+            },
+            ShouldRecursePredicate = (ref FileSystemEntry entry) =>
+            {
+                if (!IsReparsePoint(ref entry))
+                {
+                    return true;
+                }
+
+                _logger.LogDebug(
+                    "Directory not traversed: symbolic link or other reparse point. Enable FollowSymlinks to traverse it. {Path}",
+                    entry.ToFullPath());
+                _skippedLinkCount++;
+                return false;
+            }
+        };
+
+        // Materialized here because the predicates above log and mutate metadata, so the enumerable must not be
+        // walked more than once.
+        return enumerable.ToList();
+    }
+
+    /// <summary>
+    ///     Checks whether an entry is a reparse point. On Windows this covers NTFS junctions and cloud placeholder
+    ///     files (for example OneDrive Files On-Demand) in addition to symbolic links, all of which are skipped by
+    ///     default so that a scan does not traverse outside the source tree or rehydrate remote content.
+    /// </summary>
+    private static bool IsReparsePoint(ref FileSystemEntry entry)
+    {
+        return (entry.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
     }
 
     private DateTime DateScanned { get; }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.9",
+  "version": "1.10",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Follow-up to #647. Targets that PR's branch, so the diff here is only the review feedback.

#647 skips symlinks by default, which is the right default. The problem is how the skipping is implemented: `EnumerationOptions.AttributesToSkip` filters entries inside the runtime, so the scan never learns the entries existed. A skipped symlink produced no `FileRecord`, no log line, and a file count lower than the source tree, with nothing anywhere in the output explaining the gap. For a tool whose job is characterizing a codebase, a default that quietly reduces coverage with zero signal is the part worth fixing.

## Approach

Enumerate with `System.IO.Enumeration.FileSystemEnumerable<string>` and explicit predicates rather than an attribute filter. Same traversal, but the decision happens in our code, so we can report it:

- `ShouldIncludePredicate` records skipped files as `ScanState.Skipped` and logs at Debug. That flows into the existing `filesSkipped` report field for free.
- `ShouldRecursePredicate` blocks descent into linked directories and logs at Debug. There is no file to record for a directory.
- `FollowSymlinks = true` keeps the original `Directory.EnumerateFiles` path, so opting in is byte-for-byte the old behavior.

`FileSystemEnumerable` is available on netstandard2.1, so no TFM gymnastics are needed. Verified building all four target frameworks.

The shared `EnumerationOptions` still mirrors `CompatibleRecursive` (`MatchType.Win32`, `IgnoreInaccessible = false`, `AttributesToSkip = 0`), which is what makes `"*.*"` keep matching extensionless files.

## Worth a careful look

Records are added to `MetaDataHelper.Files`, not `Metadata.Files`. `PrepareReport` does `Metadata.Files = Files.ToList()`, replacing the list wholesale, so anything written to `Metadata.Files` during the constructor is discarded. The first version of this change used `Metadata.Files` and the records vanished. It only surfaced because the dangling-symlink test asserts on file names instead of a bare count.

## Other review items

- Documented that a link named directly in `SourcePath` is still scanned. `Directory.Exists` and `File.Exists` resolve links, and refusing a path the caller asked for by name would be more confusing than following it. This was already the behavior in #647 but was implicit in a test's expected count.
- Documented that reparse-point filtering also covers NTFS junctions and cloud placeholders such as OneDrive Files On-Demand. Skipping those is intentional: rehydrating thin cloud files during a scan is not a good default.
- Bumped `version.json` from 1.9 to 1.10. `AnalyzeOptions` ships in `Microsoft.CST.ApplicationInspector.Commands`, so existing library callers see a behavior change with no code change on their side. The wiki CLI page needs a matching edit, which has to happen outside this repo.
- Dropped the eager `File.Exists` (an extra stat per source path when the path is a directory) and the `NETSTANDARD2_1` guard, which was unnecessary because a literal `0` converts to the enum on every TFM.

## Tests

Moved the symlink support out of `TestAnalyzeCmd.cs` into its own file so `TestTagDiffCmd` can use it, and fixed the skip probe, which checked `Path.GetTempPath()` while the tests write under the working directory. Those can be different file systems, so the skip decision could be wrong in both directions.

Assertions now compare file names per `ScanState` rather than a single total, so a regression says which symlink shape broke. Added coverage for `TagDiffOptions.FollowSymlinks` reaching both of the `AnalyzeOptions` it builds, and for `--follow-symlinks` parsing on both verbs. Cleanup no longer throws from `finally`, where it could replace a real assertion failure.

356/356 tests pass. Verified end to end on a tree with a file link, a directory link, and a link target outside the source root:

```
default            totalFiles=2  analyzed=1  skipped=1
--follow-symlinks  totalFiles=3  analyzed=3  skipped=0
```

Both skips appear at Debug:

```
[DBG] File skipped: symbolic link or other reparse point. Enable FollowSymlinks to scan it. .../src/link.js
[DBG] Directory not traversed: symbolic link or other reparse point. Enable FollowSymlinks to traverse it. .../src/sub/linkdir
```