### PR TITLE
Make pattern-level conditions actually gate their pattern

### DIFF
--- a/AppInspector.RulesEngine/AbstractRuleSet.cs
+++ b/AppInspector.RulesEngine/AbstractRuleSet.cs
@@ -111,10 +111,10 @@ public abstract class AbstractRuleSet
             }            
 
             // Generate expression for pattern including its specific conditions
-            var pattern_expr = ProcessPatternWithConditions(pattern, clauses, ref clauseNumber);
-            if (pattern_expr != null)
+            var patternExpression = ProcessPatternWithConditions(pattern, clauses, ref clauseNumber);
+            if (patternExpression != null)
             {
-                patternExprs.Add(pattern_expr);
+                patternExprs.Add(patternExpression);
             }
             else
             {
@@ -310,39 +310,39 @@ public abstract class AbstractRuleSet
     /// <summary>
     ///     Process a single pattern and its associated conditions, building the expression and clauses.
     /// </summary>
-    private string? ProcessPatternWithConditions(SearchPattern patt, List<Clause> clausesList, ref int currClauseNum)
+    private string? ProcessPatternWithConditions(SearchPattern pattern, List<Clause> clauses, ref int currentClauseNumber)
     {
-        if (GenerateClause(patt, currClauseNum) is not { } primaryClause)
+        if (GenerateClause(pattern, currentClauseNumber) is not { } primaryClause)
         {
             return null;
         }
 
-        clausesList.Add(primaryClause);
-        var primaryNum = currClauseNum;
-        var exprText = new StringBuilder();
-        exprText.Append(primaryNum);
-        currClauseNum++;
+        clauses.Add(primaryClause);
+        var primaryNum = currentClauseNumber;
+        var expressionText = new StringBuilder();
+        expressionText.Append(primaryNum);
+        currentClauseNumber++;
 
         // Apply pattern-specific conditions if they exist
-        var specificConds = patt.Conditions;
-        if (specificConds is { Length: > 0 })
+        var specificConditions = pattern.Conditions;
+        if (specificConditions is { Length: > 0 })
         {
-            foreach (var specificCond in specificConds)
+            foreach (var specificCondition in specificConditions)
             {
-                var specificCondClause = GenerateCondition(specificCond, currClauseNum);
+                var specificCondClause = GenerateCondition(specificCondition, currentClauseNumber);
                 if (specificCondClause is not null)
                 {
-                    clausesList.Add(specificCondClause);
-                    exprText.Append(" AND ");
-                    exprText.Append(currClauseNum);
-                    currClauseNum++;
+                    clauses.Add(specificCondClause);
+                    expressionText.Append(" AND ");
+                    expressionText.Append(currentClauseNumber);
+                    currentClauseNumber++;
                 }
             }
             // Parenthesize when conditions are present
-            return $"({exprText})";
+            return $"({expressionText})";
         }
 
-        return exprText.ToString();
+        return expressionText.ToString();
     }
 
     /// <summary>

--- a/AppInspector.RulesEngine/AbstractRuleSet.cs
+++ b/AppInspector.RulesEngine/AbstractRuleSet.cs
@@ -76,8 +76,7 @@ public abstract class AbstractRuleSet
     public ConvertedOatRule? AppInspectorRuleToOatRule(Rule rule)
     {
         var clauses = new List<Clause>();
-        var clauseNumber = 0;
-        var expression = new StringBuilder("(");
+        var conditionNumber = 0;
         var patternExprs = new List<string>();
         var patternLabelCounter = 0;  // Stable pattern label, independent of clause numbering
 
@@ -111,8 +110,8 @@ public abstract class AbstractRuleSet
                 // "b" is a default option for regex engine, so no need to add "b" explicitly
             }            
 
-            // Pass stable pattern label (for pattern indexing) and running clause counter (for OAT expression) separately
-            var patternExpression = ProcessPatternWithConditions(pattern, clauses, patternLabelCounter, ref clauseNumber);
+            // Pass the stable pattern label (used for pattern indexing) and the running condition counter separately
+            var patternExpression = ProcessPatternWithConditions(pattern, clauses, patternLabelCounter, ref conditionNumber);
             if (patternExpression != null)
             {
                 patternExprs.Add(patternExpression);
@@ -124,25 +123,28 @@ public abstract class AbstractRuleSet
             }
         }
 
-        if (clauses.Count > 0)
-        {
-            expression.Append(string.Join(" OR ", patternExprs));
-            expression.Append(')');
-        }
-        else
+        if (clauses.Count == 0)
         {
             return new ConvertedOatRule(rule.Id, rule);
         }
 
+        var patternBody = string.Join(" OR ", patternExprs);
+        // OAT rejects any expression token that begins with more than one open parenthesis, so the pattern group is
+        // only wrapped when it does not already begin with one. That is safe because OAT evaluates expressions
+        // strictly left to right with no operator precedence, so the rule level conditions appended below still
+        // apply to the whole pattern group either way.
+        var expression = new StringBuilder(patternBody.StartsWith('(') ? patternBody : $"({patternBody})");
+
         foreach (var condition in rule.Conditions ?? Array.Empty<SearchCondition>())
         {
-            var clause = GenerateCondition(condition, clauseNumber);
+            var conditionLabel = ConditionLabel(conditionNumber);
+            var clause = GenerateCondition(condition, conditionLabel, null);
             if (clause is { })
             {
                 clauses.Add(clause);
                 expression.Append(" AND ");
-                expression.Append(clauseNumber);
-                clauseNumber++;
+                expression.Append(conditionLabel);
+                conditionNumber++;
             }
         }
 
@@ -153,7 +155,19 @@ public abstract class AbstractRuleSet
         };
     }
 
-    private Clause? GenerateCondition(SearchCondition condition, int clauseNumber)
+    /// <summary>
+    ///     Builds the OAT clause for a condition.
+    /// </summary>
+    /// <param name="condition">The condition to convert.</param>
+    /// <param name="clauseLabel">
+    ///     The label to give the clause. Conditions use their own label namespace so that they cannot collide with the
+    ///     numeric labels pattern clauses require.
+    /// </param>
+    /// <param name="ownerPatternIndex">
+    ///     The index of the pattern that declared this condition, or null when the condition is declared at rule level and
+    ///     therefore gates every pattern.
+    /// </param>
+    private Clause? GenerateCondition(SearchCondition condition, string clauseLabel, int? ownerPatternIndex)
     {
         if (condition.Pattern is { } conditionPattern)
         {
@@ -166,14 +180,9 @@ public abstract class AbstractRuleSet
             {
                 if (condition.SearchIn?.Equals("finding-only", StringComparison.InvariantCultureIgnoreCase) != false)
                 {
-                    return new WithinClause(subClause)
-                    {
-                        Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
-                        FindingOnly = true,
-                        Invert = condition.NegateFinding,
-                        LanguageAppliesTo = condition.AppliesTo,
-                        LanguageDoesNotApplyTo = condition.DoesNotApplyTo
-                    };
+                    var clause = NewWithinClause();
+                    clause.FindingOnly = true;
+                    return clause;
                 }
 
                 if (condition.SearchIn.StartsWith("finding-region", StringComparison.InvariantCultureIgnoreCase))
@@ -195,61 +204,36 @@ public abstract class AbstractRuleSet
 
                     if (argList.Count == 2)
                     {
-                        return new WithinClause(subClause)
-                        {
-                            Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
-                            FindingRegion = true,
-                            Before = argList[0],
-                            After = argList[1],
-                            Invert = condition.NegateFinding,
-                            LanguageAppliesTo = condition.AppliesTo,
-                            LanguageDoesNotApplyTo = condition.DoesNotApplyTo
-                        };
+                        var clause = NewWithinClause();
+                        clause.FindingRegion = true;
+                        clause.Before = argList[0];
+                        clause.After = argList[1];
+                        return clause;
                     }
                 }
                 else if (condition.SearchIn.Equals("same-line", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    return new WithinClause(subClause)
-                    {
-                        Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
-                        SameLineOnly = true,
-                        Invert = condition.NegateFinding,
-                        LanguageAppliesTo = condition.AppliesTo,
-                        LanguageDoesNotApplyTo = condition.DoesNotApplyTo
-                    };
+                    var clause = NewWithinClause();
+                    clause.SameLineOnly = true;
+                    return clause;
                 }
                 else if (condition.SearchIn.Equals("same-file", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    return new WithinClause(subClause)
-                    {
-                        Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
-                        SameFile = true,
-                        Invert = condition.NegateFinding,
-                        LanguageAppliesTo = condition.AppliesTo,
-                        LanguageDoesNotApplyTo = condition.DoesNotApplyTo
-                    };
+                    var clause = NewWithinClause();
+                    clause.SameFile = true;
+                    return clause;
                 }
                 else if (condition.SearchIn.Equals("only-before", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    return new WithinClause(subClause)
-                    {
-                        Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
-                        OnlyBefore = true,
-                        Invert = condition.NegateFinding,
-                        LanguageAppliesTo = condition.AppliesTo,
-                        LanguageDoesNotApplyTo = condition.DoesNotApplyTo
-                    };
+                    var clause = NewWithinClause();
+                    clause.OnlyBefore = true;
+                    return clause;
                 }
                 else if (condition.SearchIn.Equals("only-after", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    return new WithinClause(subClause)
-                    {
-                        Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
-                        OnlyAfter = true,
-                        Invert = condition.NegateFinding,
-                        LanguageAppliesTo = condition.AppliesTo,
-                        LanguageDoesNotApplyTo = condition.DoesNotApplyTo
-                    };
+                    var clause = NewWithinClause();
+                    clause.OnlyAfter = true;
+                    return clause;
                 }
                 else
                 {
@@ -257,10 +241,32 @@ public abstract class AbstractRuleSet
                         "Search condition {Condition} is not one of the accepted values and this condition will be ignored",
                         condition.SearchIn);
                 }
+
+                WithinClause NewWithinClause()
+                {
+                    return new WithinClause(subClause)
+                    {
+                        Label = clauseLabel,
+                        Invert = condition.NegateFinding,
+                        LanguageAppliesTo = condition.AppliesTo,
+                        LanguageDoesNotApplyTo = condition.DoesNotApplyTo,
+                        OwnerPatternIndex = ownerPatternIndex
+                    };
+                }
             }
         }
 
         return null;
+    }
+
+    /// <summary>
+    ///     Conditions are labelled in their own namespace. Pattern clauses must keep bare numeric labels because
+    ///     <see cref="OatExtensions.OatRegexWithIndexOperation" /> parses the label back into an index into the rule's
+    ///     patterns, so sharing a single counter between the two would both collide and shift pattern indexes.
+    /// </summary>
+    private static string ConditionLabel(int conditionNumber)
+    {
+        return "c" + conditionNumber.ToString(CultureInfo.InvariantCulture);
     }
 
     private Clause? GenerateClause(SearchPattern pattern, int clauseNumber = -1)
@@ -315,9 +321,9 @@ public abstract class AbstractRuleSet
     /// <param name="pattern">The search pattern to process</param>
     /// <param name="clauses">List of clauses to append to</param>
     /// <param name="patternLabel">Stable label for the pattern clause (used for pattern indexing)</param>
-    /// <param name="currentClauseNumber">Running counter for OAT expression clause numbering</param>
+    /// <param name="conditionNumber">Running counter used to label condition clauses</param>
     /// <returns>Expression string for this pattern and its conditions</returns>
-    private string? ProcessPatternWithConditions(SearchPattern pattern, List<Clause> clauses, int patternLabel, ref int currentClauseNumber)
+    private string? ProcessPatternWithConditions(SearchPattern pattern, List<Clause> clauses, int patternLabel, ref int conditionNumber)
     {
         // Generate the pattern clause with stable pattern label
         if (GenerateClause(pattern, patternLabel) is not { } primaryClause)
@@ -327,29 +333,28 @@ public abstract class AbstractRuleSet
 
         clauses.Add(primaryClause);
         var expressionText = new StringBuilder();
-        expressionText.Append(currentClauseNumber);
-        currentClauseNumber++;
+        expressionText.Append(patternLabel);
 
         // Apply pattern-specific conditions if they exist
-        var specificConditions = pattern.Conditions;
-        if (specificConditions is { Length: > 0 })
+        var addedCondition = false;
+        foreach (var specificCondition in pattern.Conditions ?? Array.Empty<SearchCondition>())
         {
-            foreach (var specificCondition in specificConditions)
+            var conditionLabel = ConditionLabel(conditionNumber);
+            if (GenerateCondition(specificCondition, conditionLabel, patternLabel) is not { } specificCondClause)
             {
-                var specificCondClause = GenerateCondition(specificCondition, currentClauseNumber);
-                if (specificCondClause is not null)
-                {
-                    clauses.Add(specificCondClause);
-                    expressionText.Append(" AND ");
-                    expressionText.Append(currentClauseNumber);
-                    currentClauseNumber++;
-                }
+                continue;
             }
-            // Parenthesize when conditions are present
-            return $"({expressionText})";
+
+            clauses.Add(specificCondClause);
+            expressionText.Append(" AND ");
+            expressionText.Append(conditionLabel);
+            conditionNumber++;
+            addedCondition = true;
         }
 
-        return expressionText.ToString();
+        // Parenthesize only when conditions were actually added, so that a pattern whose conditions all failed to
+        // generate does not produce a redundant group.
+        return addedCondition ? $"({expressionText})" : expressionText.ToString();
     }
 
     /// <summary>

--- a/AppInspector.RulesEngine/OatExtensions/WithinClause.cs
+++ b/AppInspector.RulesEngine/OatExtensions/WithinClause.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Microsoft.CST.OAT;
 
 namespace Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
@@ -21,4 +22,14 @@ public class WithinClause : Clause
     public bool SameLineOnly { get; set; }
     public bool FindingRegion { get; set; }
     public Clause SubClause { get; }
+    
+    /// <summary>
+    /// Languages where this condition applies. Empty means applies to all (except those in LanguageDoesNotApplyTo).
+    /// </summary>
+    public IList<string>? LanguageAppliesTo { get; set; }
+    
+    /// <summary>
+    /// Languages where this condition does not apply.
+    /// </summary>
+    public IList<string>? LanguageDoesNotApplyTo { get; set; }
 }

--- a/AppInspector.RulesEngine/OatExtensions/WithinClause.cs
+++ b/AppInspector.RulesEngine/OatExtensions/WithinClause.cs
@@ -22,6 +22,12 @@ public class WithinClause : Clause
     public bool SameLineOnly { get; set; }
     public bool FindingRegion { get; set; }
     public Clause SubClause { get; }
+
+    /// <summary>
+    ///     Index of the pattern that declared this condition, or null when the condition was declared at rule level.
+    ///     A rule level condition gates every pattern in the rule; a pattern level condition gates only its own pattern.
+    /// </summary>
+    public int? OwnerPatternIndex { get; set; }
     
     /// <summary>
     /// Languages where this condition applies. Empty means applies to all (except those in LanguageDoesNotApplyTo).

--- a/AppInspector.RulesEngine/OatExtensions/WithinOperation.cs
+++ b/AppInspector.RulesEngine/OatExtensions/WithinOperation.cs
@@ -29,7 +29,8 @@ public class WithinOperation : OatOperation
     {
         if (c is WithinClause wc && state1 is TextContainer tc)
         {
-            // Skip condition evaluation if it doesn't apply to current language
+            // Skip condition evaluation if it doesn't apply to current language.
+            // Returning true allows the pattern match to succeed since the condition is not applicable.
             if (!ConditionAppliesToLanguage(wc, tc.Language))
             {
                 // Pass through the captures unchanged since condition is not applicable

--- a/AppInspector.RulesEngine/OatExtensions/WithinOperation.cs
+++ b/AppInspector.RulesEngine/OatExtensions/WithinOperation.cs
@@ -29,31 +29,17 @@ public class WithinOperation : OatOperation
     {
         if (c is WithinClause wc && state1 is TextContainer tc)
         {
-            // Skip condition evaluation if it doesn't apply to current language.
-            // Returning true allows the pattern match to succeed since the condition is not applicable.
+            var governed = GovernedMatches(wc, captures);
+
+            // A condition that does not apply to this file's language still has to produce a capture, because
+            // RuleProcessor needs one gate per declared condition to know which matches have been vetted. This gate
+            // passes through everything the condition governs, so it filters nothing. Building it from the governed
+            // matches rather than from whatever captures happen to have accumulated keeps the result independent of
+            // the order the conditions are declared in.
             if (!ConditionAppliesToLanguage(wc, tc.Language))
             {
-                // Build a no-op within-filter capture that preserves all incoming tuples
-                if (captures is null)
-                {
-                    return new OperationResult(true);
-                }
-
-                var allTuples = new List<(int, Boundary)>();
-                foreach (var capture in captures)
-                {
-                    if (capture is TypedClauseCapture<List<(int, Boundary)>> tcc && tcc.Result is not null)
-                    {
-                        allTuples.AddRange(tcc.Result);
-                    }
-                }
-
-                ClauseCapture? withinCapture =
-                    allTuples.Any()
-                        ? new TypedClauseCapture<List<(int, Boundary)>>(wc, allTuples)
-                        : null;
-
-                return new OperationResult(true, withinCapture);
+                return new OperationResult(true,
+                    governed.Count > 0 ? new TypedClauseCapture<List<(int, Boundary)>>(wc, governed) : null);
             }
 
             var passed =
@@ -61,109 +47,92 @@ public class WithinOperation : OatOperation
             var failed =
                 new List<(int, Boundary)>();
 
-            foreach (var capture in captures ?? Array.Empty<ClauseCapture>())
+            foreach ((var clauseNum, var boundary) in governed)
             {
-                // Each condition filters the raw pattern matches independently; RuleProcessor then
-                // intersects the surviving matches to AND the conditions together. Consuming another
-                // condition's already-filtered capture here would double count matches and break that
-                // intersection.
-                if (capture.Clause is WithinClause)
+                var boundaryToCheck = GetBoundaryToCheck();
+                if (boundaryToCheck is not null)
                 {
-                    continue;
+                    var operationResult = ProcessLambda(boundaryToCheck);
+                    if (operationResult.Result)
+                    {
+                        passed.Add((clauseNum, boundary));
+                    }
+                    else
+                    {
+                        failed.Add((clauseNum, boundary));
+                    }
                 }
 
-                if (capture is TypedClauseCapture<List<(int, Boundary)>> tcc)
+                Boundary? GetBoundaryToCheck()
                 {
-                    foreach ((var clauseNum, var boundary) in tcc.Result)
+                    if (wc.FindingOnly)
                     {
-                        var boundaryToCheck = GetBoundaryToCheck();
-                        if (boundaryToCheck is not null)
-                        {
-                            var operationResult = ProcessLambda(boundaryToCheck);
-                            if (operationResult.Result)
-                            {
-                                passed.Add((clauseNum, boundary));
-                            }
-                            else
-                            {
-                                failed.Add((clauseNum, boundary));
-                            }
-                        }
-
-                        Boundary? GetBoundaryToCheck()
-                        {
-                            if (wc.FindingOnly)
-                            {
-                                return boundary;
-                            }
-
-                            if (wc.SameLineOnly)
-                            {
-                                var startInner = tc.LineStarts[tc.GetLocation(boundary.Index).Line];
-                                var endInner = tc.LineEnds[tc.GetLocation(startInner + (boundary.Length - 1)).Line];
-                                return new Boundary
-                                {
-                                    Index = startInner,
-                                    Length = endInner - startInner + 1
-                                };
-                            }
-
-                            if (wc.FindingRegion)
-                            {
-                                var startLine = tc.GetLocation(boundary.Index).Line;
-                                // Before is already a negative number
-                                var startInner = tc.LineStarts[Math.Max(1, startLine + wc.Before)];
-                                var endInner = tc.LineEnds[Math.Min(tc.LineEnds.Count - 1, startLine + wc.After)];
-                                return new Boundary
-                                {
-                                    Index = startInner,
-                                    Length = endInner - startInner + 1
-                                };
-                            }
-
-                            if (wc.SameFile)
-                            {
-                                var startInner = tc.LineStarts[0];
-                                var endInner = tc.LineEnds[^1];
-                                return new Boundary
-                                {
-                                    Index = startInner,
-                                    Length = endInner - startInner + 1
-                                };
-                            }
-
-                            if (wc.OnlyBefore)
-                            {
-                                var startInner = tc.LineStarts[0];
-                                var endInner = boundary.Index;
-                                return new Boundary
-                                {
-                                    Index = startInner,
-                                    Length = endInner - startInner + 1
-                                };
-                            }
-
-                            if (wc.OnlyAfter)
-                            {
-                                var startInner = boundary.Index + boundary.Length;
-                                var endInner = tc.LineEnds[^1];
-                                return new Boundary
-                                {
-                                    Index = startInner,
-                                    Length = endInner - startInner + 1
-                                };
-                            }
-
-                            return null;
-                        }
+                        return boundary;
                     }
+
+                    if (wc.SameLineOnly)
+                    {
+                        var startInner = tc.LineStarts[tc.GetLocation(boundary.Index).Line];
+                        var endInner = tc.LineEnds[tc.GetLocation(startInner + (boundary.Length - 1)).Line];
+                        return new Boundary
+                        {
+                            Index = startInner,
+                            Length = endInner - startInner + 1
+                        };
+                    }
+
+                    if (wc.FindingRegion)
+                    {
+                        var startLine = tc.GetLocation(boundary.Index).Line;
+                        // Before is already a negative number
+                        var startInner = tc.LineStarts[Math.Max(1, startLine + wc.Before)];
+                        var endInner = tc.LineEnds[Math.Min(tc.LineEnds.Count - 1, startLine + wc.After)];
+                        return new Boundary
+                        {
+                            Index = startInner,
+                            Length = endInner - startInner + 1
+                        };
+                    }
+
+                    if (wc.SameFile)
+                    {
+                        var startInner = tc.LineStarts[0];
+                        var endInner = tc.LineEnds[^1];
+                        return new Boundary
+                        {
+                            Index = startInner,
+                            Length = endInner - startInner + 1
+                        };
+                    }
+
+                    if (wc.OnlyBefore)
+                    {
+                        var startInner = tc.LineStarts[0];
+                        var endInner = boundary.Index;
+                        return new Boundary
+                        {
+                            Index = startInner,
+                            Length = endInner - startInner + 1
+                        };
+                    }
+
+                    if (wc.OnlyAfter)
+                    {
+                        var startInner = boundary.Index + boundary.Length;
+                        var endInner = tc.LineEnds[^1];
+                        return new Boundary
+                        {
+                            Index = startInner,
+                            Length = endInner - startInner + 1
+                        };
+                    }
+
+                    return null;
                 }
             }
 
-            // Each pattern clause in the rule contributes its own capture, so every capture must be
-            // evaluated before returning. Returning inside the loop would discard the matches of every
-            // pattern clause after the first, causing multi-pattern rules with a condition to report
-            // only the findings of their first pattern.
+            // The governed list is built from every pattern capture the clause was handed, so all of a rule's
+            // patterns are filtered rather than only the first one.
             var passedOrFailed = wc.Invert ? failed : passed;
             return new OperationResult(passedOrFailed.Any(),
                 passedOrFailed.Any()
@@ -177,6 +146,47 @@ public class WithinOperation : OatOperation
         }
 
         return new OperationResult(false);
+    }
+
+    /// <summary>
+    ///     The pattern matches this condition is responsible for filtering.
+    /// </summary>
+    /// <remarks>
+    ///     Two kinds of capture are excluded. Captures produced by another <see cref="WithinClause" /> are skipped
+    ///     because each condition filters the raw pattern matches independently and <c>RuleProcessor</c> intersects the
+    ///     survivors to AND the conditions together; consuming an already filtered capture would double count matches
+    ///     and break that intersection. Matches belonging to another pattern are skipped for a pattern level condition,
+    ///     because OAT hands a clause every capture accumulated so far, which for a later pattern in the rule includes
+    ///     the captures of the patterns before it.
+    /// </remarks>
+    private static List<(int, Boundary)> GovernedMatches(WithinClause wc, IEnumerable<ClauseCapture>? captures)
+    {
+        var governed = new List<(int, Boundary)>();
+        var seen = new HashSet<(int, Boundary)>();
+
+        foreach (var capture in captures ?? Array.Empty<ClauseCapture>())
+        {
+            if (capture.Clause is WithinClause || capture is not TypedClauseCapture<List<(int, Boundary)>> tcc ||
+                tcc.Result is null)
+            {
+                continue;
+            }
+
+            foreach (var match in tcc.Result)
+            {
+                if (wc.OwnerPatternIndex is { } owner && match.Item1 != owner)
+                {
+                    continue;
+                }
+
+                if (seen.Add(match))
+                {
+                    governed.Add(match);
+                }
+            }
+        }
+
+        return governed;
     }
 
     public IEnumerable<Violation> WithinValidationDelegate(CST.OAT.Rule rule, Clause clause)

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -151,8 +151,8 @@ public class RuleProcessor
         var caps = _analyzer.GetCaptures(rules, textContainer);
         foreach (var ruleCapture in caps)
         {
-            var netCaptures = FilterCaptures(ruleCapture.Captures);
             var oatRule = ruleCapture.Rule as ConvertedOatRule;
+            var netCaptures = FilterCaptures(ruleCapture.Captures);
             foreach (var match in netCaptures)
             {
                 var patternIndex = match.Item1;
@@ -200,35 +200,83 @@ public class RuleProcessor
                 resultsList.Add(newMatch);
             }
 
-            // If a WithinClause capture is present, use only within captures, otherwise just flattens the list of results from the non-within clause.
+            // Conditions produce "gates": the subset of pattern matches that satisfied that condition. A rule level
+            // condition gates every match; a pattern level condition gates only the matches of its own pattern. A
+            // match survives if it is in every gate that applies to it.
             List<(int, Boundary)> FilterCaptures(List<ClauseCapture> captures)
             {
-                // If we had a WithinClause we only want the captures that passed the within filter.
-                if (captures.Any(x => x.Clause is WithinClause))
+                var ruleGates = new List<HashSet<(int, Boundary)>>();
+                var patternGates = new Dictionary<int, List<HashSet<(int, Boundary)>>>();
+                var allMatches = new List<(int, Boundary)>();
+                var seen = new HashSet<(int, Boundary)>();
+
+                foreach (var capture in captures)
                 {
-                    var onlyWithinCaptures = captures.Where(x => x.Clause is WithinClause)
-                        .Cast<TypedClauseCapture<List<(int, Boundary)>>>().ToList();
-                    var allCaptured = onlyWithinCaptures.SelectMany(x => x.Result);
-                    ConcurrentDictionary<(int, Boundary), int> numberOfInstances = new();
-                    // If there are multiple within clauses ensure that we only return matches which passed all clauses
-                    // WithinClauses are always ANDed, but each contains all the captures that passed *that* clause.
-                    // We need the captures that passed every clause.
-                    foreach (var aCapture in allCaptured)
+                    if (capture is not TypedClauseCapture<List<(int, Boundary)>> tcc || tcc.Result is null)
                     {
-                        numberOfInstances.AddOrUpdate(aCapture, 1, (tuple, i) => i + 1);
+                        continue;
                     }
-                    return numberOfInstances.Where(x => x.Value == onlyWithinCaptures.Count).Select(x => x.Key)
-                        .ToList();
+
+                    if (capture.Clause is WithinClause withinClause)
+                    {
+                        var gate = new HashSet<(int, Boundary)>(tcc.Result);
+                        if (withinClause.OwnerPatternIndex is { } owner)
+                        {
+                            if (!patternGates.TryGetValue(owner, out var gatesForPattern))
+                            {
+                                gatesForPattern = new List<HashSet<(int, Boundary)>>();
+                                patternGates[owner] = gatesForPattern;
+                            }
+
+                            gatesForPattern.Add(gate);
+                        }
+                        else
+                        {
+                            ruleGates.Add(gate);
+                        }
+                    }
+                    else
+                    {
+                        foreach (var match in tcc.Result)
+                            if (seen.Add(match))
+                            {
+                                allMatches.Add(match);
+                            }
+                    }
                 }
 
-                var outList = new List<(int, Boundary)>();
-                foreach (var cap in captures)
-                    if (cap is TypedClauseCapture<List<(int, Boundary)>> tcc)
+                if (ruleGates.Count == 0 && patternGates.Count == 0)
+                {
+                    return allMatches;
+                }
+
+                // A condition that failed outright contributes no gate. Its pattern's matches must still be dropped,
+                // so compare against the conditions the rule declares rather than only the gates that materialized.
+                var declaredGates = ruleCapture.Rule.Clauses.OfType<WithinClause>().ToList();
+                if (ruleGates.Count != declaredGates.Count(x => x.OwnerPatternIndex is null))
+                {
+                    return new List<(int, Boundary)>();
+                }
+
+                return allMatches.Where(Survives).ToList();
+
+                bool Survives((int, Boundary) match)
+                {
+                    if (!ruleGates.All(gate => gate.Contains(match)))
                     {
-                        outList.AddRange(tcc.Result);
+                        return false;
                     }
 
-                return outList;
+                    var declaredForPattern = declaredGates.Count(x => x.OwnerPatternIndex == match.Item1);
+                    if (declaredForPattern == 0)
+                    {
+                        return true;
+                    }
+
+                    return patternGates.TryGetValue(match.Item1, out var gatesForPattern) &&
+                           gatesForPattern.Count == declaredForPattern &&
+                           gatesForPattern.All(gate => gate.Contains(match));
+                }
             }
         }
 

--- a/AppInspector.RulesEngine/SearchCondition.cs
+++ b/AppInspector.RulesEngine/SearchCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.ApplicationInspector.RulesEngine;
@@ -14,4 +15,16 @@ public class SearchCondition
 
     [JsonPropertyName("search_in")]
     public string? SearchIn { get; set; }
+
+    /// <summary>
+    ///     Restricts condition to specified languages. When empty, applies broadly (except DoesNotApplyTo).
+    /// </summary>
+    [JsonPropertyName("applies_to")]
+    public IList<string>? AppliesTo { get; set; }
+
+    /// <summary>
+    ///     Prevents condition from being evaluated for specified languages.
+    /// </summary>
+    [JsonPropertyName("does_not_apply_to")]
+    public IList<string>? DoesNotApplyTo { get; set; }
 }

--- a/AppInspector.RulesEngine/SearchPattern.cs
+++ b/AppInspector.RulesEngine/SearchPattern.cs
@@ -55,4 +55,10 @@ public class SearchPattern
     /// </summary>
     [JsonPropertyName("ymlpaths")]
     public string[]? YamlPaths { get; set; }
+
+    /// <summary>
+    ///     Per-pattern conditions. When pattern matches and conditions are present, conditions must be satisfied.
+    /// </summary>
+    [JsonPropertyName("conditions")]
+    public SearchCondition[]? Conditions { get; set; }
 }

--- a/AppInspector.Tests/RuleProcessor/PatternConditionsTests.cs
+++ b/AppInspector.Tests/RuleProcessor/PatternConditionsTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.CST.RecursiveExtractor;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -188,5 +189,135 @@ public class PatternConditionsTests
         Assert.NotNull(rule.Conditions[0].DoesNotApplyTo);
         Assert.Contains("python", rule.Conditions[0].DoesNotApplyTo);
         Assert.Contains("ruby", rule.Conditions[0].DoesNotApplyTo);
+    }
+
+    /// <summary>
+    /// Pattern-level conditions should only restrict the pattern they are attached to.
+    /// This test uses RuleProcessor to ensure that a pattern without conditions still matches.
+    /// </summary>
+    [Fact]
+    public void PatternLevelConditions_OnlyAffectAttachedPattern()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST005"",
+        ""name"": ""Pattern-level Condition Runtime Test"",
+        ""tags"": [""Test.PatternLevelCondition.Runtime""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""foo"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": {""pattern"": ""bar"", ""type"": ""regex""},
+                        ""search_in"": ""same-file""
+                    }
+                ]
+            },
+            {
+                ""pattern"": ""baz"",
+                ""type"": ""regex""
+            }
+        ]
+    }
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+
+        // Use RuleProcessor to analyze content that only contains "baz".
+        // The first pattern ("foo") has a condition requiring "bar" in the same file,
+        // so it should not match, while the second pattern ("baz") should match.
+        var processor = new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(ruleSet, new RuleProcessorOptions());
+
+        const string fileName = "test.js";
+        const string fileContent = "this line contains baz but not the other tokens";
+
+        // Derive a language from the file name; JavaScript is a reasonable choice here.
+        if (_languages.FromFileNameOut(fileName, out var languageInfo))
+        {
+            var matches = processor.AnalyzeFile(fileContent, new FileEntry(fileName, new System.IO.MemoryStream()), languageInfo);
+
+            // We expect exactly one match, corresponding to the second pattern ("baz").
+            Assert.Single(matches);
+            Assert.Contains(matches, m => m.MatchingPattern.Pattern == "baz");
+            Assert.DoesNotContain(matches, m => m.MatchingPattern.Pattern == "foo");
+        }
+        else
+        {
+            Assert.Fail("Failed to get language info");
+        }
+    }
+
+    /// <summary>
+    /// Language filters on conditions should control whether the condition is evaluated
+    /// based on the file language. When the file language is not listed in applies_to,
+    /// the condition should be skipped and not block pattern matches.
+    /// </summary>
+    [Fact]
+    public void LanguageFilters_RuntimeBehavior_AppliesToAndDoesNotApplyTo()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST006"",
+        ""name"": ""Language Filter Runtime Test"",
+        ""tags"": [""Test.LanguageFilter.Runtime""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""test_token"",
+                ""type"": ""regex""
+            }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": {""pattern"": ""javascript_only"", ""type"": ""regex""},
+                ""search_in"": ""same-file"",
+                ""applies_to"": [""javascript""],
+                ""does_not_apply_to"": [""python""]
+            }
+        ]
+    }
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+
+        var processor = new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(ruleSet, new RuleProcessorOptions());
+
+        const string contentWithBothTokens = "test_token javascript_only";
+        const string contentWithPatternOnly = "test_token no_language_marker";
+
+        // Analyze as JavaScript: condition applies (applies_to includes "javascript"),
+        // so the presence of "javascript_only" should be required for a match.
+        const string jsFileName = "file.js";
+        if (_languages.FromFileNameOut(jsFileName, out var jsLanguage))
+        {
+            var jsResultWithBoth = processor.AnalyzeFile(contentWithBothTokens, new FileEntry(jsFileName, new System.IO.MemoryStream()), jsLanguage);
+            var jsResultWithPatternOnly = processor.AnalyzeFile(contentWithPatternOnly, new FileEntry(jsFileName, new System.IO.MemoryStream()), jsLanguage);
+
+            Assert.Single(jsResultWithBoth);
+            Assert.Empty(jsResultWithPatternOnly);
+        }
+        else
+        {
+            Assert.Fail("Failed to get JavaScript language info");
+        }
+
+        // Analyze as Python: condition should be skipped (does_not_apply_to includes "python"),
+        // so the pattern should match even without the "javascript_only" token.
+        const string pyFileName = "file.py";
+        if (_languages.FromFileNameOut(pyFileName, out var pyLanguage))
+        {
+            var pyResultWithPatternOnly = processor.AnalyzeFile(contentWithPatternOnly, new FileEntry(pyFileName, new System.IO.MemoryStream()), pyLanguage);
+
+            Assert.Single(pyResultWithPatternOnly);
+            Assert.Contains(pyResultWithPatternOnly, m => m.MatchingPattern.Pattern == "test_token");
+        }
+        else
+        {
+            Assert.Fail("Failed to get Python language info");
+        }
     }
 }

--- a/AppInspector.Tests/RuleProcessor/PatternConditionsTests.cs
+++ b/AppInspector.Tests/RuleProcessor/PatternConditionsTests.cs
@@ -1,0 +1,192 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+[ExcludeFromCodeCoverage]
+public class PatternConditionsTests
+{
+    private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
+    
+    /// <summary>
+    /// Test that pattern-level conditions are parsed correctly
+    /// </summary>
+    [Fact]
+    public void PatternConditions_ParsingTest()
+    {
+        // Rule with two patterns, each with their own condition
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST001"",
+        ""name"": ""Pattern Conditions Test"",
+        ""tags"": [""Test.PatternConditions""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""foo"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": {""pattern"": ""bar"", ""type"": ""regex""},
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            },
+            {
+                ""pattern"": ""baz"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": {""pattern"": ""qux"", ""type"": ""regex""},
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            }
+        ]
+    }
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+        
+        var rules = ruleSet.GetAppInspectorRules().ToList();
+        Assert.Single(rules);
+        
+        var rule = rules.First();
+        Assert.Equal(2, rule.Patterns.Length);
+        
+        // Check that first pattern has a condition
+        Assert.NotNull(rule.Patterns[0].Conditions);
+        Assert.Single(rule.Patterns[0].Conditions);
+        
+        // Check that second pattern has a condition
+        Assert.NotNull(rule.Patterns[1].Conditions);
+        Assert.Single(rule.Patterns[1].Conditions);
+    }
+
+    /// <summary>
+    /// Test that pattern-level conditions match correctly - basic JSON parsing test
+    /// </summary>
+    [Fact]
+    public void PatternConditions_SimpleParsing()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST002"",
+        ""name"": ""Pattern Match Test"",
+        ""tags"": [""Test.PatternMatch""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""foo"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": {""pattern"": ""bar"", ""type"": ""regex""},
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            }
+        ]
+    }
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+
+        var rules = ruleSet.GetAppInspectorRules().ToList();
+        Assert.Single(rules);
+        
+        // Verify the pattern has conditions
+        var rule = rules.First();
+        Assert.NotNull(rule.Patterns[0].Conditions);
+        Assert.Single(rule.Patterns[0].Conditions);
+        Assert.Equal("bar", rule.Patterns[0].Conditions[0].Pattern?.Pattern);
+    }
+
+    /// <summary>
+    /// Test that language filters work on conditions
+    /// </summary>
+    [Fact]
+    public void LanguageFilters_AppliesToTest()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST003"",
+        ""name"": ""Language Filter Test"",
+        ""tags"": [""Test.LanguageFilter""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""test"",
+                ""type"": ""regex""
+            }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": {""pattern"": ""javascript"", ""type"": ""regex""},
+                ""search_in"": ""same-file"",
+                ""applies_to"": [""javascript""]
+            }
+        ]
+    }
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+        
+        var rules = ruleSet.GetAppInspectorRules().ToList();
+        Assert.Single(rules);
+        
+        var rule = rules.First();
+        Assert.NotNull(rule.Conditions);
+        Assert.Single(rule.Conditions);
+        Assert.NotNull(rule.Conditions[0].AppliesTo);
+        Assert.Contains("javascript", rule.Conditions[0].AppliesTo);
+    }
+
+    /// <summary>
+    /// Test that language filters work with does_not_apply_to
+    /// </summary>
+    [Fact]
+    public void LanguageFilters_DoesNotApplyToTest()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST004"",
+        ""name"": ""Language Exclusion Test"",
+        ""tags"": [""Test.LanguageExclusion""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""test"",
+                ""type"": ""regex""
+            }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": {""pattern"": ""specific"", ""type"": ""regex""},
+                ""search_in"": ""same-file"",
+                ""does_not_apply_to"": [""python"", ""ruby""]
+            }
+        ]
+    }
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+        
+        var rules = ruleSet.GetAppInspectorRules().ToList();
+        Assert.Single(rules);
+        
+        var rule = rules.First();
+        Assert.NotNull(rule.Conditions);
+        Assert.Single(rule.Conditions);
+        Assert.NotNull(rule.Conditions[0].DoesNotApplyTo);
+        Assert.Contains("python", rule.Conditions[0].DoesNotApplyTo);
+        Assert.Contains("ruby", rule.Conditions[0].DoesNotApplyTo);
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/PatternConditionsTests.cs
+++ b/AppInspector.Tests/RuleProcessor/PatternConditionsTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
 using Microsoft.CST.RecursiveExtractor;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -145,8 +146,9 @@ public class PatternConditionsTests
         var rule = rules.First();
         Assert.NotNull(rule.Conditions);
         Assert.Single(rule.Conditions);
-        Assert.NotNull(rule.Conditions[0].AppliesTo);
-        Assert.Contains("javascript", rule.Conditions[0].AppliesTo);
+        var appliesTo = rule.Conditions[0].AppliesTo;
+        Assert.NotNull(appliesTo);
+        Assert.Contains("javascript", appliesTo);
     }
 
     /// <summary>
@@ -186,9 +188,10 @@ public class PatternConditionsTests
         var rule = rules.First();
         Assert.NotNull(rule.Conditions);
         Assert.Single(rule.Conditions);
-        Assert.NotNull(rule.Conditions[0].DoesNotApplyTo);
-        Assert.Contains("python", rule.Conditions[0].DoesNotApplyTo);
-        Assert.Contains("ruby", rule.Conditions[0].DoesNotApplyTo);
+        var doesNotApplyTo = rule.Conditions[0].DoesNotApplyTo;
+        Assert.NotNull(doesNotApplyTo);
+        Assert.Contains("python", doesNotApplyTo);
+        Assert.Contains("ruby", doesNotApplyTo);
     }
 
     /// <summary>
@@ -226,13 +229,11 @@ public class PatternConditionsTests
         var ruleSet = new RuleSet(NullLoggerFactory.Instance);
         ruleSet.AddString(ruleJson, "test");
 
-        // Use RuleProcessor to analyze content that only contains "baz".
-        // The first pattern ("foo") has a condition requiring "bar" in the same file,
-        // so it should not match, while the second pattern ("baz") should match.
+        // "foo" is present but its condition requires "bar" in the same file, so only "baz" is reported.
         var processor = new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(ruleSet, new RuleProcessorOptions());
 
         const string fileName = "test.js";
-        const string fileContent = "this line contains baz but not the other tokens";
+        const string fileContent = "this line contains foo and baz but not the other token";
 
         // Derive a language from the file name; JavaScript is a reasonable choice here.
         if (_languages.FromFileNameOut(fileName, out var languageInfo))
@@ -319,5 +320,291 @@ public class PatternConditionsTests
         {
             Assert.Fail("Failed to get Python language info");
         }
+    }
+
+    private string[] Analyze(string ruleJson, string fileName, string content)
+    {
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+        var processor = new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(ruleSet,
+            new RuleProcessorOptions { Parallel = false });
+
+        Assert.True(_languages.FromFileNameOut(fileName, out var languageInfo), $"No language for {fileName}");
+
+        return processor
+            .AnalyzeFile(content, new FileEntry(fileName, new System.IO.MemoryStream()), languageInfo)
+            .Select(x => x.MatchingPattern?.Pattern ?? string.Empty)
+            .OrderBy(x => x)
+            .ToArray();
+    }
+
+    /// <summary>
+    ///     A pattern carrying a condition must still match when that condition is satisfied. Without this the
+    ///     negative-direction tests above would pass for the wrong reason, because a conditioned pattern that can
+    ///     never match also never produces a false positive.
+    /// </summary>
+    [Fact]
+    public void PatternLevelCondition_MatchesWhenConditionIsSatisfied()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST100"",
+        ""name"": ""Conditioned pattern positive case"",
+        ""tags"": [""Test.PatternLevelCondition.Positive""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""foo"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""bar"", ""type"": ""regex"" },
+                        ""search_in"": ""same-file""
+                    }
+                ]
+            },
+            { ""pattern"": ""baz"", ""type"": ""regex"" }
+        ]
+    }
+]";
+
+        Assert.Equal(new[] { "baz", "foo" }, Analyze(ruleJson, "test.js", "foo bar baz"));
+        Assert.Equal(new[] { "baz" }, Analyze(ruleJson, "test.js", "foo baz"));
+        Assert.Equal(new[] { "foo" }, Analyze(ruleJson, "test.js", "foo bar"));
+    }
+
+    /// <summary>
+    ///     A condition attached to one pattern must not gate the rule's other patterns.
+    /// </summary>
+    [Fact]
+    public void PatternLevelCondition_DoesNotGateSiblingPatterns()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST101"",
+        ""name"": ""Conditioned middle pattern"",
+        ""tags"": [""Test.PatternLevelCondition.Siblings""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            { ""pattern"": ""alpha"", ""type"": ""regex"" },
+            {
+                ""pattern"": ""beta"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""gate"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            },
+            { ""pattern"": ""gamma"", ""type"": ""regex"" }
+        ]
+    }
+]";
+
+        // The condition is satisfied, so all three patterns report.
+        Assert.Equal(new[] { "alpha", "beta", "gamma" },
+            Analyze(ruleJson, "test.js", "alpha\nbeta gate\ngamma"));
+
+        // The condition is not satisfied, so only the unconditioned siblings report.
+        Assert.Equal(new[] { "alpha", "gamma" },
+            Analyze(ruleJson, "test.js", "alpha\nbeta\ngamma"));
+    }
+
+    /// <summary>
+    ///     A rule level condition gates every pattern, including patterns that carry their own conditions.
+    /// </summary>
+    [Fact]
+    public void RuleLevelAndPatternLevelConditionsCombine()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST102"",
+        ""name"": ""Rule and pattern level conditions"",
+        ""tags"": [""Test.PatternLevelCondition.Combined""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""alpha"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""gate"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            },
+            { ""pattern"": ""beta"", ""type"": ""regex"" }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""enabled"", ""type"": ""regex"" },
+                ""search_in"": ""same-file""
+            }
+        ]
+    }
+]";
+
+        // Rule level condition satisfied, pattern level condition satisfied.
+        Assert.Equal(new[] { "alpha", "beta" }, Analyze(ruleJson, "test.js", "enabled\nalpha gate\nbeta"));
+
+        // Rule level condition satisfied, pattern level condition not; beta is unaffected.
+        Assert.Equal(new[] { "beta" }, Analyze(ruleJson, "test.js", "enabled\nalpha\nbeta"));
+
+        // Rule level condition not satisfied, so nothing reports regardless of the pattern level condition.
+        Assert.Empty(Analyze(ruleJson, "test.js", "alpha gate\nbeta"));
+    }
+
+    /// <summary>
+    ///     When every pattern carries its own condition, each pattern is gated independently: one pattern failing its
+    ///     condition must not suppress another whose condition was satisfied.
+    /// </summary>
+    [Fact]
+    public void PatternLevelConditions_GateEachPatternIndependently()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST105"",
+        ""name"": ""Both patterns conditioned"",
+        ""tags"": [""Test.PatternLevelCondition.Independent""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""alpha"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""gateA"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            },
+            {
+                ""pattern"": ""beta"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""gateB"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            }
+        ]
+    }
+]";
+
+        Assert.Equal(new[] { "alpha", "beta" }, Analyze(ruleJson, "test.js", "alpha gateA\nbeta gateB"));
+        Assert.Equal(new[] { "alpha" }, Analyze(ruleJson, "test.js", "alpha gateA\nbeta"));
+        Assert.Equal(new[] { "beta" }, Analyze(ruleJson, "test.js", "alpha\nbeta gateB"));
+        Assert.Empty(Analyze(ruleJson, "test.js", "alpha\nbeta"));
+
+        // Each pattern is gated by its own condition, not by the other pattern's.
+        Assert.Empty(Analyze(ruleJson, "test.js", "alpha gateB\nbeta gateA"));
+    }
+
+    /// <summary>
+    ///     A condition that is skipped for the file's language must not change the outcome of the conditions
+    ///     declared alongside it, whichever order they appear in.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void LanguageSkippedCondition_IsOrderIndependent(bool skippedConditionFirst)
+    {
+        const string realCondition = @"{
+                        ""pattern"": { ""pattern"": ""gate"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line""
+                    }";
+        const string skippedCondition = @"{
+                        ""pattern"": { ""pattern"": ""never"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line"",
+                        ""applies_to"": [ ""python"" ]
+                    }";
+
+        var conditions = skippedConditionFirst
+            ? $"{skippedCondition}, {realCondition}"
+            : $"{realCondition}, {skippedCondition}";
+
+        var ruleJson = $@"[
+    {{
+        ""id"": ""TEST103"",
+        ""name"": ""Skipped condition ordering"",
+        ""tags"": [""Test.PatternLevelCondition.SkipOrder""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {{
+                ""pattern"": ""alpha"",
+                ""type"": ""regex"",
+                ""conditions"": [ {conditions} ]
+            }}
+        ]
+    }}
+]";
+
+        // The skipped condition filters nothing, so the real condition alone decides the outcome.
+        Assert.Equal(new[] { "alpha" }, Analyze(ruleJson, "test.js", "alpha gate"));
+        Assert.Empty(Analyze(ruleJson, "test.js", "alpha"));
+    }
+
+    /// <summary>
+    ///     The OAT rules generated for conditions must be well formed. OAT silently refuses to evaluate an
+    ///     expression whose label matches more than one clause, so a malformed rule fails by never matching rather
+    ///     than by raising an error.
+    /// </summary>
+    [Theory]
+    [InlineData("first pattern conditioned", true, false, false, "(0 AND c0) OR 1")]
+    [InlineData("second pattern conditioned", false, true, false, "(0 OR (1 AND c0))")]
+    [InlineData("both patterns conditioned", true, true, false, "(0 AND c0) OR (1 AND c1)")]
+    [InlineData("no conditions", false, false, false, "(0 OR 1)")]
+    [InlineData("rule level only", false, false, true, "(0 OR 1) AND c0")]
+    [InlineData("pattern and rule level", true, false, true, "(0 AND c0) OR 1 AND c1")]
+    public void GeneratedOatRulesAreWellFormed(string because, bool conditionOnFirst, bool conditionOnSecond,
+        bool ruleLevelCondition, string expectedExpression)
+    {
+        const string condition = @",
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""gate"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line""
+                    }
+                ]";
+
+        var ruleLevel = ruleLevelCondition
+            ? @",
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""enabled"", ""type"": ""regex"" },
+                ""search_in"": ""same-file""
+            }
+        ]"
+            : string.Empty;
+
+        var ruleJson = $@"[
+    {{
+        ""id"": ""TEST104"",
+        ""name"": ""Well formed generated rule"",
+        ""tags"": [""Test.PatternLevelCondition.WellFormed""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {{ ""pattern"": ""alpha"", ""type"": ""regex""{(conditionOnFirst ? condition : string.Empty)} }},
+            {{ ""pattern"": ""beta"", ""type"": ""regex""{(conditionOnSecond ? condition : string.Empty)} }}
+        ]{ruleLevel}
+    }}
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+        var oatRule = Assert.Single(ruleSet.GetOatRules());
+
+        Assert.Equal(expectedExpression, oatRule.Expression);
+
+        // Clause labels must be unique, and every label in the expression must resolve to a clause.
+        var analyzer = new ApplicationInspectorAnalyzer();
+        var violations = analyzer.EnumerateRuleIssues(oatRule).Select(x => x.Description).ToList();
+        Assert.True(violations.Count == 0, $"{because}: {string.Join("; ", violations)}");
+
+        // Pattern clauses keep the bare numeric labels the pattern index is recovered from.
+        var patternLabels = oatRule.Clauses.Where(x => x is not WithinClause).Select(x => x.Label).ToArray();
+        Assert.Equal(new[] { "0", "1" }, patternLabels);
     }
 }

--- a/rule-schema-v1.json
+++ b/rule-schema-v1.json
@@ -263,7 +263,7 @@
         },
         "search_in": {
           "type": "string",
-          "pattern": "^(file|finding-region\\(-?\\d+,\\d+\\)|finding-only|same-line|same-file)$",
+          "pattern": "^(finding-region\\(-?\\d+,\\d+\\)|finding-only|same-line|same-file|only-before|only-after)$",
           "description": "Where to search for the condition"
         },
         "negate_finding": {

--- a/rule-schema-v1.json
+++ b/rule-schema-v1.json
@@ -240,6 +240,16 @@
             { "type": "null" }
           ],
           "description": "YAMLPath expressions for YAML matching"
+        },
+        "conditions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": { "$ref": "#/definitions/searchCondition" }
+            },
+            { "type": "null" }
+          ],
+          "description": "Pattern-specific conditions that must be met when this pattern matches"
         }
       }
     },
@@ -260,6 +270,26 @@
           "type": "boolean",
           "default": false,
           "description": "Whether to negate the condition"
+        },
+        "applies_to": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            { "type": "null" }
+          ],
+          "description": "Languages this condition applies to"
+        },
+        "does_not_apply_to": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            { "type": "null" }
+          ],
+          "description": "Languages this condition does not apply to"
         }
       }
     }


### PR DESCRIPTION
Supersedes #636. Stacked on #650 — **review that first**; this PR's diff will collapse once #650 merges.

Contains #636's commits plus the fixes below.

## The problem

Pattern-level conditions as merged in the draft did not work. Any rule using them generated an OAT rule that OAT itself rejected, so the rule silently never matched anything. Nothing in the existing test suite caught this because #636's tests only assert that the *JSON deserializes* — they never run the rule against source and check the findings.

Four defects, each independently fatal.

### 1. Label collision between patterns and conditions

Pattern clauses must keep bare numeric labels: `OatRegexWithIndexOperation` does `Convert.ToInt32(clause.Label)` to index back into `Rule.Patterns[]`, and `RuleProcessor` uses that index to attribute a finding to a pattern.

Conditions were drawing from the same counter, so a rule with two patterns where the first is conditioned produced labels `0`, `1` (the condition), `1` (the second pattern). OAT's `Analyzer.Evaluate` hits the duplicate and returns `(false, null)`, failing the entire rule. Even without a collision, a condition consumed a number and shifted every later pattern's index.

Conditions now get their own `c{n}` namespace, so the two counters can't interact.

### 2. Generated expressions contained an illegal `((` token

The expression was seeded with `"("` and each conditioned pattern group added its own, yielding `((0 AND 1) OR 2)`. OAT's validator rejects any token that begins with two open parens (`Err_ClauseParenthesis`), and a bare `(` token is invalid too, so there's no whitespace workaround.

The outer group is now added only when the pattern body doesn't already start with `(`. That's safe because OAT evaluates strictly left-to-right with no operator precedence — `(A) OR B AND C` ≡ `((A) OR B) AND C` — so rule-level conditions still apply to the whole pattern group either way.

Note: OAT's rejection of `((0` is arguably a validator bug (the expression evaluates fine at runtime). Worth reporting upstream separately; this PR just avoids emitting the shape.

### 3. `FilterCaptures` treated every condition as rule-level

`FilterCaptures` intersected every within-capture against every match, so a condition attached to one pattern suppressed findings from its siblings — the exact opposite of what pattern-level conditions are for.

Conditions now carry `OwnerPatternIndex`, and `FilterCaptures` intersects each match only against the gates that apply to it: rule-level gates apply to everything, pattern-level gates only to their own pattern.

One subtlety: a condition that fails outright contributes no capture at all, so counting materialized gates isn't enough — its pattern's raw matches would leak through. The check compares against the conditions the rule *declares* (`Rule.Clauses.OfType<WithinClause>()`).

### 4. The language-skip path was order dependent

When a condition doesn't apply to the file's language, `WithinOperation` returned whatever captures had accumulated so far. Because OAT unions captures as it evaluates, a *later* condition's "skip" saw earlier patterns' matches and passed them through as if vetted.

The skip path now emits a pass-through gate built from the matches that condition actually governs, so a skipped condition is a no-op regardless of where it's declared. A gate is still emitted (rather than nothing) so `FilterCaptures` can distinguish "vetted" from "never evaluated".

## Verification

Generated expressions, now asserted in `GeneratedOatRulesAreWellFormed` along with `EnumerateRuleIssues` returning zero violations for each:

| layout | expression |
|---|---|
| first pattern conditioned | `(0 AND c0) OR 1` |
| second pattern conditioned | `(0 OR (1 AND c0))` |
| both conditioned | `(0 AND c0) OR (1 AND c1)` |
| no conditions | `(0 OR 1)` |
| rule-level only | `(0 OR 1) AND c0` |
| rule-level + pattern-level | `(0 AND c0) OR 1 AND c1` |

New runtime tests cover the satisfied and unsatisfied paths, sibling independence, per-pattern independent gating, rule- and pattern-level conditions combined, and order independence of language-skipped conditions. All nine fail on the pre-fix baseline.

- Full suite: 368/368 (355 before this PR's tests)
- `verifyrules -r AppInspector/rules/default/`: `TAGTEST_RESULTS_SUCCESS`, zero failing rules
- Builds clean on net8.0/net9.0/net10.0/netstandard2.1

## Out of scope

`RulesVerifier.CheckIntegrity` validates `rule.Conditions` but not `pattern.Conditions`, condition language names aren't validated against known languages, and the schema doesn't recurse into nested pattern conditions. Those are follow-ups.
