### PR TITLE
Allow explicitly targeted rules in build files

### DIFF
--- a/AppInspector.CLI/CLICmdOptions.cs
+++ b/AppInspector.CLI/CLICmdOptions.cs
@@ -154,7 +154,7 @@ public record CLIAnalyzeCmdOptions : CLIAnalysisSharedCommandOptions
     public bool NoFileMetadata { get; set; }
 
     [Option('A', "allow-all-tags-in-build-files", Required = false,
-        HelpText = "Allow all tags (not just Metadata tags) in files of type Build.")]
+        HelpText = "Allow non-Metadata tags from universal rules in Build files. Rules declaring applies_to or applies_to_file_regex are always eligible.")]
     public bool AllowAllTagsInBuildFiles { get; set; }
 
     [Option('M', "max-num-matches-per-tag", Required = false,

--- a/AppInspector.RulesEngine/AbstractRuleSet.cs
+++ b/AppInspector.RulesEngine/AbstractRuleSet.cs
@@ -63,9 +63,7 @@ public abstract class AbstractRuleSet
     /// <returns></returns>
     public IEnumerable<ConvertedOatRule> GetUniversalRules()
     {
-        return _oatRules.Where(x =>
-            (x.AppInspectorRule.FileRegexes is null || x.AppInspectorRule.FileRegexes.Count == 0) &&
-            (x.AppInspectorRule.AppliesTo is null || x.AppInspectorRule.AppliesTo.Count == 0));
+        return _oatRules.Where(x => x.AppInspectorRule.IsUniversal);
     }
 
     /// <summary>

--- a/AppInspector.RulesEngine/Rule.cs
+++ b/AppInspector.RulesEngine/Rule.cs
@@ -96,6 +96,14 @@ namespace Microsoft.ApplicationInspector.RulesEngine
                 _updateCompiledFileRegex = true;
             }
         }
+
+        /// <summary>
+        ///     Gets whether the rule applies universally instead of declaring a target language or file name.
+        /// </summary>
+        [JsonIgnore]
+        public bool IsUniversal =>
+            (FileRegexes is null || FileRegexes.Count == 0) &&
+            (AppliesTo is null || AppliesTo.Count == 0);
         
         /// <summary>
         ///     Internal API to cache construction of <see cref="FileRegexes"/>

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -157,8 +157,10 @@ public class RuleProcessor
             {
                 var patternIndex = match.Item1;
                 var boundary = match.Item2;
-                //restrict adds from build files to tags with "metadata" only to avoid false feature positives that are not part of executable code
-                if (!_opts.AllowAllTagsInBuildFiles && languageInfo.Type == LanguageInfo.LangFileType.Build &&
+                // Universal rules can reach build files incidentally, so suppress their non-Metadata tags by default.
+                if (!_opts.AllowAllTagsInBuildFiles &&
+                    languageInfo.Type == LanguageInfo.LangFileType.Build &&
+                    oatRule.AppInspectorRule.IsUniversal &&
                     (oatRule.AppInspectorRule.Tags?.Any(v => !v.Contains("Metadata")) ?? false))
                 {
                     continue;
@@ -366,9 +368,10 @@ public class RuleProcessor
                                 var patternIndex = match.Item1;
                                 var boundary = match.Item2;
 
-                                //restrict adds from build files to tags with "metadata" only to avoid false feature positives that are not part of executable code
+                                // Universal rules can reach build files incidentally, so suppress their non-Metadata tags by default.
                                 if (!_opts.AllowAllTagsInBuildFiles &&
                                     languageInfo.Type == LanguageInfo.LangFileType.Build &&
+                                    oatRule.AppInspectorRule.IsUniversal &&
                                     (oatRule.AppInspectorRule.Tags?.Any(v => !v.Contains("Metadata")) ?? false))
                                 {
                                     continue;

--- a/AppInspector.Tests/RuleProcessor/BuildFileRuleTests.cs
+++ b/AppInspector.Tests/RuleProcessor/BuildFileRuleTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.CST.RecursiveExtractor;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+public class BuildFileRuleTests
+{
+    private const string BuildFileContents = "{\"value\":\"build-marker\"}";
+    private const string BuildFileName = "test.json";
+    private const string FeatureTag = "Testing.Build.Feature";
+    private const string Marker = "build-marker";
+    private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExplicitBuildLanguageRuleEmitsFeatureTagByDefault(bool analyzeAsync)
+    {
+        var languageInfo = GetBuildLanguage();
+        var rule = CreateRule("BUILD000001", new[] { languageInfo.Name });
+
+        var matches = await AnalyzeAsync(rule, languageInfo, false, analyzeAsync);
+
+        var match = Assert.Single(matches);
+        Assert.Equal(FeatureTag, Assert.Single(match.Rule!.Tags!));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task UniversalBuildRuleEmitsFeatureTagOnlyWhenAllowed(bool analyzeAsync)
+    {
+        var languageInfo = GetBuildLanguage();
+        var rule = CreateRule("BUILD000002");
+
+        var defaultMatches = await AnalyzeAsync(rule, languageInfo, false, analyzeAsync);
+        var allowedMatches = await AnalyzeAsync(rule, languageInfo, true, analyzeAsync);
+
+        Assert.Empty(defaultMatches);
+        var match = Assert.Single(allowedMatches);
+        Assert.Equal(FeatureTag, Assert.Single(match.Rule!.Tags!));
+    }
+
+    private static async Task<List<MatchRecord>> AnalyzeAsync(Rule rule, LanguageInfo languageInfo,
+        bool allowAllTagsInBuildFiles, bool analyzeAsync)
+    {
+        RuleSet rules = new();
+        rules.AddRule(rule);
+        Microsoft.ApplicationInspector.RulesEngine.RuleProcessor processor = new(rules,
+            new RuleProcessorOptions { AllowAllTagsInBuildFiles = allowAllTagsInBuildFiles });
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(BuildFileContents));
+        FileEntry fileEntry = new(BuildFileName, stream);
+
+        return analyzeAsync
+            ? await processor.AnalyzeFileAsync(fileEntry, languageInfo)
+            : processor.AnalyzeFile(BuildFileContents, fileEntry, languageInfo);
+    }
+
+    private static Rule CreateRule(string id, string[]? appliesTo = null)
+    {
+        return new Rule
+        {
+            Id = id,
+            Name = "Build file filtering test",
+            AppliesTo = appliesTo,
+            Tags = new[] { FeatureTag },
+            Patterns = new[]
+            {
+                new SearchPattern
+                {
+                    Pattern = Marker,
+                    PatternType = PatternType.Substring,
+                    Confidence = Confidence.High
+                }
+            }
+        };
+    }
+
+    private LanguageInfo GetBuildLanguage()
+    {
+        Assert.True(_languages.FromFileNameOut(BuildFileName, out var languageInfo));
+        Assert.Equal(LanguageInfo.LangFileType.Build, languageInfo.Type);
+        return languageInfo;
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/XmlAndJsonTests.cs
+++ b/AppInspector.Tests/RuleProcessor/XmlAndJsonTests.cs
@@ -62,7 +62,7 @@ public class XmlAndJsonTests
         RuleSet rules = new();
         rules.AddString(rule, "TestRules");
         Microsoft.ApplicationInspector.RulesEngine.RuleProcessor processor = new(rules,
-            new RuleProcessorOptions { AllowAllTagsInBuildFiles = true });
+            new RuleProcessorOptions());
         
         if (_languages.FromFileNameOut("pom.xml", out var info))
         {
@@ -347,7 +347,7 @@ public class XmlAndJsonTests
         //var verification= verifier.Verify(rules);
         //Assert.Equal(true,verification.Verified);
         Microsoft.ApplicationInspector.RulesEngine.RuleProcessor processor = new(rules,
-            new RuleProcessorOptions { AllowAllTagsInBuildFiles = true });
+            new RuleProcessorOptions());
         if (_languages.FromFileNameOut("AndroidManifest.xml", out var info))
         {
             var matches = processor.AnalyzeFile(@"<?xml version=""1.0"" encoding=""utf-8""?><manifest xmlns:android=""http://schemas.android.com/apk/res/android"" xmlns=""http://maven.apache.org/POM/4.0.0""><application android:debuggable='true' /></manifest>", new FileEntry("AndroidManifest.xml", new MemoryStream()), info);
@@ -390,7 +390,7 @@ public class XmlAndJsonTests
         RuleSet rules = new();
         rules.AddString(attributeRule, "JsonTestRules");
         Microsoft.ApplicationInspector.RulesEngine.RuleProcessor processor = new(rules,
-            new RuleProcessorOptions { AllowAllTagsInBuildFiles = true });
+            new RuleProcessorOptions());
         if (_languages.FromFileNameOut("test.config", out var info))
         {
             var matches = processor.AnalyzeFile(attributeContent, new FileEntry("test.config", new MemoryStream()), info);

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -61,8 +61,8 @@ public class AnalyzeOptions
     public bool SingleThread { get; set; }
 
     /// <summary>
-    ///     Treat <see cref="LanguageInfo.LangFileType.Build" /> files as if they were
-    ///     <see cref="LanguageInfo.LangFileType.Code" /> when determining if tags should apply.
+    ///     Allow universal rules to emit non-Metadata tags in <see cref="LanguageInfo.LangFileType.Build" /> files.
+    ///     Rules declaring applies_to or applies_to_file_regex are always eligible.
     /// </summary>
     public bool AllowAllTagsInBuildFiles { get; set; }
 


### PR DESCRIPTION
## Summary

- Factor the existing universal-rule predicate into `Rule.IsUniversal` and reuse it from rule selection and both processing paths.
- Preserve build-file noise suppression for universal rules, while allowing rules that explicitly declare `applies_to` or `applies_to_file_regex` to emit non-Metadata tags without `-A`.
- Clarify `--allow-all-tags-in-build-files`, add synchronous and asynchronous regression coverage, and remove three now-unnecessary test workarounds.

## Background

The build-file filter was intended to prevent generic feature rules from producing incidental findings in build/configuration files. Because it applied to every matching rule, it also suppressed rules deliberately scoped to build languages or filenames, making 22 default rules silent unless users supplied `-A`.

The project's XML tests were also working around this behavior with `AllowAllTagsInBuildFiles = true`; the overrides are now removed where those rules explicitly target `pom.xml`, `AndroidManifest.xml`, or `.config` files. Universal JSON/XML tests retain the option.

## Revived default rules

- CI: `AI002100` TravisCI, `AI002200` CircleCI, `AI002300` Azure Pipelines, `AI017300` Bamboo
- Build tools: `AI016800` Maven, `AI016900` Ant, `AI017000` Gradle, `AI017100` Jenkins, `AI017200` SBT, `AI017600` Ivy, `AI017700` Leiningen, `AI017800` VisualStudio
- Platforms: `AI028500` NETCore, `AI028600` NETStandard, `AI028700` Mono
- AI libraries: `AI070003` GenerativeAI, `AI070302` MCP
- Other explicitly targeted rules: `AI002600` Azure DataStorage, `AI011700` Oracle SQL, `AI031565` Hashicorp Packer, `AI034700` OS ACL Write Unsafe, `AI041800` Ava

## Behavior change

Scans can now report additional tags from rules that explicitly target build-type files. Universal rules remain filtered in build files by default, so the original anti-noise behavior is preserved; `-A` only opts universal rules into non-Metadata findings.

Scanning this repository with the old and fixed engines against the same source tree using `--no-file-metadata` changed `uniqueTags` from 76 to 79. No tags were removed; these were added:

- `CloudServices.Code.CI.Microsoft.Azure` (`AI002300`)
- `Development.Build.VisualStudio` (`AI017800`)
- `Platform.Microsoft.NETStandard` (`AI028600`)

## Validation

- `dotnet build` succeeded.
- The `.travis.yml` / `pom.xml` / `.csproj` / `build.gradle` repro emits `CloudServices.Code.CI.TravisCI`, `Development.Build.Maven`, and `Platform.Microsoft.NETStandard` without `-A`; the universal `Application.Target.Framework` tag remains suppressed.
- `dotnet test AppInspector.Tests/AppInspector.Tests.csproj -f net9.0`: 351 passed, 0 failed.

PR #651 ("Add WebApp.API ruleset for detecting exposed HTTP/REST APIs") depends on this fix and will be rebased onto this branch.