### PR TITLE
Boolean expression support in the rules engine

### DIFF
--- a/AppInspector.CLI/Writers/VerifyRulesTextWriter.cs
+++ b/AppInspector.CLI/Writers/VerifyRulesTextWriter.cs
@@ -40,8 +40,30 @@ internal class VerifyRulesTextWriter : CommandResultsWriter
         {
             TextWriter.WriteLine("Rule status");
             foreach (var ruleStatus in verifyRulesResult.RuleStatusList)
+            {
                 TextWriter.WriteLine("Ruleid: {0}, Rulename: {1}, Status: {2}", ruleStatus.RulesId,
                     ruleStatus.RulesName, ruleStatus.Verified);
+
+                if (ruleStatus.Verified)
+                {
+                    continue;
+                }
+
+                foreach (var error in ruleStatus.Errors)
+                {
+                    TextWriter.WriteLine("    Error: {0}", error);
+                }
+
+                foreach (var oatIssue in ruleStatus.OatIssues)
+                {
+                    TextWriter.WriteLine("    OAT issue: {0}", oatIssue.Description);
+                }
+
+                foreach (var schemaError in ruleStatus.SchemaValidationErrors)
+                {
+                    TextWriter.WriteLine("    Schema error: {0}", schemaError.Message);
+                }
+            }
         }
 
         if (autoClose)

--- a/AppInspector.RulesEngine/AbstractRuleSet.cs
+++ b/AppInspector.RulesEngine/AbstractRuleSet.cs
@@ -156,13 +156,24 @@ public abstract class AbstractRuleSet
             return new ConvertedOatRule(rule.Id, rule);
         }
 
-        // An authored expression replaces the generated pattern-OR, condition-AND shape.
+        // An authored expression is a per-finding predicate, applied by the RuleProcessor. The engine is only asked
+        // whether the file is worth examining, so it gets a plain disjunction of every clause: a superset of the
+        // authored expression that still forces each clause to run and contribute its captures. Handing the engine
+        // the authored expression instead would evaluate NOT file-wide, letting one compliant finding suppress
+        // sibling findings that individually satisfy the rule.
+        if (!string.IsNullOrWhiteSpace(rule.Expression))
+        {
+            return new ConvertedOatRule(rule.Id, rule)
+            {
+                Clauses = clauses,
+                Expression = string.Join(" OR ", clauses.Select(clause => clause.Label))
+            };
+        }
+
         return new ConvertedOatRule(rule.Id, rule)
         {
             Clauses = clauses,
-            Expression = string.IsNullOrWhiteSpace(rule.Expression)
-                ? generatedExpression.ToString()
-                : rule.Expression
+            Expression = generatedExpression.ToString()
         };
     }
 

--- a/AppInspector.RulesEngine/AbstractRuleSet.cs
+++ b/AppInspector.RulesEngine/AbstractRuleSet.cs
@@ -74,8 +74,9 @@ public abstract class AbstractRuleSet
     public ConvertedOatRule? AppInspectorRuleToOatRule(Rule rule)
     {
         var clauses = new List<Clause>();
-        var clauseNumber = 0;
-        var expression = new StringBuilder("(");
+        var conditionNumber = 0;
+        var patternExprs = new List<string>();
+        var patternLabelCounter = 0;  // Stable pattern label, independent of clause numbering
 
         foreach (var pattern in rule.Patterns)
         {
@@ -107,16 +108,12 @@ public abstract class AbstractRuleSet
                 // "b" is a default option for regex engine, so no need to add "b" explicitly
             }            
 
-            if (GenerateClause(pattern, clauseNumber) is { } clause)
+            // Pass the stable pattern label (used for pattern indexing) and the running condition counter separately
+            var patternExpression = ProcessPatternWithConditions(pattern, clauses, patternLabelCounter, ref conditionNumber);
+            if (patternExpression != null)
             {
-                clauses.Add(clause);
-                if (clauseNumber > 0)
-                {
-                    expression.Append(" OR ");
-                }
-
-                expression.Append(clauseNumber);
-                clauseNumber++;
+                patternExprs.Add(patternExpression);
+                patternLabelCounter++;
             }
             else
             {
@@ -124,24 +121,28 @@ public abstract class AbstractRuleSet
             }
         }
 
-        if (clauses.Count > 0)
-        {
-            expression.Append(')');
-        }
-        else
+        if (clauses.Count == 0)
         {
             return new ConvertedOatRule(rule.Id, rule);
         }
 
+        var patternBody = string.Join(" OR ", patternExprs);
+        // OAT rejects any expression token that begins with more than one open parenthesis, so the pattern group is
+        // only wrapped when it does not already begin with one. That is safe because OAT evaluates expressions
+        // strictly left to right with no operator precedence, so the rule level conditions appended below still
+        // apply to the whole pattern group either way.
+        var expression = new StringBuilder(patternBody.StartsWith('(') ? patternBody : $"({patternBody})");
+
         foreach (var condition in rule.Conditions ?? Array.Empty<SearchCondition>())
         {
-            var clause = GenerateCondition(condition, clauseNumber);
+            var conditionLabel = ConditionLabel(conditionNumber);
+            var clause = GenerateCondition(condition, conditionLabel, null);
             if (clause is { })
             {
                 clauses.Add(clause);
                 expression.Append(" AND ");
-                expression.Append(clauseNumber);
-                clauseNumber++;
+                expression.Append(conditionLabel);
+                conditionNumber++;
             }
         }
 
@@ -152,7 +153,19 @@ public abstract class AbstractRuleSet
         };
     }
 
-    private Clause? GenerateCondition(SearchCondition condition, int clauseNumber)
+    /// <summary>
+    ///     Builds the OAT clause for a condition.
+    /// </summary>
+    /// <param name="condition">The condition to convert.</param>
+    /// <param name="clauseLabel">
+    ///     The label to give the clause. Conditions use their own label namespace so that they cannot collide with the
+    ///     numeric labels pattern clauses require.
+    /// </param>
+    /// <param name="ownerPatternIndex">
+    ///     The index of the pattern that declared this condition, or null when the condition is declared at rule level and
+    ///     therefore gates every pattern.
+    /// </param>
+    private Clause? GenerateCondition(SearchCondition condition, string clauseLabel, int? ownerPatternIndex)
     {
         if (condition.Pattern is { } conditionPattern)
         {
@@ -165,12 +178,9 @@ public abstract class AbstractRuleSet
             {
                 if (condition.SearchIn?.Equals("finding-only", StringComparison.InvariantCultureIgnoreCase) != false)
                 {
-                    return new WithinClause(subClause)
-                    {
-                        Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
-                        FindingOnly = true,
-                        Invert = condition.NegateFinding
-                    };
+                    var clause = NewWithinClause();
+                    clause.FindingOnly = true;
+                    return clause;
                 }
 
                 if (condition.SearchIn.StartsWith("finding-region", StringComparison.InvariantCultureIgnoreCase))
@@ -192,51 +202,36 @@ public abstract class AbstractRuleSet
 
                     if (argList.Count == 2)
                     {
-                        return new WithinClause(subClause)
-                        {
-                            Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
-                            FindingRegion = true,
-                            Before = argList[0],
-                            After = argList[1],
-                            Invert = condition.NegateFinding
-                        };
+                        var clause = NewWithinClause();
+                        clause.FindingRegion = true;
+                        clause.Before = argList[0];
+                        clause.After = argList[1];
+                        return clause;
                     }
                 }
                 else if (condition.SearchIn.Equals("same-line", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    return new WithinClause(subClause)
-                    {
-                        Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
-                        SameLineOnly = true,
-                        Invert = condition.NegateFinding
-                    };
+                    var clause = NewWithinClause();
+                    clause.SameLineOnly = true;
+                    return clause;
                 }
                 else if (condition.SearchIn.Equals("same-file", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    return new WithinClause(subClause)
-                    {
-                        Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
-                        SameFile = true,
-                        Invert = condition.NegateFinding
-                    };
+                    var clause = NewWithinClause();
+                    clause.SameFile = true;
+                    return clause;
                 }
                 else if (condition.SearchIn.Equals("only-before", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    return new WithinClause(subClause)
-                    {
-                        Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
-                        OnlyBefore = true,
-                        Invert = condition.NegateFinding
-                    };
+                    var clause = NewWithinClause();
+                    clause.OnlyBefore = true;
+                    return clause;
                 }
                 else if (condition.SearchIn.Equals("only-after", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    return new WithinClause(subClause)
-                    {
-                        Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
-                        OnlyAfter = true,
-                        Invert = condition.NegateFinding
-                    };
+                    var clause = NewWithinClause();
+                    clause.OnlyAfter = true;
+                    return clause;
                 }
                 else
                 {
@@ -244,10 +239,32 @@ public abstract class AbstractRuleSet
                         "Search condition {Condition} is not one of the accepted values and this condition will be ignored",
                         condition.SearchIn);
                 }
+
+                WithinClause NewWithinClause()
+                {
+                    return new WithinClause(subClause)
+                    {
+                        Label = clauseLabel,
+                        Invert = condition.NegateFinding,
+                        LanguageAppliesTo = condition.AppliesTo,
+                        LanguageDoesNotApplyTo = condition.DoesNotApplyTo,
+                        OwnerPatternIndex = ownerPatternIndex
+                    };
+                }
             }
         }
 
         return null;
+    }
+
+    /// <summary>
+    ///     Conditions are labelled in their own namespace. Pattern clauses must keep bare numeric labels because
+    ///     <see cref="OatExtensions.OatRegexWithIndexOperation" /> parses the label back into an index into the rule's
+    ///     patterns, so sharing a single counter between the two would both collide and shift pattern indexes.
+    /// </summary>
+    private static string ConditionLabel(int conditionNumber)
+    {
+        return "c" + conditionNumber.ToString(CultureInfo.InvariantCulture);
     }
 
     private Clause? GenerateClause(SearchPattern pattern, int clauseNumber = -1)
@@ -294,6 +311,48 @@ public abstract class AbstractRuleSet
         }
 
         return null;
+    }
+
+    /// <summary>
+    ///     Process a single pattern and its associated conditions, building the expression and clauses.
+    /// </summary>
+    /// <param name="pattern">The search pattern to process</param>
+    /// <param name="clauses">List of clauses to append to</param>
+    /// <param name="patternLabel">Stable label for the pattern clause (used for pattern indexing)</param>
+    /// <param name="conditionNumber">Running counter used to label condition clauses</param>
+    /// <returns>Expression string for this pattern and its conditions</returns>
+    private string? ProcessPatternWithConditions(SearchPattern pattern, List<Clause> clauses, int patternLabel, ref int conditionNumber)
+    {
+        // Generate the pattern clause with stable pattern label
+        if (GenerateClause(pattern, patternLabel) is not { } primaryClause)
+        {
+            return null;
+        }
+
+        clauses.Add(primaryClause);
+        var expressionText = new StringBuilder();
+        expressionText.Append(patternLabel);
+
+        // Apply pattern-specific conditions if they exist
+        var addedCondition = false;
+        foreach (var specificCondition in pattern.Conditions ?? Array.Empty<SearchCondition>())
+        {
+            var conditionLabel = ConditionLabel(conditionNumber);
+            if (GenerateCondition(specificCondition, conditionLabel, patternLabel) is not { } specificCondClause)
+            {
+                continue;
+            }
+
+            clauses.Add(specificCondClause);
+            expressionText.Append(" AND ");
+            expressionText.Append(conditionLabel);
+            conditionNumber++;
+            addedCondition = true;
+        }
+
+        // Parenthesize only when conditions were actually added, so that a pattern whose conditions all failed to
+        // generate does not produce a redundant group.
+        return addedCondition ? $"({expressionText})" : expressionText.ToString();
     }
 
     /// <summary>

--- a/AppInspector.RulesEngine/AbstractRuleSet.cs
+++ b/AppInspector.RulesEngine/AbstractRuleSet.cs
@@ -146,6 +146,16 @@ public abstract class AbstractRuleSet
             }
         }
 
+        // Evaluating an expression recurses once per level of parenthesis nesting, so a deeply nested one
+        // would exhaust the stack before any rule could be reported. Refuse the rule instead.
+        if (rule.Expression is { } authored && RuleExpression.MaxNestingOf(authored) > RuleExpression.MaxNestingDepth)
+        {
+            _logger.LogError(
+                "Expression in rule {id} nests parentheses more than {max} deep and will not be used. This rule will not match anything.",
+                rule.Id, RuleExpression.MaxNestingDepth);
+            return new ConvertedOatRule(rule.Id, rule);
+        }
+
         // An authored expression replaces the generated pattern-OR, condition-AND shape.
         return new ConvertedOatRule(rule.Id, rule)
         {

--- a/AppInspector.RulesEngine/AbstractRuleSet.cs
+++ b/AppInspector.RulesEngine/AbstractRuleSet.cs
@@ -271,9 +271,10 @@ public abstract class AbstractRuleSet
     }
 
     /// <summary>
-    ///     Conditions are labelled in their own namespace. Pattern clauses must keep bare numeric labels because
-    ///     <see cref="OatExtensions.OatRegexWithIndexOperation" /> parses the label back into an index into the rule's
-    ///     patterns, so sharing a single counter between the two would both collide and shift pattern indexes.
+    ///     Conditions are labelled in their own namespace so that an automatically numbered condition cannot collide
+    ///     with an automatically numbered pattern. The pattern a finding belongs to travels on the clause's
+    ///     <see cref="OatExtensions.OatRegexWithIndexClause.PatternIndex" />, not its label, so labels are free to be
+    ///     anything the author chooses.
     /// </summary>
     private static string ConditionLabel(int conditionNumber)
     {
@@ -303,7 +304,7 @@ public abstract class AbstractRuleSet
             {
                 return new OatRegexWithIndexClause(scopes, null, pattern.XPaths, pattern.JsonPaths, pattern.YamlPaths, pattern.XPathNamespaces)
                 {
-                    Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
+                    Label = clauseLabel,
                     PatternIndex = clauseNumber,
                     Data = new List<string> { pattern.Pattern },
                     Capture = true,
@@ -315,7 +316,7 @@ public abstract class AbstractRuleSet
             {
                 return new OatRegexWithIndexClause(scopes, null, pattern.XPaths, pattern.JsonPaths, pattern.YamlPaths, pattern.XPathNamespaces)
                 {
-                    Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
+                    Label = clauseLabel,
                     PatternIndex = clauseNumber,
                     Data = new List<string> { $"\\b({pattern.Pattern})\\b" },
                     Capture = true,
@@ -354,7 +355,7 @@ public abstract class AbstractRuleSet
         var addedCondition = false;
         foreach (var specificCondition in pattern.Conditions ?? Array.Empty<SearchCondition>())
         {
-            var conditionLabel = ConditionLabel(conditionNumber);
+            var conditionLabel = specificCondition.Label ?? ConditionLabel(conditionNumber);
             if (GenerateCondition(specificCondition, conditionLabel, patternLabel) is not { } specificCondClause)
             {
                 continue;

--- a/AppInspector.RulesEngine/AbstractRuleSet.cs
+++ b/AppInspector.RulesEngine/AbstractRuleSet.cs
@@ -277,8 +277,8 @@ public abstract class AbstractRuleSet
                 return new OatSubstringIndexClause(scopes, useWordBoundaries: pattern.PatternType == PatternType.String,
                     xPaths: pattern.XPaths, jsonPaths: pattern.JsonPaths, yamlPaths: pattern.YamlPaths, xPathNameSpaces: pattern.XPathNamespaces)
                 {
-                    Label = clauseNumber.ToString(CultureInfo
-                        .InvariantCulture), //important to pattern index identification
+                    Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
+                    PatternIndex = clauseNumber,
                     Data = new List<string> { pattern.Pattern },
                     Capture = true,
                     Arguments = pattern.Modifiers,
@@ -289,8 +289,8 @@ public abstract class AbstractRuleSet
             {
                 return new OatRegexWithIndexClause(scopes, null, pattern.XPaths, pattern.JsonPaths, pattern.YamlPaths, pattern.XPathNamespaces)
                 {
-                    Label = clauseNumber.ToString(CultureInfo
-                        .InvariantCulture), //important to pattern index identification
+                    Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
+                    PatternIndex = clauseNumber,
                     Data = new List<string> { pattern.Pattern },
                     Capture = true,
                     Arguments = pattern.Modifiers,
@@ -301,8 +301,8 @@ public abstract class AbstractRuleSet
             {
                 return new OatRegexWithIndexClause(scopes, null, pattern.XPaths, pattern.JsonPaths, pattern.YamlPaths, pattern.XPathNamespaces)
                 {
-                    Label = clauseNumber.ToString(CultureInfo
-                        .InvariantCulture), //important to pattern index identification
+                    Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
+                    PatternIndex = clauseNumber,
                     Data = new List<string> { $"\\b({pattern.Pattern})\\b" },
                     Capture = true,
                     Arguments = pattern.Modifiers,

--- a/AppInspector.RulesEngine/AbstractRuleSet.cs
+++ b/AppInspector.RulesEngine/AbstractRuleSet.cs
@@ -131,25 +131,28 @@ public abstract class AbstractRuleSet
         // only wrapped when it does not already begin with one. That is safe because OAT evaluates expressions
         // strictly left to right with no operator precedence, so the rule level conditions appended below still
         // apply to the whole pattern group either way.
-        var expression = new StringBuilder(patternBody.StartsWith('(') ? patternBody : $"({patternBody})");
+        var generatedExpression = new StringBuilder(patternBody.StartsWith('(') ? patternBody : $"({patternBody})");
 
         foreach (var condition in rule.Conditions ?? Array.Empty<SearchCondition>())
         {
-            var conditionLabel = ConditionLabel(conditionNumber);
+            var conditionLabel = condition.Label ?? ConditionLabel(conditionNumber);
             var clause = GenerateCondition(condition, conditionLabel, null);
             if (clause is { })
             {
                 clauses.Add(clause);
-                expression.Append(" AND ");
-                expression.Append(conditionLabel);
+                generatedExpression.Append(" AND ");
+                generatedExpression.Append(conditionLabel);
                 conditionNumber++;
             }
         }
 
+        // An authored expression replaces the generated pattern-OR, condition-AND shape.
         return new ConvertedOatRule(rule.Id, rule)
         {
             Clauses = clauses,
-            Expression = expression.ToString()
+            Expression = string.IsNullOrWhiteSpace(rule.Expression)
+                ? generatedExpression.ToString()
+                : rule.Expression
         };
     }
 
@@ -267,17 +270,18 @@ public abstract class AbstractRuleSet
         return "c" + conditionNumber.ToString(CultureInfo.InvariantCulture);
     }
 
-    private Clause? GenerateClause(SearchPattern pattern, int clauseNumber = -1)
+    private Clause? GenerateClause(SearchPattern pattern, int clauseNumber = -1, string? label = null)
     {
         if (pattern.Pattern != null)
         {
             var scopes = pattern.Scopes ?? new[] { PatternScope.All };
+            var clauseLabel = label ?? clauseNumber.ToString(CultureInfo.InvariantCulture);
             if (pattern.PatternType is PatternType.String or PatternType.Substring)
             {
                 return new OatSubstringIndexClause(scopes, useWordBoundaries: pattern.PatternType == PatternType.String,
                     xPaths: pattern.XPaths, jsonPaths: pattern.JsonPaths, yamlPaths: pattern.YamlPaths, xPathNameSpaces: pattern.XPathNamespaces)
                 {
-                    Label = clauseNumber.ToString(CultureInfo.InvariantCulture),
+                    Label = clauseLabel,
                     PatternIndex = clauseNumber,
                     Data = new List<string> { pattern.Pattern },
                     Capture = true,
@@ -323,15 +327,18 @@ public abstract class AbstractRuleSet
     /// <returns>Expression string for this pattern and its conditions</returns>
     private string? ProcessPatternWithConditions(SearchPattern pattern, List<Clause> clauses, int patternLabel, ref int conditionNumber)
     {
-        // Generate the pattern clause with stable pattern label
-        if (GenerateClause(pattern, patternLabel) is not { } primaryClause)
+        // An author supplied label replaces the numeric one in the expression; the pattern index is carried
+        // separately on the clause, so naming a pattern cannot disturb which pattern a finding is reported against.
+        var label = pattern.Label ?? patternLabel.ToString(CultureInfo.InvariantCulture);
+
+        if (GenerateClause(pattern, patternLabel, label) is not { } primaryClause)
         {
             return null;
         }
 
         clauses.Add(primaryClause);
         var expressionText = new StringBuilder();
-        expressionText.Append(patternLabel);
+        expressionText.Append(label);
 
         // Apply pattern-specific conditions if they exist
         var addedCondition = false;

--- a/AppInspector.RulesEngine/AppInspector.RulesEngine.csproj
+++ b/AppInspector.RulesEngine/AppInspector.RulesEngine.csproj
@@ -32,7 +32,7 @@
     <ItemGroup>
         <PackageReference Include="JsonCons.JsonPath" Version="1.1.0" />
         <PackageReference Include="JsonSchema.Net" Version="7.4.0" />
-        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.87" />
+        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.95" />
         <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.45" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
         <PackageReference Include="YamlDotNet" Version="16.3.0" />

--- a/AppInspector.RulesEngine/OatExtensions/ConvertedOatRule.cs
+++ b/AppInspector.RulesEngine/OatExtensions/ConvertedOatRule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
 
@@ -7,8 +8,7 @@ namespace Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
 /// </summary>
 public class ConvertedOatRule : CST.OAT.Rule
 {
-    private RuleExpression? _parsedExpression;
-    private string? _parsedExpressionSource;
+    private ParsedExpressionCache? _parsedExpressionCache;
 
     public ConvertedOatRule(string name, Rule rule) : base(name)
     {
@@ -21,25 +21,42 @@ public class ConvertedOatRule : CST.OAT.Rule
     public Rule AppInspectorRule { get; }
 
     /// <summary>
-    ///     The rule's expression parsed for per finding evaluation, or null if it cannot be parsed.
-    ///     Cached against the rule so it is not reparsed per file, and reparsed if the expression changes.
+    ///     The rule's authored expression parsed for per finding evaluation, or null if there is none or it cannot be
+    ///     parsed. This is the expression the rule author wrote, not <see cref="CST.OAT.Rule.Expression" />, which is
+    ///     the weaker one handed to the engine. Cached against the rule so it is not reparsed per file.
     /// </summary>
     internal RuleExpression? ParsedExpression
     {
         get
         {
-            if (Expression is not { } expression)
+            if (AppInspectorRule.Expression is not { } expression || string.IsNullOrWhiteSpace(expression))
             {
                 return null;
             }
 
-            if (!string.Equals(_parsedExpressionSource, expression, StringComparison.Ordinal))
+            // Files are scanned in parallel, so the source and the parse result are published together behind a
+            // single reference. Caching them in two fields would let another thread see a new source paired with a
+            // stale or null parse and silently drop that rule's findings.
+            var cache = Volatile.Read(ref _parsedExpressionCache);
+            if (cache is null || !string.Equals(cache.Source, expression, StringComparison.Ordinal))
             {
-                _parsedExpression = RuleExpression.TryParse(expression);
-                _parsedExpressionSource = expression;
+                cache = new ParsedExpressionCache(expression, RuleExpression.TryParse(expression));
+                Volatile.Write(ref _parsedExpressionCache, cache);
             }
 
-            return _parsedExpression;
+            return cache.Parsed;
         }
+    }
+
+    private sealed class ParsedExpressionCache
+    {
+        internal ParsedExpressionCache(string source, RuleExpression? parsed)
+        {
+            Source = source;
+            Parsed = parsed;
+        }
+
+        internal string Source { get; }
+        internal RuleExpression? Parsed { get; }
     }
 }

--- a/AppInspector.RulesEngine/OatExtensions/ConvertedOatRule.cs
+++ b/AppInspector.RulesEngine/OatExtensions/ConvertedOatRule.cs
@@ -1,10 +1,15 @@
-﻿namespace Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
+﻿using System;
+
+namespace Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
 
 /// <summary>
 ///     Wrapper for OAT based processing
 /// </summary>
 public class ConvertedOatRule : CST.OAT.Rule
 {
+    private RuleExpression? _parsedExpression;
+    private string? _parsedExpressionSource;
+
     public ConvertedOatRule(string name, Rule rule) : base(name)
     {
         AppInspectorRule = rule;
@@ -14,4 +19,27 @@ public class ConvertedOatRule : CST.OAT.Rule
     ///     Native Application Inspector Rule to preserve format and instance data
     /// </summary>
     public Rule AppInspectorRule { get; }
+
+    /// <summary>
+    ///     The rule's expression parsed for per finding evaluation, or null if it cannot be parsed.
+    ///     Cached against the rule so it is not reparsed per file, and reparsed if the expression changes.
+    /// </summary>
+    internal RuleExpression? ParsedExpression
+    {
+        get
+        {
+            if (Expression is not { } expression)
+            {
+                return null;
+            }
+
+            if (!string.Equals(_parsedExpressionSource, expression, StringComparison.Ordinal))
+            {
+                _parsedExpression = RuleExpression.TryParse(expression);
+                _parsedExpressionSource = expression;
+            }
+
+            return _parsedExpression;
+        }
+    }
 }

--- a/AppInspector.RulesEngine/OatExtensions/OatRegexWithIndexClause.cs
+++ b/AppInspector.RulesEngine/OatExtensions/OatRegexWithIndexClause.cs
@@ -24,6 +24,12 @@ public class OatRegexWithIndexClause : Clause
 
     public Dictionary<string, string> XPathNameSpaces { get; }
 
+    /// <summary>
+    ///     Index of the <see cref="SearchPattern" /> in the originating rule that this clause was built from.
+    ///     Used to report which pattern matched; -1 when the clause is a condition subclause.
+    /// </summary>
+    public int PatternIndex { get; set; } = -1;
+
     public PatternScope[] Scopes { get; }
     public string[]? YmlPaths { get; }
 }

--- a/AppInspector.RulesEngine/OatExtensions/OatRegexWithIndexOperation.cs
+++ b/AppInspector.RulesEngine/OatExtensions/OatRegexWithIndexOperation.cs
@@ -172,8 +172,7 @@ public class OatRegexWithIndexOperation : OatOperation
                     Index = m.Index + (boundary?.Index ?? 0)
                 };
 
-                //regex patterns will be indexed off data while string patterns result in N clauses
-                var patternIndex = Convert.ToInt32(clause.Label);
+                var patternIndex = clause is OatRegexWithIndexClause src ? src.PatternIndex : -1;
 
                 // Should return only scoped matches
                 if (tc.ScopeMatch(scopes, translatedBoundary))

--- a/AppInspector.RulesEngine/OatExtensions/OatSubstringIndexClause.cs
+++ b/AppInspector.RulesEngine/OatExtensions/OatSubstringIndexClause.cs
@@ -27,6 +27,12 @@ public class OatSubstringIndexClause : Clause
 
     public string[]? XPaths { get; }
 
+    /// <summary>
+    ///     Index of the <see cref="SearchPattern" /> in the originating rule that this clause was built from.
+    ///     Used to report which pattern matched; -1 when the clause is a condition subclause.
+    /// </summary>
+    public int PatternIndex { get; set; } = -1;
+
     public PatternScope[] Scopes { get; }
 
     public bool UseWordBoundaries { get; }

--- a/AppInspector.RulesEngine/OatExtensions/OatSubstringIndexOperation.cs
+++ b/AppInspector.RulesEngine/OatExtensions/OatSubstringIndexOperation.cs
@@ -72,6 +72,7 @@ public class OatSubstringIndexOperation : OatOperation
             if (clause.Data is { Count: > 0 } stringList)
             {
                 var outmatches = new List<(int, Boundary)>(); //tuple results i.e. pattern index and where
+                var patternIndex = src.PatternIndex;
 
                 for (var i = 0; i < stringList.Count; i++)
                 {
@@ -86,7 +87,7 @@ public class OatSubstringIndexOperation : OatOperation
                                 foreach (var match in matches)
                                 {
                                     match.Index += target.Item2.Index;
-                                    outmatches.Add((i, match));
+                                    outmatches.Add((patternIndex, match));
                                 }
                             }
                         }
@@ -103,7 +104,7 @@ public class OatSubstringIndexOperation : OatOperation
                                 foreach (var match in matches)
                                 {
                                     match.Index += target.Item2.Index;
-                                    outmatches.Add((i, match));
+                                    outmatches.Add((patternIndex, match));
                                 }
                             }
                         }
@@ -120,7 +121,7 @@ public class OatSubstringIndexOperation : OatOperation
                                 foreach (var match in matches)
                                 {
                                     match.Index += target.Item2.Index;
-                                    outmatches.Add((i, match));
+                                    outmatches.Add((patternIndex, match));
                                 }
                             }
                         }
@@ -133,12 +134,12 @@ public class OatSubstringIndexOperation : OatOperation
                         {
                             var matches = GetMatches(tc.GetBoundaryText(boundary), stringList[i], comparisonType, tc,
                                 src);
-                            outmatches.AddRange(matches.Select(x => (i, x)));
+                            outmatches.AddRange(matches.Select(x => (patternIndex, x)));
                         }
                         else
                         {
                             var matches = GetMatches(tc.FullContent, stringList[i], comparisonType, tc, src);
-                            outmatches.AddRange(matches.Select(x => (i, x)));
+                            outmatches.AddRange(matches.Select(x => (patternIndex, x)));
                         }
                     }
                 }

--- a/AppInspector.RulesEngine/OatExtensions/WithinClause.cs
+++ b/AppInspector.RulesEngine/OatExtensions/WithinClause.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Microsoft.CST.OAT;
 
 namespace Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
@@ -21,4 +22,20 @@ public class WithinClause : Clause
     public bool SameLineOnly { get; set; }
     public bool FindingRegion { get; set; }
     public Clause SubClause { get; }
+
+    /// <summary>
+    ///     Index of the pattern that declared this condition, or null when the condition was declared at rule level.
+    ///     A rule level condition gates every pattern in the rule; a pattern level condition gates only its own pattern.
+    /// </summary>
+    public int? OwnerPatternIndex { get; set; }
+    
+    /// <summary>
+    /// Languages where this condition applies. Empty means applies to all (except those in LanguageDoesNotApplyTo).
+    /// </summary>
+    public IList<string>? LanguageAppliesTo { get; set; }
+    
+    /// <summary>
+    /// Languages where this condition does not apply.
+    /// </summary>
+    public IList<string>? LanguageDoesNotApplyTo { get; set; }
 }

--- a/AppInspector.RulesEngine/OatExtensions/WithinClause.cs
+++ b/AppInspector.RulesEngine/OatExtensions/WithinClause.cs
@@ -21,6 +21,7 @@ public class WithinClause : Clause
     public bool FindingOnly { get; set; }
     public bool SameLineOnly { get; set; }
     public bool FindingRegion { get; set; }
+
     public Clause SubClause { get; }
 
     /// <summary>
@@ -28,14 +29,14 @@ public class WithinClause : Clause
     ///     A rule level condition gates every pattern in the rule; a pattern level condition gates only its own pattern.
     /// </summary>
     public int? OwnerPatternIndex { get; set; }
-    
+
     /// <summary>
-    /// Languages where this condition applies. Empty means applies to all (except those in LanguageDoesNotApplyTo).
+    ///     Languages where this condition applies. Empty means applies to all (except those in LanguageDoesNotApplyTo).
     /// </summary>
     public IList<string>? LanguageAppliesTo { get; set; }
-    
+
     /// <summary>
-    /// Languages where this condition does not apply.
+    ///     Languages where this condition does not apply.
     /// </summary>
     public IList<string>? LanguageDoesNotApplyTo { get; set; }
 }

--- a/AppInspector.RulesEngine/OatExtensions/WithinOperation.cs
+++ b/AppInspector.RulesEngine/OatExtensions/WithinOperation.cs
@@ -29,114 +29,110 @@ public class WithinOperation : OatOperation
     {
         if (c is WithinClause wc && state1 is TextContainer tc)
         {
+            var governed = GovernedMatches(wc, captures);
+
+            // A condition that does not apply to this file's language still has to produce a capture, because
+            // RuleProcessor needs one gate per declared condition to know which matches have been vetted. This gate
+            // passes through everything the condition governs, so it filters nothing. Building it from the governed
+            // matches rather than from whatever captures happen to have accumulated keeps the result independent of
+            // the order the conditions are declared in.
+            if (!ConditionAppliesToLanguage(wc, tc.Language))
+            {
+                return new OperationResult(true,
+                    governed.Count > 0 ? new TypedClauseCapture<List<(int, Boundary)>>(wc, governed) : null);
+            }
+
             var passed =
                 new List<(int, Boundary)>();
             var failed =
                 new List<(int, Boundary)>();
 
-            foreach (var capture in captures ?? Array.Empty<ClauseCapture>())
+            foreach ((var clauseNum, var boundary) in governed)
             {
-                // Each condition filters the raw pattern matches independently; RuleProcessor then
-                // intersects the surviving matches to AND the conditions together. Consuming another
-                // condition's already-filtered capture here would double count matches and break that
-                // intersection.
-                if (capture.Clause is WithinClause)
+                var boundaryToCheck = GetBoundaryToCheck();
+                if (boundaryToCheck is not null)
                 {
-                    continue;
+                    var operationResult = ProcessLambda(boundaryToCheck);
+                    if (operationResult.Result)
+                    {
+                        passed.Add((clauseNum, boundary));
+                    }
+                    else
+                    {
+                        failed.Add((clauseNum, boundary));
+                    }
                 }
 
-                if (capture is TypedClauseCapture<List<(int, Boundary)>> tcc)
+                Boundary? GetBoundaryToCheck()
                 {
-                    foreach ((var clauseNum, var boundary) in tcc.Result)
+                    if (wc.FindingOnly)
                     {
-                        var boundaryToCheck = GetBoundaryToCheck();
-                        if (boundaryToCheck is not null)
-                        {
-                            var operationResult = ProcessLambda(boundaryToCheck);
-                            if (operationResult.Result)
-                            {
-                                passed.Add((clauseNum, boundary));
-                            }
-                            else
-                            {
-                                failed.Add((clauseNum, boundary));
-                            }
-                        }
-
-                        Boundary? GetBoundaryToCheck()
-                        {
-                            if (wc.FindingOnly)
-                            {
-                                return boundary;
-                            }
-
-                            if (wc.SameLineOnly)
-                            {
-                                var startInner = tc.LineStarts[tc.GetLocation(boundary.Index).Line];
-                                var endInner = tc.LineEnds[tc.GetLocation(startInner + (boundary.Length - 1)).Line];
-                                return new Boundary
-                                {
-                                    Index = startInner,
-                                    Length = endInner - startInner + 1
-                                };
-                            }
-
-                            if (wc.FindingRegion)
-                            {
-                                var startLine = tc.GetLocation(boundary.Index).Line;
-                                // Before is already a negative number
-                                var startInner = tc.LineStarts[Math.Max(1, startLine + wc.Before)];
-                                var endInner = tc.LineEnds[Math.Min(tc.LineEnds.Count - 1, startLine + wc.After)];
-                                return new Boundary
-                                {
-                                    Index = startInner,
-                                    Length = endInner - startInner + 1
-                                };
-                            }
-
-                            if (wc.SameFile)
-                            {
-                                var startInner = tc.LineStarts[0];
-                                var endInner = tc.LineEnds[^1];
-                                return new Boundary
-                                {
-                                    Index = startInner,
-                                    Length = endInner - startInner + 1
-                                };
-                            }
-
-                            if (wc.OnlyBefore)
-                            {
-                                var startInner = tc.LineStarts[0];
-                                var endInner = boundary.Index;
-                                return new Boundary
-                                {
-                                    Index = startInner,
-                                    Length = endInner - startInner + 1
-                                };
-                            }
-
-                            if (wc.OnlyAfter)
-                            {
-                                var startInner = boundary.Index + boundary.Length;
-                                var endInner = tc.LineEnds[^1];
-                                return new Boundary
-                                {
-                                    Index = startInner,
-                                    Length = endInner - startInner + 1
-                                };
-                            }
-
-                            return null;
-                        }
+                        return boundary;
                     }
+
+                    if (wc.SameLineOnly)
+                    {
+                        var startInner = tc.LineStarts[tc.GetLocation(boundary.Index).Line];
+                        var endInner = tc.LineEnds[tc.GetLocation(startInner + (boundary.Length - 1)).Line];
+                        return new Boundary
+                        {
+                            Index = startInner,
+                            Length = endInner - startInner + 1
+                        };
+                    }
+
+                    if (wc.FindingRegion)
+                    {
+                        var startLine = tc.GetLocation(boundary.Index).Line;
+                        // Before is already a negative number
+                        var startInner = tc.LineStarts[Math.Max(1, startLine + wc.Before)];
+                        var endInner = tc.LineEnds[Math.Min(tc.LineEnds.Count - 1, startLine + wc.After)];
+                        return new Boundary
+                        {
+                            Index = startInner,
+                            Length = endInner - startInner + 1
+                        };
+                    }
+
+                    if (wc.SameFile)
+                    {
+                        var startInner = tc.LineStarts[0];
+                        var endInner = tc.LineEnds[^1];
+                        return new Boundary
+                        {
+                            Index = startInner,
+                            Length = endInner - startInner + 1
+                        };
+                    }
+
+                    if (wc.OnlyBefore)
+                    {
+                        var startInner = tc.LineStarts[0];
+                        var endInner = boundary.Index;
+                        return new Boundary
+                        {
+                            Index = startInner,
+                            Length = endInner - startInner + 1
+                        };
+                    }
+
+                    if (wc.OnlyAfter)
+                    {
+                        var startInner = boundary.Index + boundary.Length;
+                        var endInner = tc.LineEnds[^1];
+                        return new Boundary
+                        {
+                            Index = startInner,
+                            Length = endInner - startInner + 1
+                        };
+                    }
+
+                    return null;
                 }
             }
 
-            // Each pattern clause in the rule contributes its own capture, so every capture must be
-            // evaluated before returning. Returning inside the loop would discard the matches of every
-            // pattern clause after the first, causing multi-pattern rules with a condition to report
-            // only the findings of their first pattern.
+            // The governed list is built from every pattern capture the clause was handed, so all of a rule's
+            // patterns are filtered rather than only the first one.
             var passedOrFailed = wc.Invert ? failed : passed;
             return new OperationResult(passedOrFailed.Any(),
                 passedOrFailed.Any()
@@ -150,6 +146,47 @@ public class WithinOperation : OatOperation
         }
 
         return new OperationResult(false);
+    }
+
+    /// <summary>
+    ///     The pattern matches this condition is responsible for filtering.
+    /// </summary>
+    /// <remarks>
+    ///     Two kinds of capture are excluded. Captures produced by another <see cref="WithinClause" /> are skipped
+    ///     because each condition filters the raw pattern matches independently and <c>RuleProcessor</c> intersects the
+    ///     survivors to AND the conditions together; consuming an already filtered capture would double count matches
+    ///     and break that intersection. Matches belonging to another pattern are skipped for a pattern level condition,
+    ///     because OAT hands a clause every capture accumulated so far, which for a later pattern in the rule includes
+    ///     the captures of the patterns before it.
+    /// </remarks>
+    private static List<(int, Boundary)> GovernedMatches(WithinClause wc, IEnumerable<ClauseCapture>? captures)
+    {
+        var governed = new List<(int, Boundary)>();
+        var seen = new HashSet<(int, Boundary)>();
+
+        foreach (var capture in captures ?? Array.Empty<ClauseCapture>())
+        {
+            if (capture.Clause is WithinClause || capture is not TypedClauseCapture<List<(int, Boundary)>> tcc ||
+                tcc.Result is null)
+            {
+                continue;
+            }
+
+            foreach (var match in tcc.Result)
+            {
+                if (wc.OwnerPatternIndex is { } owner && match.Item1 != owner)
+                {
+                    continue;
+                }
+
+                if (seen.Add(match))
+                {
+                    governed.Add(match);
+                }
+            }
+        }
+
+        return governed;
     }
 
     public IEnumerable<Violation> WithinValidationDelegate(CST.OAT.Rule rule, Clause clause)
@@ -242,5 +279,31 @@ public class WithinOperation : OatOperation
                 $"Rule {rule.Name} clause {clause.Label ?? rule.Clauses.IndexOf(clause).ToString(CultureInfo.InvariantCulture)} is not a WithinClause",
                 rule, clause);
         }
+    }
+
+    /// <summary>
+    /// Check if a WithinClause's language filters allow it to apply to the given language.
+    /// </summary>
+    private static bool ConditionAppliesToLanguage(WithinClause clause, string currentLanguage)
+    {
+        // If applies_to is specified and doesn't include current language, condition doesn't apply
+        if (clause.LanguageAppliesTo is { Count: > 0 })
+        {
+            if (!clause.LanguageAppliesTo.Contains(currentLanguage, StringComparer.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        // If does_not_apply_to includes current language, condition doesn't apply
+        if (clause.LanguageDoesNotApplyTo is { Count: > 0 })
+        {
+            if (clause.LanguageDoesNotApplyTo.Contains(currentLanguage, StringComparer.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/AppInspector.RulesEngine/OatExtensions/WithinOperation.cs
+++ b/AppInspector.RulesEngine/OatExtensions/WithinOperation.cs
@@ -36,6 +36,15 @@ public class WithinOperation : OatOperation
 
             foreach (var capture in captures ?? Array.Empty<ClauseCapture>())
             {
+                // Each condition filters the raw pattern matches independently; RuleProcessor then
+                // intersects the surviving matches to AND the conditions together. Consuming another
+                // condition's already-filtered capture here would double count matches and break that
+                // intersection.
+                if (capture.Clause is WithinClause)
+                {
+                    continue;
+                }
+
                 if (capture is TypedClauseCapture<List<(int, Boundary)>> tcc)
                 {
                     foreach ((var clauseNum, var boundary) in tcc.Result)
@@ -122,13 +131,17 @@ public class WithinOperation : OatOperation
                         }
                     }
                 }
-
-                var passedOrFailed = wc.Invert ? failed : passed;
-                return new OperationResult(passedOrFailed.Any(),
-                    passedOrFailed.Any()
-                        ? new TypedClauseCapture<List<(int, Boundary)>>(wc, passedOrFailed.ToList())
-                        : null);
             }
+
+            // Each pattern clause in the rule contributes its own capture, so every capture must be
+            // evaluated before returning. Returning inside the loop would discard the matches of every
+            // pattern clause after the first, causing multi-pattern rules with a condition to report
+            // only the findings of their first pattern.
+            var passedOrFailed = wc.Invert ? failed : passed;
+            return new OperationResult(passedOrFailed.Any(),
+                passedOrFailed.Any()
+                    ? new TypedClauseCapture<List<(int, Boundary)>>(wc, passedOrFailed.ToList())
+                    : null);
 
             OperationResult ProcessLambda(Boundary target)
             {

--- a/AppInspector.RulesEngine/Rule.cs
+++ b/AppInspector.RulesEngine/Rule.cs
@@ -188,6 +188,16 @@ namespace Microsoft.ApplicationInspector.RulesEngine
         public SearchCondition[]? Conditions { get; set; }
 
         /// <summary>
+        ///     Optional boolean expression combining pattern and condition labels, for example
+        ///     <c>(curl AND NOT tls13) OR wget</c>. When unset, any pattern matching satisfies the rule and
+        ///     every condition must then hold.
+        ///     Evaluated strictly left to right with no operator precedence, so grouping requires parentheses:
+        ///     <c>a OR b AND c</c> means <c>(a OR b) AND c</c>.
+        /// </summary>
+        [JsonPropertyName("expression")]
+        public string? Expression { get; set; }
+
+        /// <summary>
         ///     Optional list of self-test sample texts that the rule must match to be considered valid.
         /// </summary>
         [JsonPropertyName("must-match")]

--- a/AppInspector.RulesEngine/RuleExpression.cs
+++ b/AppInspector.RulesEngine/RuleExpression.cs
@@ -1,0 +1,246 @@
+// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.ApplicationInspector.RulesEngine;
+
+/// <summary>
+///     A parsed rule expression, used to decide which individual findings satisfy the rule rather than
+///     only whether the rule matched at all.
+///     Mirrors the evaluation model of the underlying engine: operators fold strictly left to right with
+///     no precedence, and grouping is expressed only with parentheses.
+/// </summary>
+internal sealed class RuleExpression
+{
+    private static readonly string[] Operators = { "AND", "OR", "XOR", "NAND", "NOR" };
+
+    private static readonly ConcurrentDictionary<string, RuleExpression?> Cache = new();
+
+    private readonly Node _root;
+
+    private RuleExpression(Node root)
+    {
+        _root = root;
+    }
+
+    /// <summary>
+    ///     Parses an expression, returning null if it is malformed.
+    /// </summary>
+    public static RuleExpression? TryParse(string expression)
+    {
+        return Cache.GetOrAdd(expression, static toParse =>
+        {
+            var tokens = Tokenize(toParse);
+            if (tokens.Count == 0)
+            {
+                return null;
+            }
+
+            var index = 0;
+            var root = ParseSequence(tokens, ref index);
+            return root is null || index != tokens.Count ? null : new RuleExpression(root);
+        });
+    }
+
+    public bool Evaluate(Func<string, bool> labelValue)
+    {
+        return _root.Evaluate(labelValue);
+    }
+
+    private static List<Token> Tokenize(string expression)
+    {
+        List<Token> tokens = new();
+
+        foreach (var raw in expression.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var remaining = raw;
+
+            while (remaining.StartsWith("(", StringComparison.Ordinal))
+            {
+                tokens.Add(new Token(TokenKind.OpenParen, "("));
+                remaining = remaining.Substring(1);
+            }
+
+            var closers = 0;
+            while (remaining.EndsWith(")", StringComparison.Ordinal))
+            {
+                closers++;
+                remaining = remaining.Substring(0, remaining.Length - 1);
+            }
+
+            if (remaining.Length > 0)
+            {
+                if (remaining.Equals("NOT", StringComparison.OrdinalIgnoreCase))
+                {
+                    tokens.Add(new Token(TokenKind.Not, remaining));
+                }
+                else if (Operators.Contains(remaining, StringComparer.OrdinalIgnoreCase))
+                {
+                    tokens.Add(new Token(TokenKind.Operator, remaining.ToUpperInvariant()));
+                }
+                else
+                {
+                    tokens.Add(new Token(TokenKind.Label, remaining));
+                }
+            }
+
+            for (var i = 0; i < closers; i++) tokens.Add(new Token(TokenKind.CloseParen, ")"));
+        }
+
+        return tokens;
+    }
+
+    private static Node? ParseSequence(List<Token> tokens, ref int index)
+    {
+        var left = ParseTerm(tokens, ref index);
+        if (left is null)
+        {
+            return null;
+        }
+
+        while (index < tokens.Count && tokens[index].Kind == TokenKind.Operator)
+        {
+            var op = tokens[index].Text;
+            index++;
+
+            var right = ParseTerm(tokens, ref index);
+            if (right is null)
+            {
+                return null;
+            }
+
+            left = new BinaryNode(op, left, right);
+        }
+
+        return left;
+    }
+
+    private static Node? ParseTerm(List<Token> tokens, ref int index)
+    {
+        var negate = false;
+        while (index < tokens.Count && tokens[index].Kind == TokenKind.Not)
+        {
+            negate = !negate;
+            index++;
+        }
+
+        if (index >= tokens.Count)
+        {
+            return null;
+        }
+
+        Node? inner;
+
+        if (tokens[index].Kind == TokenKind.OpenParen)
+        {
+            index++;
+            inner = ParseSequence(tokens, ref index);
+            if (inner is null || index >= tokens.Count || tokens[index].Kind != TokenKind.CloseParen)
+            {
+                return null;
+            }
+
+            index++;
+        }
+        else if (tokens[index].Kind == TokenKind.Label)
+        {
+            inner = new LabelNode(tokens[index].Text);
+            index++;
+        }
+        else
+        {
+            return null;
+        }
+
+        return negate ? new NotNode(inner) : inner;
+    }
+
+    private enum TokenKind
+    {
+        OpenParen,
+        CloseParen,
+        Not,
+        Operator,
+        Label
+    }
+
+    private readonly struct Token
+    {
+        public Token(TokenKind kind, string text)
+        {
+            Kind = kind;
+            Text = text;
+        }
+
+        public TokenKind Kind { get; }
+        public string Text { get; }
+    }
+
+    private abstract class Node
+    {
+        public abstract bool Evaluate(Func<string, bool> labelValue);
+    }
+
+    private sealed class LabelNode : Node
+    {
+        private readonly string _label;
+
+        public LabelNode(string label)
+        {
+            _label = label;
+        }
+
+        public override bool Evaluate(Func<string, bool> labelValue)
+        {
+            return labelValue(_label);
+        }
+    }
+
+    private sealed class NotNode : Node
+    {
+        private readonly Node _inner;
+
+        public NotNode(Node inner)
+        {
+            _inner = inner;
+        }
+
+        public override bool Evaluate(Func<string, bool> labelValue)
+        {
+            return !_inner.Evaluate(labelValue);
+        }
+    }
+
+    private sealed class BinaryNode : Node
+    {
+        private readonly Node _left;
+        private readonly string _operator;
+        private readonly Node _right;
+
+        public BinaryNode(string op, Node left, Node right)
+        {
+            _operator = op;
+            _left = left;
+            _right = right;
+        }
+
+        public override bool Evaluate(Func<string, bool> labelValue)
+        {
+            var left = _left.Evaluate(labelValue);
+            var right = _right.Evaluate(labelValue);
+
+            return _operator switch
+            {
+                "AND" => left && right,
+                "OR" => left || right,
+                "XOR" => left ^ right,
+                "NAND" => !(left && right),
+                "NOR" => !(left || right),
+                _ => false
+            };
+        }
+    }
+}

--- a/AppInspector.RulesEngine/RuleExpression.cs
+++ b/AppInspector.RulesEngine/RuleExpression.cs
@@ -1,7 +1,6 @@
 // Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -15,9 +14,15 @@ namespace Microsoft.ApplicationInspector.RulesEngine;
 /// </summary>
 internal sealed class RuleExpression
 {
-    private static readonly string[] Operators = { "AND", "OR", "XOR", "NAND", "NOR" };
+    /// <summary>
+    ///     Parsing recurses once per level of parenthesis nesting, as does the underlying engine's own
+    ///     evaluator, so nesting is capped well above anything an author would write by hand. Deeply
+    ///     nested input would otherwise exhaust the stack, which cannot be caught and takes the process
+    ///     down with it.
+    /// </summary>
+    internal const int MaxNestingDepth = 64;
 
-    private static readonly ConcurrentDictionary<string, RuleExpression?> Cache = new();
+    private static readonly string[] Operators = { "AND", "OR", "XOR", "NAND", "NOR" };
 
     private readonly Node _root;
 
@@ -27,22 +32,45 @@ internal sealed class RuleExpression
     }
 
     /// <summary>
-    ///     Parses an expression, returning null if it is malformed.
+    ///     Counts the deepest parenthesis nesting in an expression without parsing it, so callers can
+    ///     reject one before it reaches a recursive evaluator.
+    /// </summary>
+    internal static int MaxNestingOf(string expression)
+    {
+        var depth = 0;
+        var deepest = 0;
+
+        foreach (var character in expression)
+            if (character == '(')
+            {
+                depth++;
+                if (depth > deepest)
+                {
+                    deepest = depth;
+                }
+            }
+            else if (character == ')')
+            {
+                depth--;
+            }
+
+        return deepest;
+    }
+
+    /// <summary>
+    ///     Parses an expression, returning null if it is malformed or nested past <see cref="MaxNestingDepth" />.
     /// </summary>
     public static RuleExpression? TryParse(string expression)
     {
-        return Cache.GetOrAdd(expression, static toParse =>
+        var tokens = Tokenize(expression);
+        if (tokens.Count == 0)
         {
-            var tokens = Tokenize(toParse);
-            if (tokens.Count == 0)
-            {
-                return null;
-            }
+            return null;
+        }
 
-            var index = 0;
-            var root = ParseSequence(tokens, ref index);
-            return root is null || index != tokens.Count ? null : new RuleExpression(root);
-        });
+        var index = 0;
+        var root = ParseSequence(tokens, ref index, 0);
+        return root is null || index != tokens.Count ? null : new RuleExpression(root);
     }
 
     public bool Evaluate(Func<string, bool> labelValue)
@@ -93,9 +121,9 @@ internal sealed class RuleExpression
         return tokens;
     }
 
-    private static Node? ParseSequence(List<Token> tokens, ref int index)
+    private static Node? ParseSequence(List<Token> tokens, ref int index, int depth)
     {
-        var left = ParseTerm(tokens, ref index);
+        var left = ParseTerm(tokens, ref index, depth);
         if (left is null)
         {
             return null;
@@ -106,7 +134,7 @@ internal sealed class RuleExpression
             var op = tokens[index].Text;
             index++;
 
-            var right = ParseTerm(tokens, ref index);
+            var right = ParseTerm(tokens, ref index, depth);
             if (right is null)
             {
                 return null;
@@ -118,7 +146,7 @@ internal sealed class RuleExpression
         return left;
     }
 
-    private static Node? ParseTerm(List<Token> tokens, ref int index)
+    private static Node? ParseTerm(List<Token> tokens, ref int index, int depth)
     {
         var negate = false;
         while (index < tokens.Count && tokens[index].Kind == TokenKind.Not)
@@ -136,8 +164,13 @@ internal sealed class RuleExpression
 
         if (tokens[index].Kind == TokenKind.OpenParen)
         {
+            if (depth >= MaxNestingDepth)
+            {
+                return null;
+            }
+
             index++;
-            inner = ParseSequence(tokens, ref index);
+            inner = ParseSequence(tokens, ref index, depth + 1);
             if (inner is null || index >= tokens.Count || tokens[index].Kind != TokenKind.CloseParen)
             {
                 return null;

--- a/AppInspector.RulesEngine/RuleExpression.cs
+++ b/AppInspector.RulesEngine/RuleExpression.cs
@@ -123,27 +123,30 @@ internal sealed class RuleExpression
 
     private static Node? ParseSequence(List<Token> tokens, ref int index, int depth)
     {
-        var left = ParseTerm(tokens, ref index, depth);
-        if (left is null)
+        var first = ParseTerm(tokens, ref index, depth);
+        if (first is null)
         {
             return null;
         }
+
+        List<(string Operator, Node Operand)>? rest = null;
 
         while (index < tokens.Count && tokens[index].Kind == TokenKind.Operator)
         {
             var op = tokens[index].Text;
             index++;
 
-            var right = ParseTerm(tokens, ref index, depth);
-            if (right is null)
+            var operand = ParseTerm(tokens, ref index, depth);
+            if (operand is null)
             {
                 return null;
             }
 
-            left = new BinaryNode(op, left, right);
+            rest ??= new List<(string, Node)>();
+            rest.Add((op, operand));
         }
 
-        return left;
+        return rest is null ? first : new SequenceNode(first, rest);
     }
 
     private static Node? ParseTerm(List<Token> tokens, ref int index, int depth)
@@ -247,25 +250,33 @@ internal sealed class RuleExpression
         }
     }
 
-    private sealed class BinaryNode : Node
+    /// <summary>
+    ///     A run of operands folded left to right. Held flat rather than as a left leaning tree so that
+    ///     evaluating a long expression does not recurse once per operator.
+    /// </summary>
+    private sealed class SequenceNode : Node
     {
-        private readonly Node _left;
-        private readonly string _operator;
-        private readonly Node _right;
+        private readonly Node _first;
+        private readonly List<(string Operator, Node Operand)> _rest;
 
-        public BinaryNode(string op, Node left, Node right)
+        public SequenceNode(Node first, List<(string Operator, Node Operand)> rest)
         {
-            _operator = op;
-            _left = left;
-            _right = right;
+            _first = first;
+            _rest = rest;
         }
 
         public override bool Evaluate(Func<string, bool> labelValue)
         {
-            var left = _left.Evaluate(labelValue);
-            var right = _right.Evaluate(labelValue);
+            var current = _first.Evaluate(labelValue);
 
-            return _operator switch
+            foreach (var (op, operand) in _rest) current = Apply(op, current, operand.Evaluate(labelValue));
+
+            return current;
+        }
+
+        private static bool Apply(string op, bool left, bool right)
+        {
+            return op switch
             {
                 "AND" => left && right,
                 "OR" => left || right,

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -151,8 +151,8 @@ public class RuleProcessor
         var caps = _analyzer.GetCaptures(rules, textContainer);
         foreach (var ruleCapture in caps)
         {
-            var netCaptures = FilterCaptures(ruleCapture.Captures);
             var oatRule = ruleCapture.Rule as ConvertedOatRule;
+            var netCaptures = FilterCaptures(ruleCapture.Captures);
             foreach (var match in netCaptures)
             {
                 var patternIndex = match.Item1;
@@ -202,35 +202,83 @@ public class RuleProcessor
                 resultsList.Add(newMatch);
             }
 
-            // If a WithinClause capture is present, use only within captures, otherwise just flattens the list of results from the non-within clause.
+            // Conditions produce "gates": the subset of pattern matches that satisfied that condition. A rule level
+            // condition gates every match; a pattern level condition gates only the matches of its own pattern. A
+            // match survives if it is in every gate that applies to it.
             List<(int, Boundary)> FilterCaptures(List<ClauseCapture> captures)
             {
-                // If we had a WithinClause we only want the captures that passed the within filter.
-                if (captures.Any(x => x.Clause is WithinClause))
+                var ruleGates = new List<HashSet<(int, Boundary)>>();
+                var patternGates = new Dictionary<int, List<HashSet<(int, Boundary)>>>();
+                var allMatches = new List<(int, Boundary)>();
+                var seen = new HashSet<(int, Boundary)>();
+
+                foreach (var capture in captures)
                 {
-                    var onlyWithinCaptures = captures.Where(x => x.Clause is WithinClause)
-                        .Cast<TypedClauseCapture<List<(int, Boundary)>>>().ToList();
-                    var allCaptured = onlyWithinCaptures.SelectMany(x => x.Result);
-                    ConcurrentDictionary<(int, Boundary), int> numberOfInstances = new();
-                    // If there are multiple within clauses ensure that we only return matches which passed all clauses
-                    // WithinClauses are always ANDed, but each contains all the captures that passed *that* clause.
-                    // We need the captures that passed every clause.
-                    foreach (var aCapture in allCaptured)
+                    if (capture is not TypedClauseCapture<List<(int, Boundary)>> tcc || tcc.Result is null)
                     {
-                        numberOfInstances.AddOrUpdate(aCapture, 1, (tuple, i) => i + 1);
+                        continue;
                     }
-                    return numberOfInstances.Where(x => x.Value == onlyWithinCaptures.Count).Select(x => x.Key)
-                        .ToList();
+
+                    if (capture.Clause is WithinClause withinClause)
+                    {
+                        var gate = new HashSet<(int, Boundary)>(tcc.Result);
+                        if (withinClause.OwnerPatternIndex is { } owner)
+                        {
+                            if (!patternGates.TryGetValue(owner, out var gatesForPattern))
+                            {
+                                gatesForPattern = new List<HashSet<(int, Boundary)>>();
+                                patternGates[owner] = gatesForPattern;
+                            }
+
+                            gatesForPattern.Add(gate);
+                        }
+                        else
+                        {
+                            ruleGates.Add(gate);
+                        }
+                    }
+                    else
+                    {
+                        foreach (var match in tcc.Result)
+                            if (seen.Add(match))
+                            {
+                                allMatches.Add(match);
+                            }
+                    }
                 }
 
-                var outList = new List<(int, Boundary)>();
-                foreach (var cap in captures)
-                    if (cap is TypedClauseCapture<List<(int, Boundary)>> tcc)
+                if (ruleGates.Count == 0 && patternGates.Count == 0)
+                {
+                    return allMatches;
+                }
+
+                // A condition that failed outright contributes no gate. Its pattern's matches must still be dropped,
+                // so compare against the conditions the rule declares rather than only the gates that materialized.
+                var declaredGates = ruleCapture.Rule.Clauses.OfType<WithinClause>().ToList();
+                if (ruleGates.Count != declaredGates.Count(x => x.OwnerPatternIndex is null))
+                {
+                    return new List<(int, Boundary)>();
+                }
+
+                return allMatches.Where(Survives).ToList();
+
+                bool Survives((int, Boundary) match)
+                {
+                    if (!ruleGates.All(gate => gate.Contains(match)))
                     {
-                        outList.AddRange(tcc.Result);
+                        return false;
                     }
 
-                return outList;
+                    var declaredForPattern = declaredGates.Count(x => x.OwnerPatternIndex == match.Item1);
+                    if (declaredForPattern == 0)
+                    {
+                        return true;
+                    }
+
+                    return patternGates.TryGetValue(match.Item1, out var gatesForPattern) &&
+                           gatesForPattern.Count == declaredForPattern &&
+                           gatesForPattern.All(gate => gate.Contains(match));
+                }
             }
         }
 

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -477,8 +477,9 @@ public class RuleProcessor
         }
         catch (Exception e)
         {
-            _logger.LogDebug("Failed to analyze file {path}. {type}:{message}. ({stackTrace})",
-                fileEntry.FullPath, e.GetType(), e.Message, e.StackTrace);
+            // Analysis continues on empty content, so this must not be silent.
+            _logger.LogError("Failed to read {path} for analysis, it will be treated as empty. {type}:{message}",
+                fileEntry.FullPath, e.GetType(), e.Message);
         }
 
         return AnalyzeFile(contents, fileEntry, languageInfo, tagsToIgnore, numLinesContext);
@@ -510,8 +511,9 @@ public class RuleProcessor
         }
         catch (Exception e)
         {
-            _logger.LogDebug("Failed to analyze file {path}. {type}:{message}. ({stackTrace})",
-                fileEntry.FullPath, e.GetType(), e.Message, e.StackTrace);
+            // Analysis continues on empty content, so this must not be silent.
+            _logger.LogError("Failed to read {path} for analysis, it will be treated as empty. {type}:{message}",
+                fileEntry.FullPath, e.GetType(), e.Message);
         }
 
         TextContainer textContainer = new(contents, languageInfo.Name, _languages,

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -151,133 +151,17 @@ public class RuleProcessor
         var caps = _analyzer.GetCaptures(rules, textContainer);
         foreach (var ruleCapture in caps)
         {
-            var oatRule = ruleCapture.Rule as ConvertedOatRule;
-            var netCaptures = FilterCaptures(ruleCapture.Captures);
-            foreach (var match in netCaptures)
+            if (ruleCapture.Rule is not ConvertedOatRule oatRule)
             {
-                var patternIndex = match.Item1;
-                var boundary = match.Item2;
-                // Universal rules can reach build files incidentally, so suppress their non-Metadata tags by default.
-                if (!_opts.AllowAllTagsInBuildFiles &&
-                    languageInfo.Type == LanguageInfo.LangFileType.Build &&
-                    oatRule.AppInspectorRule.IsUniversal &&
-                    (oatRule.AppInspectorRule.Tags?.Any(v => !v.Contains("Metadata")) ?? false))
-                {
-                    continue;
-                }
-
-                if (!_opts.ConfidenceFilter.HasFlag(oatRule.AppInspectorRule.Patterns[patternIndex].Confidence))
-                {
-                    continue;
-                }
-
-                var startLocation = textContainer.GetLocation(boundary.Index);
-                var endLocation = textContainer.GetLocation(boundary.Index + boundary.Length);
-                MatchRecord newMatch = new(oatRule.AppInspectorRule)
-                {
-                    FileName = fileEntry.FullPath,
-                    FullTextContainer = textContainer,
-                    LanguageInfo = languageInfo,
-                    Boundary = boundary,
-                    StartLocationLine = startLocation.Line,
-                    StartLocationColumn = startLocation.Column,
-                    EndLocationLine =
-                        endLocation.Line != 0 ? endLocation.Line : startLocation.Line + 1, //match is on last line
-                    EndLocationColumn = endLocation.Column,
-                    MatchingPattern = oatRule.AppInspectorRule.Patterns[patternIndex],
-                    Excerpt = numLinesContext > 0
-                        ? ExtractExcerpt(textContainer, startLocation, endLocation, boundary, numLinesContext)
-                        : string.Empty,
-                    Sample = numLinesContext > -1
-                        ? ExtractTextSample(textContainer.FullContent, boundary.Index, boundary.Length)
-                        : string.Empty
-                };
-
-                if (oatRule.AppInspectorRule.Tags?.Contains("Dependency.SourceInclude") ?? false)
-                {
-                    newMatch.Sample = ExtractDependency(newMatch.FullTextContainer, newMatch.Boundary.Index,
-                        newMatch.Pattern, newMatch.LanguageInfo.Name);
-                }
-
-                resultsList.Add(newMatch);
+                continue;
             }
 
-            // Conditions produce "gates": the subset of pattern matches that satisfied that condition. A rule level
-            // condition gates every match; a pattern level condition gates only the matches of its own pattern. A
-            // match survives if it is in every gate that applies to it.
-            List<(int, Boundary)> FilterCaptures(List<ClauseCapture> captures)
+            foreach (var (patternIndex, boundary) in FilterCaptures(oatRule, ruleCapture.Captures))
             {
-                var ruleGates = new List<HashSet<(int, Boundary)>>();
-                var patternGates = new Dictionary<int, List<HashSet<(int, Boundary)>>>();
-                var allMatches = new List<(int, Boundary)>();
-                var seen = new HashSet<(int, Boundary)>();
-
-                foreach (var capture in captures)
+                if (BuildMatchRecord(oatRule, patternIndex, boundary, textContainer, fileEntry, languageInfo,
+                        numLinesContext) is { } newMatch)
                 {
-                    if (capture is not TypedClauseCapture<List<(int, Boundary)>> tcc || tcc.Result is null)
-                    {
-                        continue;
-                    }
-
-                    if (capture.Clause is WithinClause withinClause)
-                    {
-                        var gate = new HashSet<(int, Boundary)>(tcc.Result);
-                        if (withinClause.OwnerPatternIndex is { } owner)
-                        {
-                            if (!patternGates.TryGetValue(owner, out var gatesForPattern))
-                            {
-                                gatesForPattern = new List<HashSet<(int, Boundary)>>();
-                                patternGates[owner] = gatesForPattern;
-                            }
-
-                            gatesForPattern.Add(gate);
-                        }
-                        else
-                        {
-                            ruleGates.Add(gate);
-                        }
-                    }
-                    else
-                    {
-                        foreach (var match in tcc.Result)
-                            if (seen.Add(match))
-                            {
-                                allMatches.Add(match);
-                            }
-                    }
-                }
-
-                if (ruleGates.Count == 0 && patternGates.Count == 0)
-                {
-                    return allMatches;
-                }
-
-                // A condition that failed outright contributes no gate. Its pattern's matches must still be dropped,
-                // so compare against the conditions the rule declares rather than only the gates that materialized.
-                var declaredGates = ruleCapture.Rule.Clauses.OfType<WithinClause>().ToList();
-                if (ruleGates.Count != declaredGates.Count(x => x.OwnerPatternIndex is null))
-                {
-                    return new List<(int, Boundary)>();
-                }
-
-                return allMatches.Where(Survives).ToList();
-
-                bool Survives((int, Boundary) match)
-                {
-                    if (!ruleGates.All(gate => gate.Contains(match)))
-                    {
-                        return false;
-                    }
-
-                    var declaredForPattern = declaredGates.Count(x => x.OwnerPatternIndex == match.Item1);
-                    if (declaredForPattern == 0)
-                    {
-                        return true;
-                    }
-
-                    return patternGates.TryGetValue(match.Item1, out var gatesForPattern) &&
-                           gatesForPattern.Count == declaredForPattern &&
-                           gatesForPattern.All(gate => gate.Contains(match));
+                    resultsList.Add(newMatch);
                 }
             }
         }
@@ -305,6 +189,145 @@ public class RuleProcessor
         resultsList.RemoveAll(x => removes.Contains(x));
 
         return resultsList;
+    }
+
+    /// <summary>
+    ///     Reduces a rule's captures to the findings that should be reported.
+    ///     Conditions produce "gates": the subset of pattern matches that satisfied that condition. A rule level
+    ///     condition gates every match; a pattern level condition gates only the matches of its own pattern. A
+    ///     match survives if it is in every gate that applies to it.
+    /// </summary>
+    private static List<(int, Boundary)> FilterCaptures(ConvertedOatRule oatRule, List<ClauseCapture> captures)
+    {
+        var ruleGates = new List<HashSet<(int, Boundary)>>();
+        var patternGates = new Dictionary<int, List<HashSet<(int, Boundary)>>>();
+        var allMatches = new List<(int, Boundary)>();
+        var seen = new HashSet<(int, Boundary)>();
+
+        foreach (var capture in captures)
+        {
+            if (capture is not TypedClauseCapture<List<(int, Boundary)>> tcc || tcc.Result is null)
+            {
+                continue;
+            }
+
+            if (capture.Clause is WithinClause withinClause)
+            {
+                var gate = new HashSet<(int, Boundary)>(tcc.Result);
+                if (withinClause.OwnerPatternIndex is { } owner)
+                {
+                    if (!patternGates.TryGetValue(owner, out var gatesForPattern))
+                    {
+                        gatesForPattern = new List<HashSet<(int, Boundary)>>();
+                        patternGates[owner] = gatesForPattern;
+                    }
+
+                    gatesForPattern.Add(gate);
+                }
+                else
+                {
+                    ruleGates.Add(gate);
+                }
+            }
+            else
+            {
+                foreach (var match in tcc.Result)
+                    if (seen.Add(match))
+                    {
+                        allMatches.Add(match);
+                    }
+            }
+        }
+
+        if (ruleGates.Count == 0 && patternGates.Count == 0)
+        {
+            return allMatches;
+        }
+
+        // A condition that failed outright contributes no gate. Its pattern's matches must still be dropped,
+        // so compare against the conditions the rule declares rather than only the gates that materialized.
+        var declaredGates = oatRule.Clauses.OfType<WithinClause>().ToList();
+        if (ruleGates.Count != declaredGates.Count(x => x.OwnerPatternIndex is null))
+        {
+            return new List<(int, Boundary)>();
+        }
+
+        return allMatches.Where(Survives).ToList();
+
+        bool Survives((int, Boundary) match)
+        {
+            if (!ruleGates.All(gate => gate.Contains(match)))
+            {
+                return false;
+            }
+
+            var declaredForPattern = declaredGates.Count(x => x.OwnerPatternIndex == match.Item1);
+            if (declaredForPattern == 0)
+            {
+                return true;
+            }
+
+            return patternGates.TryGetValue(match.Item1, out var gatesForPattern) &&
+                   gatesForPattern.Count == declaredForPattern &&
+                   gatesForPattern.All(gate => gate.Contains(match));
+        }
+    }
+
+    /// <summary>
+    ///     Builds the <see cref="MatchRecord" /> for one finding, or returns null if the finding is filtered out.
+    /// </summary>
+    private MatchRecord? BuildMatchRecord(ConvertedOatRule oatRule, int patternIndex, Boundary boundary,
+        TextContainer textContainer, FileEntry fileEntry, LanguageInfo languageInfo, int numLinesContext)
+    {
+        // Universal rules can reach build files incidentally, so suppress their non-Metadata tags by default.
+        if (!_opts.AllowAllTagsInBuildFiles &&
+            languageInfo.Type == LanguageInfo.LangFileType.Build &&
+            oatRule.AppInspectorRule.IsUniversal &&
+            (oatRule.AppInspectorRule.Tags?.Any(v => !v.Contains("Metadata")) ?? false))
+        {
+            return null;
+        }
+
+        if (patternIndex < 0 || patternIndex >= oatRule.AppInspectorRule.Patterns.Length)
+        {
+            _logger.LogError("Index out of range for patterns for rule: {ruleName}", oatRule.AppInspectorRule.Name);
+            return null;
+        }
+
+        if (!_opts.ConfidenceFilter.HasFlag(oatRule.AppInspectorRule.Patterns[patternIndex].Confidence))
+        {
+            return null;
+        }
+
+        var startLocation = textContainer.GetLocation(boundary.Index);
+        var endLocation = textContainer.GetLocation(boundary.Index + boundary.Length);
+        MatchRecord newMatch = new(oatRule.AppInspectorRule)
+        {
+            FileName = fileEntry.FullPath,
+            FullTextContainer = textContainer,
+            LanguageInfo = languageInfo,
+            Boundary = boundary,
+            StartLocationLine = startLocation.Line,
+            StartLocationColumn = startLocation.Column,
+            EndLocationLine =
+                endLocation.Line != 0 ? endLocation.Line : startLocation.Line + 1, //match is on last line
+            EndLocationColumn = endLocation.Column,
+            MatchingPattern = oatRule.AppInspectorRule.Patterns[patternIndex],
+            Excerpt = numLinesContext > 0
+                ? ExtractExcerpt(textContainer, startLocation, endLocation, boundary, numLinesContext)
+                : string.Empty,
+            Sample = numLinesContext > -1
+                ? ExtractTextSample(textContainer.FullContent, boundary.Index, boundary.Length)
+                : string.Empty
+        };
+
+        if (oatRule.AppInspectorRule.Tags?.Contains("Dependency.SourceInclude") ?? false)
+        {
+            newMatch.Sample = ExtractDependency(newMatch.FullTextContainer, newMatch.Boundary.Index,
+                newMatch.Pattern, newMatch.LanguageInfo.Name);
+        }
+
+        return newMatch;
     }
 
     /// <summary>
@@ -390,89 +413,23 @@ public class RuleProcessor
             _languages, _opts.LoggerFactory ?? NullLoggerFactory.Instance, fileEntry.FullPath);
         foreach (var ruleCapture in _analyzer.GetCaptures(rules, textContainer))
         {
-            // If we had a WithinClause we only want the captures that passed the within filter.
-            var filteredCaptures = ruleCapture.Captures.Any(x => x.Clause is WithinClause)
-                ? ruleCapture.Captures.Where(x => x.Clause is WithinClause)
-                : ruleCapture.Captures;
             if (cancellationToken?.IsCancellationRequested is true)
             {
                 return resultsList;
             }
 
-            foreach (var cap in filteredCaptures) resultsList.AddRange(ProcessBoundary(cap));
-
-            List<MatchRecord> ProcessBoundary(ClauseCapture cap)
+            if (ruleCapture.Rule is not ConvertedOatRule oatRule)
             {
-                List<MatchRecord> newMatches = new(); //matches for this rule clause only
+                continue;
+            }
 
-                if (cap is TypedClauseCapture<List<(int, Boundary)>> tcc)
+            foreach (var (patternIndex, boundary) in FilterCaptures(oatRule, ruleCapture.Captures))
+            {
+                if (BuildMatchRecord(oatRule, patternIndex, boundary, textContainer, fileEntry, languageInfo,
+                        numLinesContext) is { } newMatch)
                 {
-                    if (ruleCapture.Rule is ConvertedOatRule oatRule)
-                    {
-                        if (tcc.Result is { } captureResults)
-                        {
-                            foreach (var match in captureResults)
-                            {
-                                var patternIndex = match.Item1;
-                                var boundary = match.Item2;
-
-                                // Universal rules can reach build files incidentally, so suppress their non-Metadata tags by default.
-                                if (!_opts.AllowAllTagsInBuildFiles &&
-                                    languageInfo.Type == LanguageInfo.LangFileType.Build &&
-                                    oatRule.AppInspectorRule.IsUniversal &&
-                                    (oatRule.AppInspectorRule.Tags?.Any(v => !v.Contains("Metadata")) ?? false))
-                                {
-                                    continue;
-                                }
-
-                                if (patternIndex < 0 || patternIndex > oatRule.AppInspectorRule.Patterns.Length)
-                                {
-                                    _logger.LogError("Index out of range for patterns for rule: {ruleName}",
-                                        oatRule.AppInspectorRule.Name);
-                                    continue;
-                                }
-
-                                if (!_opts.ConfidenceFilter.HasFlag(oatRule.AppInspectorRule.Patterns[patternIndex]
-                                        .Confidence))
-                                {
-                                    continue;
-                                }
-
-                                var startLocation = textContainer.GetLocation(boundary.Index);
-                                var endLocation = textContainer.GetLocation(boundary.Index + boundary.Length);
-                                MatchRecord newMatch = new(oatRule.AppInspectorRule)
-                                {
-                                    FileName = fileEntry.FullPath,
-                                    FullTextContainer = textContainer,
-                                    LanguageInfo = languageInfo,
-                                    Boundary = boundary,
-                                    StartLocationLine = startLocation.Line,
-                                    EndLocationLine =
-                                        endLocation.Line != 0
-                                            ? endLocation.Line
-                                            : startLocation.Line + 1, //match is on last line
-                                    MatchingPattern = oatRule.AppInspectorRule.Patterns[patternIndex],
-                                    Excerpt = numLinesContext > 0
-                                        ? ExtractExcerpt(textContainer, startLocation, endLocation, boundary, numLinesContext)
-                                        : string.Empty,
-                                    Sample = numLinesContext > -1
-                                        ? ExtractTextSample(textContainer.FullContent, boundary.Index, boundary.Length)
-                                        : string.Empty
-                                };
-
-                                if (oatRule.AppInspectorRule.Tags?.Contains("Dependency.SourceInclude") ?? false)
-                                {
-                                    newMatch.Sample = ExtractDependency(newMatch.FullTextContainer,
-                                        newMatch.Boundary.Index, newMatch.Pattern, newMatch.LanguageInfo.Name);
-                                }
-
-                                newMatches.Add(newMatch);
-                            }
-                        }
-                    }
+                    resultsList.Add(newMatch);
                 }
-
-                return newMatches;
             }
         }
 

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -145,12 +145,27 @@ public class RuleProcessor
     public List<MatchRecord> AnalyzeFile(TextContainer textContainer, FileEntry fileEntry,
         LanguageInfo languageInfo, IEnumerable<string>? tagsToIgnore = null, int numLinesContext = 3)
     {
+        return AnalyzeTextContainer(textContainer, fileEntry, languageInfo, tagsToIgnore, numLinesContext, null);
+    }
+
+    /// <summary>
+    ///     The single implementation behind every analysis entry point, so the synchronous and asynchronous
+    ///     APIs cannot report different results for the same input.
+    /// </summary>
+    private List<MatchRecord> AnalyzeTextContainer(TextContainer textContainer, FileEntry fileEntry,
+        LanguageInfo languageInfo, IEnumerable<string>? tagsToIgnore, int numLinesContext,
+        CancellationToken? cancellationToken)
+    {
         var rules = GetRulesForFile(languageInfo, fileEntry, tagsToIgnore);
         List<MatchRecord> resultsList = new();
 
-        var caps = _analyzer.GetCaptures(rules, textContainer);
-        foreach (var ruleCapture in caps)
+        foreach (var ruleCapture in _analyzer.GetCaptures(rules, textContainer))
         {
+            if (cancellationToken?.IsCancellationRequested is true)
+            {
+                return resultsList;
+            }
+
             if (ruleCapture.Rule is not ConvertedOatRule oatRule)
             {
                 continue;
@@ -166,7 +181,7 @@ public class RuleProcessor
             }
         }
 
-        RemoveOverriddenMatches(resultsList);
+        RemoveOverriddenMatches(resultsList, cancellationToken);
 
         return resultsList;
     }
@@ -458,49 +473,48 @@ public class RuleProcessor
         }
         catch (Exception e)
         {
-            _logger.LogDebug("Failed to analyze file {path}. {type}:{message}. ({stackTrace}), fileRecord.FileName",
+            _logger.LogDebug("Failed to analyze file {path}. {type}:{message}. ({stackTrace})",
                 fileEntry.FullPath, e.GetType(), e.Message, e.StackTrace);
         }
 
         return AnalyzeFile(contents, fileEntry, languageInfo, tagsToIgnore, numLinesContext);
     }
 
+    /// <summary>
+    ///     Analyzes a file and returns a list of <see cref="MatchRecord" />
+    /// </summary>
+    /// <param name="fileEntry">
+    ///     FileEntry which holds the name of the file being analyzed as well as a Stream containing the
+    ///     contents to analyze
+    /// </param>
+    /// <param name="languageInfo">The LanguageInfo for the file</param>
+    /// <param name="cancellationToken">Token to abort the analysis</param>
+    /// <param name="tagsToIgnore">Ignore rules that match tags that are only in the tags to ignore list</param>
+    /// <param name="numLinesContext">
+    ///     Number of lines of text to extract for the sample. Set to 0 to disable context gathering.
+    ///     Set to -1 to also disable sampling the match.
+    /// </param>
+    /// <returns>A List of the matches against the Rules the processor is configured with.</returns>
     public async Task<List<MatchRecord>> AnalyzeFileAsync(FileEntry fileEntry, LanguageInfo languageInfo,
         CancellationToken? cancellationToken = null, IEnumerable<string>? tagsToIgnore = null, int numLinesContext = 3)
     {
-        var rules = GetRulesForFile(languageInfo, fileEntry, tagsToIgnore);
-
-        List<MatchRecord> resultsList = new();
-
         using var sr = new StreamReader(fileEntry.Content);
-
-        TextContainer textContainer = new(await sr.ReadToEndAsync().ConfigureAwait(false), languageInfo.Name,
-            _languages, _opts.LoggerFactory ?? NullLoggerFactory.Instance, fileEntry.FullPath);
-        foreach (var ruleCapture in _analyzer.GetCaptures(rules, textContainer))
+        var contents = string.Empty;
+        try
         {
-            if (cancellationToken?.IsCancellationRequested is true)
-            {
-                return resultsList;
-            }
-
-            if (ruleCapture.Rule is not ConvertedOatRule oatRule)
-            {
-                continue;
-            }
-
-            foreach (var (patternIndex, boundary) in FilterCaptures(oatRule, ruleCapture.Captures))
-            {
-                if (BuildMatchRecord(oatRule, patternIndex, boundary, textContainer, fileEntry, languageInfo,
-                        numLinesContext) is { } newMatch)
-                {
-                    resultsList.Add(newMatch);
-                }
-            }
+            contents = await sr.ReadToEndAsync().ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug("Failed to analyze file {path}. {type}:{message}. ({stackTrace})",
+                fileEntry.FullPath, e.GetType(), e.Message, e.StackTrace);
         }
 
-        RemoveOverriddenMatches(resultsList, cancellationToken);
+        TextContainer textContainer = new(contents, languageInfo.Name, _languages,
+            _opts.LoggerFactory ?? NullLoggerFactory.Instance, fileEntry.FullPath);
 
-        return resultsList;
+        return AnalyzeTextContainer(textContainer, fileEntry, languageInfo, tagsToIgnore, numLinesContext,
+            cancellationToken);
     }
 
 

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -166,29 +166,40 @@ public class RuleProcessor
             }
         }
 
+        RemoveOverriddenMatches(resultsList);
+
+        return resultsList;
+    }
+
+    /// <summary>
+    ///     Drops findings that a matched overriding rule supersedes. A finding is only superseded when it
+    ///     lies entirely within the overriding finding, so an overlapping but wider finding is kept.
+    /// </summary>
+    private static void RemoveOverriddenMatches(List<MatchRecord> matches,
+        CancellationToken? cancellationToken = null)
+    {
         List<MatchRecord> removes = new();
 
-        foreach (var m in resultsList.Where(x => x.Rule?.Overrides?.Count > 0))
+        foreach (var overridingMatch in matches.Where(x => x.Rule?.Overrides?.Count > 0))
         {
-            foreach (var idsToOverride in m.Rule?.Overrides ?? Array.Empty<string>())
+            if (cancellationToken?.IsCancellationRequested is true)
             {
-                // Find all overriden rules and mark them for removal from issues list
-                foreach (var om in resultsList.FindAll(x => x.Rule?.Id == idsToOverride))
+                return;
+            }
+
+            foreach (var idToOverride in overridingMatch.Rule?.Overrides ?? Array.Empty<string>())
+            foreach (var overriddenMatch in matches.FindAll(x => x.Rule?.Id == idToOverride))
+            {
+                if (overriddenMatch.Boundary.Index >= overridingMatch.Boundary.Index &&
+                    overriddenMatch.Boundary.Index + overriddenMatch.Boundary.Length <=
+                    overridingMatch.Boundary.Index + overridingMatch.Boundary.Length)
                 {
-                    // If the overridden match is a subset of the overriding match
-                    if (om.Boundary.Index >= m.Boundary.Index &&
-                        om.Boundary.Index <= m.Boundary.Index + m.Boundary.Length)
-                    {
-                        removes.Add(om);
-                    }
+                    removes.Add(overriddenMatch);
                 }
             }
         }
 
-        // Remove overriden rules
-        resultsList.RemoveAll(x => removes.Contains(x));
-
-        return resultsList;
+        matches.RemoveAll(x => removes.Contains(x));
     }
 
     /// <summary>
@@ -487,35 +498,7 @@ public class RuleProcessor
             }
         }
 
-        List<MatchRecord> removes = new();
-
-        foreach (var matchRecord in resultsList.Where(x => x.Rule?.Overrides?.Count > 0))
-        {
-            if (cancellationToken?.IsCancellationRequested is true)
-            {
-                return resultsList;
-            }
-
-            foreach (var idToOverride in matchRecord.Rule?.Overrides ?? Array.Empty<string>())
-            {
-                // Find all overriden rules and mark them for removal from issues list
-                foreach (var potentialOverriddenMatch in resultsList.FindAll(x => x.Rule?.Id == idToOverride))
-                {
-                    // Start after or matching start
-                    if (potentialOverriddenMatch.Boundary.Index >= matchRecord.Boundary.Index &&
-                        // End before or matching end
-                        (potentialOverriddenMatch.Boundary.Index + potentialOverriddenMatch.Boundary.Length)
-                            <= (matchRecord.Boundary.Index + matchRecord.Boundary.Length))
-                    {
-                        removes.Add(potentialOverriddenMatch);
-                    }
-                }
-            }
-           
-        }
-
-        // Remove overriden rules
-        resultsList.RemoveAll(x => removes.Contains(x));
+        RemoveOverriddenMatches(resultsList, cancellationToken);
 
         return resultsList;
     }

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -199,6 +199,12 @@ public class RuleProcessor
     /// </summary>
     private static List<(int, Boundary)> FilterCaptures(ConvertedOatRule oatRule, List<ClauseCapture> captures)
     {
+        // Gate membership assumes conditions are ANDed, which an authored expression need not be.
+        if (!string.IsNullOrWhiteSpace(oatRule.AppInspectorRule.Expression))
+        {
+            return FilterCapturesByExpression(oatRule, captures);
+        }
+
         var ruleGates = new List<HashSet<(int, Boundary)>>();
         var patternGates = new Dictionary<int, List<HashSet<(int, Boundary)>>>();
         var allMatches = new List<(int, Boundary)>();
@@ -271,6 +277,54 @@ public class RuleProcessor
                    gatesForPattern.Count == declaredForPattern &&
                    gatesForPattern.All(gate => gate.Contains(match));
         }
+    }
+
+    /// <summary>
+    ///     Reports the findings that individually satisfy the rule's expression. The engine only tells us
+    ///     that the rule matched, so each candidate finding is re-evaluated against the expression using
+    ///     which clauses reported it.
+    /// </summary>
+    private static List<(int, Boundary)> FilterCapturesByExpression(ConvertedOatRule oatRule,
+        List<ClauseCapture> captures)
+    {
+        if (oatRule.Expression is null || RuleExpression.TryParse(oatRule.Expression) is not { } expression)
+        {
+            return new List<(int, Boundary)>();
+        }
+
+        Dictionary<string, HashSet<(int, Boundary)>> reportedByLabel = new();
+        List<(int, Boundary)> candidates = new();
+        HashSet<(int, Boundary)> seenCandidates = new();
+
+        foreach (var capture in captures)
+        {
+            if (capture is not TypedClauseCapture<List<(int, Boundary)>> tcc || capture.Clause?.Label is not { } label)
+            {
+                continue;
+            }
+
+            if (!reportedByLabel.TryGetValue(label, out var reported))
+            {
+                reported = new HashSet<(int, Boundary)>();
+                reportedByLabel[label] = reported;
+            }
+
+            foreach (var finding in tcc.Result)
+            {
+                reported.Add(finding);
+
+                // Only patterns originate findings; conditions merely retain them.
+                if (capture.Clause is not WithinClause && seenCandidates.Add(finding))
+                {
+                    candidates.Add(finding);
+                }
+            }
+        }
+
+        return candidates
+            .Where(candidate => expression.Evaluate(label =>
+                reportedByLabel.TryGetValue(label, out var reported) && reported.Contains(candidate)))
+            .ToList();
     }
 
     /// <summary>

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -306,9 +306,13 @@ public class RuleProcessor
     }
 
     /// <summary>
-    ///     Reports the findings that individually satisfy the rule's expression. The engine only tells us
-    ///     that the rule matched, so each candidate finding is re-evaluated against the expression using
-    ///     which clauses reported it.
+    ///     Reports the findings that individually satisfy the rule's expression.
+    ///     The engine evaluates the same expression, but only to decide whether the rule matched at all; it
+    ///     has no notion of which findings satisfied it. Its captures approximate that, because a
+    ///     sub-expression that evaluated false contributes none, which is why most shapes report correctly
+    ///     without this. It breaks down when sibling conditions each succeed for a different finding: both
+    ///     contribute captures, and intersecting them then demands one finding that passed every condition
+    ///     and reports nothing. Re-evaluating per finding is what makes those report correctly.
     /// </summary>
     private List<(int, Boundary)> FilterCapturesByExpression(ConvertedOatRule oatRule,
         List<ClauseCapture> captures)

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -322,7 +322,7 @@ public class RuleProcessor
             // Verification rejects these, so reaching here means the rule set was not verified.
             _logger.LogError(
                 "Expression '{expression}' in rule {id} could not be parsed, so no findings will be reported for it.",
-                oatRule.Expression, oatRule.AppInspectorRule.Id);
+                oatRule.AppInspectorRule.Expression, oatRule.AppInspectorRule.Id);
             return new List<(int, Boundary)>();
         }
 

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -193,7 +193,7 @@ public class RuleProcessor
     private static void RemoveOverriddenMatches(List<MatchRecord> matches,
         CancellationToken? cancellationToken = null)
     {
-        List<MatchRecord> removes = new();
+        HashSet<MatchRecord> removes = new();
 
         foreach (var overridingMatch in matches.Where(x => x.Rule?.Overrides?.Count > 0))
         {

--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -223,7 +223,7 @@ public class RuleProcessor
     ///     condition gates every match; a pattern level condition gates only the matches of its own pattern. A
     ///     match survives if it is in every gate that applies to it.
     /// </summary>
-    private static List<(int, Boundary)> FilterCaptures(ConvertedOatRule oatRule, List<ClauseCapture> captures)
+    private List<(int, Boundary)> FilterCaptures(ConvertedOatRule oatRule, List<ClauseCapture> captures)
     {
         // Gate membership assumes conditions are ANDed, which an authored expression need not be.
         if (!string.IsNullOrWhiteSpace(oatRule.AppInspectorRule.Expression))
@@ -310,11 +310,15 @@ public class RuleProcessor
     ///     that the rule matched, so each candidate finding is re-evaluated against the expression using
     ///     which clauses reported it.
     /// </summary>
-    private static List<(int, Boundary)> FilterCapturesByExpression(ConvertedOatRule oatRule,
+    private List<(int, Boundary)> FilterCapturesByExpression(ConvertedOatRule oatRule,
         List<ClauseCapture> captures)
     {
-        if (oatRule.Expression is null || RuleExpression.TryParse(oatRule.Expression) is not { } expression)
+        if (oatRule.ParsedExpression is not { } expression)
         {
+            // Verification rejects these, so reaching here means the rule set was not verified.
+            _logger.LogError(
+                "Expression '{expression}' in rule {id} could not be parsed, so no findings will be reported for it.",
+                oatRule.Expression, oatRule.AppInspectorRule.Id);
             return new List<(int, Boundary)>();
         }
 

--- a/AppInspector.RulesEngine/RulesVerifier.cs
+++ b/AppInspector.RulesEngine/RulesVerifier.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -357,6 +358,8 @@ public class RulesVerifier
         }
 
 
+        errors.AddRange(ValidateExpression(rule, convertedOatRule));
+
         var singleList = new[] { convertedOatRule };
 
         // We need to provide a language for the TextContainer, which will later be referenced by the Rule when executed.
@@ -440,5 +443,91 @@ public class RulesVerifier
             SchemaValidationErrors = schemaErrors,
             PassedSchemaValidation = passedSchemaValidation
         };
+    }
+
+    private static readonly string[] BinaryOperators = { "AND", "OR", "XOR", "NAND", "NOR" };
+
+    /// <summary>
+    ///     Validates labels, <see cref="Rule.Expression" /> and condition scoping.
+    /// </summary>
+    private IEnumerable<string> ValidateExpression(Rule rule, ConvertedOatRule convertedOatRule)
+    {
+        List<string> errors = new();
+
+        void Error(string message)
+        {
+            _logger?.LogError("{Message}", message);
+            errors.Add(message);
+        }
+
+        foreach (var label in convertedOatRule.Clauses.Select(x => x.Label))
+        {
+            if (label is not null && (label.Any(char.IsWhiteSpace) || label.Contains('(') || label.Contains(')')))
+            {
+                Error(
+                    $"Label '{label}' in rule {rule.Id} may not contain whitespace or parentheses because expressions are split on spaces.");
+            }
+        }
+
+        // A duplicated label makes OAT abandon the expression, so the rule would silently never match.
+        foreach (var duplicate in convertedOatRule.Clauses.Select(x => x.Label).Where(x => x is not null)
+                     .GroupBy(x => x).Where(x => x.Count() > 1).Select(x => x.Key))
+        {
+            Error($"Label '{duplicate}' is used by more than one pattern or condition in rule {rule.Id}.");
+        }
+
+        var patternLabels = rule.Patterns
+            .Select((pattern, index) => pattern.Label ?? index.ToString(CultureInfo.InvariantCulture)).ToList();
+
+        if (string.IsNullOrWhiteSpace(rule.Expression))
+        {
+            return errors;
+        }
+
+        var expression = rule.Expression!;
+
+        if (rule.Conditions?.Any(x => x.NegateFinding) ?? false)
+        {
+            Error(
+                $"Rule {rule.Id} supplies an expression, so negation must be expressed with NOT in the expression rather than negate_finding.");
+        }
+
+        var tokens = expression.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        var depth = 0;
+        var operatorsSeenAtDepth = new Dictionary<int, HashSet<string>>();
+
+        foreach (var token in tokens)
+        {
+            depth += token.Count(x => x == '(');
+
+            var bare = token.Trim('(', ')');
+            if (BinaryOperators.Contains(bare, StringComparer.OrdinalIgnoreCase))
+            {
+                if (!operatorsSeenAtDepth.TryGetValue(depth, out var seen))
+                {
+                    seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    operatorsSeenAtDepth[depth] = seen;
+                }
+
+                seen.Add(bare);
+            }
+
+            depth -= token.Count(x => x == ')');
+        }
+
+        if (depth != 0)
+        {
+            Error($"Expression '{expression}' in rule {rule.Id} has unbalanced parentheses.");
+        }
+
+        // Expressions are folded left to right with no operator precedence, so mixing operators without
+        // parentheses almost never means what the author intended.
+        foreach (var level in operatorsSeenAtDepth.Where(x => x.Value.Count > 1))
+        {
+            Error(
+                $"Expression '{expression}' in rule {rule.Id} mixes the operators {string.Join(", ", level.Value.OrderBy(x => x))} without parentheses. Expressions are evaluated left to right with no operator precedence, so add parentheses to make the grouping explicit.");
+        }
+
+        return errors;
     }
 }

--- a/AppInspector.RulesEngine/RulesVerifier.cs
+++ b/AppInspector.RulesEngine/RulesVerifier.cs
@@ -432,7 +432,9 @@ public class RulesVerifier
             RulesId = rule.Id,
             RulesName = rule.Name,
             Errors = errors,
-            OatIssues = _analyzer.EnumerateRuleIssues(convertedOatRule),
+            // Materialized because RuleStatus.Verified and any consumer reporting the issues each
+            // enumerate this, and EnumerateRuleIssues re-runs the whole check on every enumeration.
+            OatIssues = _analyzer.EnumerateRuleIssues(convertedOatRule).ToList(),
             HasPositiveSelfTests = rule.MustMatch?.Count > 0,
             HasNegativeSelfTests = rule.MustNotMatch?.Count > 0,
             SchemaValidationErrors = schemaErrors,

--- a/AppInspector.RulesEngine/RulesVerifier.cs
+++ b/AppInspector.RulesEngine/RulesVerifier.cs
@@ -520,6 +520,12 @@ public class RulesVerifier
             Error($"Expression '{expression}' in rule {rule.Id} has unbalanced parentheses.");
         }
 
+        if (RuleExpression.MaxNestingOf(expression) > RuleExpression.MaxNestingDepth)
+        {
+            Error(
+                $"Expression in rule {rule.Id} nests parentheses more than {RuleExpression.MaxNestingDepth} deep. Evaluation recurses once per level, so this would exhaust the stack.");
+        }
+
         // Expressions are folded left to right with no operator precedence, so mixing operators without
         // parentheses almost never means what the author intended.
         foreach (var level in operatorsSeenAtDepth.Where(x => x.Value.Count > 1))

--- a/AppInspector.RulesEngine/RulesVerifier.cs
+++ b/AppInspector.RulesEngine/RulesVerifier.cs
@@ -358,7 +358,10 @@ public class RulesVerifier
         }
 
 
-        errors.AddRange(ValidateExpression(rule, convertedOatRule));
+        var expressionErrors = ValidateExpression(rule, convertedOatRule).ToList();
+        errors.AddRange(expressionErrors);
+
+        var oatIssues = _analyzer.EnumerateRuleIssues(convertedOatRule).ToList();
 
         var singleList = new[] { convertedOatRule };
 
@@ -371,11 +374,19 @@ public class RulesVerifier
                            !convertedOatRule.AppInspectorRule.DoesNotApplyTo?.Contains(x,
                                StringComparer.InvariantCultureIgnoreCase) ?? true) ?? "Rule Verifier Default Value";
 
+        // Self tests run the rule, and a rule already known to be malformed can fail hard rather than
+        // simply not matching, so only run them once the rule is structurally sound.
+        var ruleIsSound = expressionErrors.Count == 0 && oatIssues.Count == 0;
+
         // validate all must match samples are matched
         foreach (var mustMatchElement in (IList<string>?)rule.MustMatch ?? Array.Empty<string>())
         {
-            var tc = new TextContainer(mustMatchElement, language, _options.LanguageSpecs);
-            if (!_analyzer.Analyze(singleList, tc).Any())
+            if (!ruleIsSound)
+            {
+                break;
+            }
+
+            if (!SelfTestMatches(singleList, mustMatchElement, language, rule, errors))
             {
                 _logger?.LogError("Rule {ID} does not match the 'MustMatch' test {MustMatch}. ", rule.Id,
                     mustMatchElement);
@@ -386,8 +397,12 @@ public class RulesVerifier
         // validate no must not match conditions are matched
         foreach (var mustNotMatchElement in (IList<string>?)rule.MustNotMatch ?? Array.Empty<string>())
         {
-            var tc = new TextContainer(mustNotMatchElement, language, _options.LanguageSpecs);
-            if (_analyzer.Analyze(singleList, tc).Any())
+            if (!ruleIsSound)
+            {
+                break;
+            }
+
+            if (SelfTestMatches(singleList, mustNotMatchElement, language, rule, errors))
             {
                 _logger?.LogError("Rule {ID} matches the 'MustNotMatch' test '{MustNotMatch}'. ", rule.Id,
                     mustNotMatchElement);
@@ -437,7 +452,7 @@ public class RulesVerifier
             Errors = errors,
             // Materialized because RuleStatus.Verified and any consumer reporting the issues each
             // enumerate this, and EnumerateRuleIssues re-runs the whole check on every enumeration.
-            OatIssues = _analyzer.EnumerateRuleIssues(convertedOatRule).ToList(),
+            OatIssues = oatIssues,
             HasPositiveSelfTests = rule.MustMatch?.Count > 0,
             HasNegativeSelfTests = rule.MustNotMatch?.Count > 0,
             SchemaValidationErrors = schemaErrors,
@@ -446,6 +461,27 @@ public class RulesVerifier
     }
 
     private static readonly string[] BinaryOperators = { "AND", "OR", "XOR", "NAND", "NOR" };
+
+    /// <summary>
+    ///     Runs one self-test sample. A rule can fail hard rather than simply not matching, and a bad rule
+    ///     must not take verification down with it, so failures are reported as verification errors.
+    /// </summary>
+    private bool SelfTestMatches(ConvertedOatRule[] rules, string sample, string language, Rule rule,
+        List<string> errors)
+    {
+        try
+        {
+            var tc = new TextContainer(sample, language, _options.LanguageSpecs);
+            return _analyzer.Analyze(rules, tc).Any();
+        }
+        catch (Exception e)
+        {
+            _logger?.LogError("Rule {ID} failed to run against its self-test sample. {Type}: {Message}", rule.Id,
+                e.GetType(), e.Message);
+            errors.Add($"Rule {rule.Id} failed to run against its self-test sample. {e.GetType()}: {e.Message}");
+            return false;
+        }
+    }
 
     /// <summary>
     ///     Validates labels, <see cref="Rule.Expression" /> and condition scoping.
@@ -494,25 +530,41 @@ public class RulesVerifier
 
         var tokens = expression.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
         var depth = 0;
-        var operatorsSeenAtDepth = new Dictionary<int, HashSet<string>>();
+        var nextGroup = 0;
+        // Sibling groups at the same nesting level are independent, so operators are tracked per group
+        // rather than per depth.
+        var openGroups = new Stack<int>();
+        openGroups.Push(nextGroup++);
+        var operatorsByGroup = new Dictionary<int, HashSet<string>>();
 
         foreach (var token in tokens)
         {
-            depth += token.Count(x => x == '(');
+            foreach (var _ in token.Where(x => x == '('))
+            {
+                depth++;
+                openGroups.Push(nextGroup++);
+            }
 
             var bare = token.Trim('(', ')');
             if (BinaryOperators.Contains(bare, StringComparer.OrdinalIgnoreCase))
             {
-                if (!operatorsSeenAtDepth.TryGetValue(depth, out var seen))
+                if (!operatorsByGroup.TryGetValue(openGroups.Peek(), out var seen))
                 {
                     seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    operatorsSeenAtDepth[depth] = seen;
+                    operatorsByGroup[openGroups.Peek()] = seen;
                 }
 
                 seen.Add(bare);
             }
 
-            depth -= token.Count(x => x == ')');
+            foreach (var _ in token.Where(x => x == ')'))
+            {
+                depth--;
+                if (openGroups.Count > 1)
+                {
+                    openGroups.Pop();
+                }
+            }
         }
 
         if (depth != 0)
@@ -526,14 +578,69 @@ public class RulesVerifier
                 $"Expression in rule {rule.Id} nests parentheses more than {RuleExpression.MaxNestingDepth} deep. Evaluation recurses once per level, so this would exhaust the stack.");
         }
 
-        // Expressions are folded left to right with no operator precedence, so mixing operators without
-        // parentheses almost never means what the author intended.
-        foreach (var level in operatorsSeenAtDepth.Where(x => x.Value.Count > 1))
+        // Expressions are folded left to right with no operator precedence, so mixing operators within one
+        // group almost never means what the author intended.
+        foreach (var group in operatorsByGroup.Where(x => x.Value.Count > 1))
         {
             Error(
-                $"Expression '{expression}' in rule {rule.Id} mixes the operators {string.Join(", ", level.Value.OrderBy(x => x))} without parentheses. Expressions are evaluated left to right with no operator precedence, so add parentheses to make the grouping explicit.");
+                $"Expression '{expression}' in rule {rule.Id} mixes the operators {string.Join(", ", group.Value.OrderBy(x => x))} without parentheses. Expressions are evaluated left to right with no operator precedence, so add parentheses to make the grouping explicit.");
         }
 
+        errors.AddRange(CheckExpressionCanReportAFinding(rule, expression, patternLabels));
+
         return errors;
+    }
+
+    /// <summary>
+    ///     A finding originates from exactly one pattern, so a term naming a different pattern is false
+    ///     while that finding is being judged. An expression that therefore has no satisfying assignment
+    ///     will match at the rule level and then report nothing, which looks like the rule silently
+    ///     failing. Conditions are treated as free, since their value depends on the file being scanned.
+    /// </summary>
+    private IEnumerable<string> CheckExpressionCanReportAFinding(Rule rule, string expression,
+        IReadOnlyList<string> patternLabels)
+    {
+        const int maxConditionsToEnumerate = 16;
+
+        if (RuleExpression.TryParse(expression) is not { } parsed || patternLabels.Count == 0)
+        {
+            yield break;
+        }
+
+        var conditionLabels = (rule.Conditions ?? Array.Empty<SearchCondition>())
+            .Select((condition, index) =>
+                condition.Label ?? (patternLabels.Count + index).ToString(CultureInfo.InvariantCulture))
+            .ToList();
+
+        if (conditionLabels.Count > maxConditionsToEnumerate)
+        {
+            yield break;
+        }
+
+        var combinations = 1 << conditionLabels.Count;
+
+        foreach (var originatingPattern in patternLabels)
+        for (var conditionValues = 0; conditionValues < combinations; conditionValues++)
+        {
+            var assignment = conditionValues;
+            if (parsed.Evaluate(label =>
+                {
+                    var conditionIndex = conditionLabels.IndexOf(label);
+                    if (conditionIndex >= 0)
+                    {
+                        return (assignment & (1 << conditionIndex)) != 0;
+                    }
+
+                    return label == originatingPattern;
+                }))
+            {
+                yield break;
+            }
+        }
+
+        var message =
+            $"Expression '{expression}' in rule {rule.Id} can never report a finding, because it requires more than one pattern to be true at once and a finding comes from a single pattern. Split the patterns into separate rules, or express the extra requirement as a condition.";
+        _logger?.LogError("{Message}", message);
+        yield return message;
     }
 }

--- a/AppInspector.RulesEngine/RulesVerifier.cs
+++ b/AppInspector.RulesEngine/RulesVerifier.cs
@@ -550,6 +550,7 @@ public class RulesVerifier
 
         var tokens = expression.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
         var depth = 0;
+        var closedTooEarly = false;
         var nextGroup = 0;
         // Sibling groups at the same nesting level are independent, so operators are tracked per group
         // rather than per depth.
@@ -580,6 +581,11 @@ public class RulesVerifier
             foreach (var _ in token.Where(x => x == ')'))
             {
                 depth--;
+                if (depth < 0)
+                {
+                    closedTooEarly = true;
+                }
+
                 if (openGroups.Count > 1)
                 {
                     openGroups.Pop();
@@ -587,9 +593,29 @@ public class RulesVerifier
             }
         }
 
-        if (depth != 0)
+        // A running count that ends at zero is not enough: 'a) AND (b' balances overall while closing a group
+        // that was never opened.
+        if (depth != 0 || closedTooEarly)
         {
             Error($"Expression '{expression}' in rule {rule.Id} has unbalanced parentheses.");
+        }
+
+        // The engine is handed a weaker expression than the authored one, so it never sees these operands and
+        // cannot report them. An operand naming nothing is silently false when findings are judged, which reads
+        // as the rule mysteriously matching less than it should.
+        var knownLabels = new HashSet<string>(patternLabels.Concat(conditionLabels), StringComparer.Ordinal);
+        var unresolved = tokens
+            .Select(token => token.Trim('(', ')'))
+            .Where(bare => bare.Length > 0)
+            .Where(bare => !ReservedLabels.Contains(bare, StringComparer.OrdinalIgnoreCase))
+            .Where(bare => !knownLabels.Contains(bare))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        foreach (var bare in unresolved)
+        {
+            Error(
+                $"Expression '{expression}' in rule {rule.Id} refers to '{bare}', which is not a pattern or condition label in this rule. Known labels are {string.Join(", ", knownLabels.OrderBy(x => x, StringComparer.Ordinal))}.");
         }
 
         if (RuleExpression.MaxNestingOf(expression) > RuleExpression.MaxNestingDepth)
@@ -643,30 +669,39 @@ public class RulesVerifier
     private IEnumerable<string> CheckExpressionCanReportAFinding(Rule rule, string expression,
         IReadOnlyList<string> patternLabels, IReadOnlyList<string> conditionLabels)
     {
-        const int maxConditionsToEnumerate = 16;
+        // The search is exponential in the number of conditions, so it runs on a fixed budget of evaluations.
+        // Exhausting it means no satisfying assignment was found within the budget, which is not evidence that
+        // none exists, so the rule is left alone rather than reported.
+        const int maxEvaluations = 4096;
 
         if (RuleExpression.TryParse(expression) is not { } parsed || patternLabels.Count == 0)
         {
             yield break;
         }
 
-        if (conditionLabels.Count > maxConditionsToEnumerate)
+        if (conditionLabels.Count >= 31)
         {
             yield break;
         }
 
-        var combinations = 1 << conditionLabels.Count;
+        var combinations = 1L << conditionLabels.Count;
+        var evaluations = 0;
 
         foreach (var originatingPattern in patternLabels)
-        for (var conditionValues = 0; conditionValues < combinations; conditionValues++)
+        for (var conditionValues = 0L; conditionValues < combinations; conditionValues++)
         {
+            if (++evaluations > maxEvaluations)
+            {
+                yield break;
+            }
+
             var assignment = conditionValues;
             if (parsed.Evaluate(label =>
                 {
                     for (var conditionIndex = 0; conditionIndex < conditionLabels.Count; conditionIndex++)
                         if (conditionLabels[conditionIndex] == label)
                         {
-                            return (assignment & (1 << conditionIndex)) != 0;
+                            return (assignment & (1L << conditionIndex)) != 0;
                         }
 
                     return label == originatingPattern;

--- a/AppInspector.RulesEngine/RulesVerifier.cs
+++ b/AppInspector.RulesEngine/RulesVerifier.cs
@@ -462,6 +462,8 @@ public class RulesVerifier
 
     private static readonly string[] BinaryOperators = { "AND", "OR", "XOR", "NAND", "NOR" };
 
+    private static readonly string[] ReservedLabels = { "AND", "OR", "XOR", "NAND", "NOR", "NOT" };
+
     /// <summary>
     ///     Runs one self-test sample. A rule can fail hard rather than simply not matching, and a bad rule
     ///     must not take verification down with it, so failures are reported as verification errors.
@@ -498,10 +500,23 @@ public class RulesVerifier
 
         foreach (var label in convertedOatRule.Clauses.Select(x => x.Label))
         {
-            if (label is not null && (label.Any(char.IsWhiteSpace) || label.Contains('(') || label.Contains(')')))
+            if (label is null)
+            {
+                continue;
+            }
+
+            if (label.Any(char.IsWhiteSpace) || label.Contains('(') || label.Contains(')'))
             {
                 Error(
                     $"Label '{label}' in rule {rule.Id} may not contain whitespace or parentheses because expressions are split on spaces.");
+            }
+
+            // An operator named as a label reads as an operator to one evaluator and as an operand to the
+            // other, so the rule would match and then report nothing.
+            if (ReservedLabels.Contains(label, StringComparer.OrdinalIgnoreCase))
+            {
+                Error(
+                    $"Label '{label}' in rule {rule.Id} is an expression operator and may not be used as a label. Reserved names are {string.Join(", ", ReservedLabels)}.");
             }
         }
 

--- a/AppInspector.RulesEngine/RulesVerifier.cs
+++ b/AppInspector.RulesEngine/RulesVerifier.cs
@@ -515,6 +515,11 @@ public class RulesVerifier
         var patternLabels = rule.Patterns
             .Select((pattern, index) => pattern.Label ?? index.ToString(CultureInfo.InvariantCulture)).ToList();
 
+        // Taken from the generated clauses rather than recomputed, so pattern level and rule level
+        // conditions are both covered however they were numbered.
+        var conditionLabels = convertedOatRule.Clauses.OfType<WithinClause>()
+            .Select(x => x.Label).Where(x => x is not null).Select(x => x!).ToList();
+
         if (string.IsNullOrWhiteSpace(rule.Expression))
         {
             return errors;
@@ -586,7 +591,30 @@ public class RulesVerifier
                 $"Expression '{expression}' in rule {rule.Id} mixes the operators {string.Join(", ", group.Value.OrderBy(x => x))} without parentheses. Expressions are evaluated left to right with no operator precedence, so add parentheses to make the grouping explicit.");
         }
 
-        errors.AddRange(CheckExpressionCanReportAFinding(rule, expression, patternLabels));
+        errors.AddRange(CheckExpressionCanReportAFinding(rule, expression, patternLabels, conditionLabels));
+
+        // Clauses are evaluated in the order they appear and captures accumulate as they go, so a condition
+        // reached before any pattern has nothing to test and is always false.
+        var seenAPattern = false;
+        string? conditionBeforeAnyPattern = null;
+
+        foreach (var bare in tokens.Select(token => token.Trim('(', ')')))
+        {
+            if (patternLabels.Contains(bare))
+            {
+                seenAPattern = true;
+            }
+            else if (!seenAPattern && conditionLabels.Contains(bare))
+            {
+                conditionBeforeAnyPattern ??= bare;
+            }
+        }
+
+        if (conditionBeforeAnyPattern is not null)
+        {
+            Error(
+                $"Expression '{expression}' in rule {rule.Id} uses the condition '{conditionBeforeAnyPattern}' before any pattern. Conditions test findings that earlier clauses produced, so one evaluated first is always false and the rule can never report. Put a pattern label ahead of it.");
+        }
 
         return errors;
     }
@@ -598,7 +626,7 @@ public class RulesVerifier
     ///     failing. Conditions are treated as free, since their value depends on the file being scanned.
     /// </summary>
     private IEnumerable<string> CheckExpressionCanReportAFinding(Rule rule, string expression,
-        IReadOnlyList<string> patternLabels)
+        IReadOnlyList<string> patternLabels, IReadOnlyList<string> conditionLabels)
     {
         const int maxConditionsToEnumerate = 16;
 
@@ -606,11 +634,6 @@ public class RulesVerifier
         {
             yield break;
         }
-
-        var conditionLabels = (rule.Conditions ?? Array.Empty<SearchCondition>())
-            .Select((condition, index) =>
-                condition.Label ?? (patternLabels.Count + index).ToString(CultureInfo.InvariantCulture))
-            .ToList();
 
         if (conditionLabels.Count > maxConditionsToEnumerate)
         {
@@ -625,11 +648,11 @@ public class RulesVerifier
             var assignment = conditionValues;
             if (parsed.Evaluate(label =>
                 {
-                    var conditionIndex = conditionLabels.IndexOf(label);
-                    if (conditionIndex >= 0)
-                    {
-                        return (assignment & (1 << conditionIndex)) != 0;
-                    }
+                    for (var conditionIndex = 0; conditionIndex < conditionLabels.Count; conditionIndex++)
+                        if (conditionLabels[conditionIndex] == label)
+                        {
+                            return (assignment & (1 << conditionIndex)) != 0;
+                        }
 
                     return label == originatingPattern;
                 }))

--- a/AppInspector.RulesEngine/SearchCondition.cs
+++ b/AppInspector.RulesEngine/SearchCondition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.ApplicationInspector.RulesEngine;
@@ -14,4 +15,16 @@ public class SearchCondition
 
     [JsonPropertyName("search_in")]
     public string? SearchIn { get; set; }
+
+    /// <summary>
+    ///     Restricts condition to specified languages. When empty, applies broadly (except DoesNotApplyTo).
+    /// </summary>
+    [JsonPropertyName("applies_to")]
+    public IList<string>? AppliesTo { get; set; }
+
+    /// <summary>
+    ///     Prevents condition from being evaluated for specified languages.
+    /// </summary>
+    [JsonPropertyName("does_not_apply_to")]
+    public IList<string>? DoesNotApplyTo { get; set; }
 }

--- a/AppInspector.RulesEngine/SearchCondition.cs
+++ b/AppInspector.RulesEngine/SearchCondition.cs
@@ -27,4 +27,11 @@ public class SearchCondition
     /// </summary>
     [JsonPropertyName("does_not_apply_to")]
     public IList<string>? DoesNotApplyTo { get; set; }
+
+    /// <summary>
+    ///     Optional name for this condition, for use in the rule's <c>expression</c>. Defaults to the
+    ///     condition's clause index. May not contain spaces or parentheses, and must be unique within the rule.
+    /// </summary>
+    [JsonPropertyName("label")]
+    public string? Label { get; set; }
 }

--- a/AppInspector.RulesEngine/SearchPattern.cs
+++ b/AppInspector.RulesEngine/SearchPattern.cs
@@ -55,4 +55,10 @@ public class SearchPattern
     /// </summary>
     [JsonPropertyName("ymlpaths")]
     public string[]? YamlPaths { get; set; }
+
+    /// <summary>
+    ///     Per-pattern conditions. When pattern matches and conditions are present, conditions must be satisfied.
+    /// </summary>
+    [JsonPropertyName("conditions")]
+    public SearchCondition[]? Conditions { get; set; }
 }

--- a/AppInspector.RulesEngine/SearchPattern.cs
+++ b/AppInspector.RulesEngine/SearchPattern.cs
@@ -14,6 +14,13 @@ public class SearchPattern
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Confidence Confidence { get; set; }
 
+    /// <summary>
+    ///     Optional name for this pattern, for use in the rule's <c>expression</c>. Defaults to the
+    ///     pattern's index. May not contain spaces or parentheses, and must be unique within the rule.
+    /// </summary>
+    [JsonPropertyName("label")]
+    public string? Label { get; set; }
+
     [JsonPropertyName("modifiers")]
     public List<string> Modifiers { get; set; } = new List<string>();
 

--- a/AppInspector.Tests/Commands/AnalyzeResilienceTests.cs
+++ b/AppInspector.Tests/Commands/AnalyzeResilienceTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInspector.Commands;
+using Microsoft.ApplicationInspector.Common;
+using Microsoft.ApplicationInspector.Logging;
+using Xunit;
+
+namespace AppInspector.Tests.Commands;
+
+/// <summary>
+///     A single file that cannot be analyzed must be recorded against that file and leave the rest of the
+///     scan intact, rather than abandoning the run.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class AnalyzeResilienceTests : IDisposable
+{
+    // Unbalanced parentheses make the engine throw during evaluation rather than simply not matching.
+    private const string throwingRule = @"[
+    {
+        ""id"": ""SA900001"",
+        ""name"": ""Testing.Rules.Throws"",
+        ""tags"": [ ""Testing.Rules.Throws"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""expression that fails at evaluation time"",
+        ""expression"": ""(a OR b"",
+        ""patterns"": [
+            { ""pattern"": ""alpha"", ""type"": ""substring"", ""label"": ""a"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""beta"",  ""type"": ""substring"", ""label"": ""b"", ""scopes"": [ ""code"" ] }
+        ]
+    }
+]";
+
+    private readonly string _rulePath;
+    private readonly string _sourceDirectory;
+
+    public AnalyzeResilienceTests()
+    {
+        _sourceDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(_sourceDirectory);
+        File.WriteAllText(Path.Combine(_sourceDirectory, "one.c"), "alpha\n");
+        File.WriteAllText(Path.Combine(_sourceDirectory, "two.c"), "beta\n");
+
+        _rulePath = Path.Combine(_sourceDirectory, "rule.json");
+        File.WriteAllText(_rulePath, throwingRule);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_sourceDirectory, true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private AnalyzeOptions Options(bool singleThread)
+    {
+        return new AnalyzeOptions
+        {
+            SourcePath = new[] { Path.Combine(_sourceDirectory, "one.c"), Path.Combine(_sourceDirectory, "two.c") },
+            CustomRulesPath = _rulePath,
+            IgnoreDefaultRules = true,
+            DisableCustomRuleVerification = true,
+            SingleThread = singleThread
+        };
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FailingFileIsRecordedAndScanContinues(bool singleThread)
+    {
+        var factory = new LogOptions().GetLoggerFactory();
+        AnalyzeCommand command = new(Options(singleThread), factory);
+
+        var result = command.GetResult();
+
+        Assert.Equal(2, result.Metadata.Files.Count);
+        Assert.All(result.Metadata.Files, x => Assert.Equal(ScanState.Error, x.Status));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task FailingFileIsRecordedAndScanContinuesAsync(bool singleThread)
+    {
+        var factory = new LogOptions().GetLoggerFactory();
+        AnalyzeCommand command = new(Options(singleThread), factory);
+
+        var result = await command.GetResultAsync();
+
+        Assert.Equal(2, result.Metadata.Files.Count);
+        Assert.All(result.Metadata.Files, x => Assert.Equal(ScanState.Error, x.Status));
+    }
+}

--- a/AppInspector.Tests/Commands/AnalyzeResilienceTests.cs
+++ b/AppInspector.Tests/Commands/AnalyzeResilienceTests.cs
@@ -17,7 +17,9 @@ namespace AppInspector.Tests.Commands;
 [ExcludeFromCodeCoverage]
 public class AnalyzeResilienceTests : IDisposable
 {
-    // Unbalanced parentheses make the engine throw during evaluation rather than simply not matching.
+    // A label containing an unmatched parenthesis corrupts the expression handed to the engine, which throws
+    // while evaluating rather than simply not matching. Verification rejects such a label, so the scan below
+    // disables it; the point here is what the scan does when evaluation throws, not how the rule got that way.
     private const string throwingRule = @"[
     {
         ""id"": ""SA900001"",
@@ -25,9 +27,8 @@ public class AnalyzeResilienceTests : IDisposable
         ""tags"": [ ""Testing.Rules.Throws"" ],
         ""severity"": ""Critical"",
         ""description"": ""expression that fails at evaluation time"",
-        ""expression"": ""(a OR b"",
         ""patterns"": [
-            { ""pattern"": ""alpha"", ""type"": ""substring"", ""label"": ""a"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""alpha"", ""type"": ""substring"", ""label"": ""a)"", ""scopes"": [ ""code"" ] },
             { ""pattern"": ""beta"",  ""type"": ""substring"", ""label"": ""b"", ""scopes"": [ ""code"" ] }
         ]
     }

--- a/AppInspector.Tests/Commands/TestVerifyRulesCmd.cs
+++ b/AppInspector.Tests/Commands/TestVerifyRulesCmd.cs
@@ -1,6 +1,8 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using Microsoft.ApplicationInspector.CLI;
 using Microsoft.ApplicationInspector.Commands;
 using Microsoft.ApplicationInspector.Common;
 using Microsoft.ApplicationInspector.Logging;
@@ -242,5 +244,42 @@ public class TestVerifyRulesCmd
         VerifyRulesCommand command = new(options, _factory);
         var result = command.GetResult();
         Assert.Equal(VerifyRulesResult.ExitCode.NotVerified, result.ResultCode);
+    }
+
+    /// <summary>
+    ///     A rule that fails verification must have the reason surfaced in the text output, not just a
+    ///     `Status: False`.
+    /// </summary>
+    [Fact]
+    public void TextWriterReportsWhyARuleFailedVerification()
+    {
+        VerifyRulesOptions options = new()
+        {
+            CustomRulesPath = _mustMatchRuleFailPath
+        };
+
+        VerifyRulesCommand command = new(options, _factory);
+        var result = command.GetResult();
+        Assert.Equal(VerifyRulesResult.ExitCode.NotVerified, result.ResultCode);
+
+        var outputPath = Path.Combine(Path.GetTempPath(), $"test_verifyrules_{Guid.NewGuid()}.txt");
+        try
+        {
+            var cliOptions = new CLIVerifyRulesCmdOptions
+                { OutputFilePath = outputPath, OutputFileFormat = "text" };
+            new WriterFactory(_factory).GetWriter(cliOptions).WriteResults(result, cliOptions);
+
+            var content = File.ReadAllText(outputPath);
+            Assert.Contains("Status: False", content);
+            Assert.Contains("Error: ", content);
+            Assert.Contains("does not match the 'MustMatch' test", content);
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
     }
 }

--- a/AppInspector.Tests/RuleProcessor/ExpressionGenerationTests.cs
+++ b/AppInspector.Tests/RuleProcessor/ExpressionGenerationTests.cs
@@ -74,8 +74,13 @@ public class ExpressionGenerationTests
         }
     }
 
+    /// <summary>
+    ///     The engine decides only whether a file is worth examining, so it gets a disjunction of every clause.
+    ///     The authored expression stays on the rule and is applied per finding, which is what keeps a file-wide
+    ///     NOT from suppressing findings that individually satisfy it.
+    /// </summary>
     [Fact]
-    public void AuthorSuppliedExpression_IsPassedThroughVerbatim()
+    public void AuthorSuppliedExpression_IsAppliedPerFindingNotByTheEngine()
     {
         const string ruleJson = @"[
     {
@@ -102,7 +107,8 @@ public class ExpressionGenerationTests
         rules.AddString(ruleJson, "TestRules");
         var oatRule = rules.GetOatRules().Single();
 
-        Assert.Equal("(curl AND NOT tls13) OR wget", oatRule.Expression);
+        Assert.Equal("curl OR wget OR tls13", oatRule.Expression);
+        Assert.Equal("(curl AND NOT tls13) OR wget", oatRule.AppInspectorRule.Expression);
         Assert.Equal(new[] { "curl", "wget", "tls13" }, oatRule.Clauses.Select(x => x.Label));
     }
 

--- a/AppInspector.Tests/RuleProcessor/ExpressionGenerationTests.cs
+++ b/AppInspector.Tests/RuleProcessor/ExpressionGenerationTests.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.ApplicationInspector.Commands;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+/// <summary>
+///     Rules that do not opt in to labels or an expression must translate exactly as they always have.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class ExpressionGenerationTests
+{
+    private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
+
+    private static string GeneratedExpression(int patternClauses, int conditionClauses)
+    {
+        var expression = "(" + string.Join(" OR ", Enumerable.Range(0, patternClauses)) + ")";
+        for (var i = 0; i < conditionClauses; i++) expression += $" AND c{i}";
+        return expression;
+    }
+
+    /// <summary>
+    ///     Golden test over every shipped rule: a rule that opts into neither labels nor an expression must
+    ///     generate the same string it would without this feature. Patterns keep bare numeric labels because
+    ///     the pattern index is read back from them; conditions live in their own c-prefixed namespace so the
+    ///     two cannot collide.
+    /// </summary>
+    [Fact]
+    public void DefaultRules_GenerateUnchangedExpressions()
+    {
+        var ruleSet = RuleSetUtils.GetDefaultRuleSet();
+        var oatRules = ruleSet.GetOatRules().ToList();
+
+        Assert.NotEmpty(oatRules);
+
+        List<string> mismatches = new();
+
+        foreach (var oatRule in oatRules)
+        {
+            var patternClauses = oatRule.Clauses.Count(x => x is not WithinClause);
+            var conditionClauses = oatRule.Clauses.Count(x => x is WithinClause);
+
+            // Every shipped pattern must produce a clause, otherwise indices and labels would shift.
+            Assert.Equal(oatRule.AppInspectorRule.Patterns.Length, patternClauses);
+
+            var expected = GeneratedExpression(patternClauses, conditionClauses);
+
+            if (oatRule.Expression != expected)
+            {
+                mismatches.Add($"{oatRule.AppInspectorRule.Id}: expected '{expected}' but got '{oatRule.Expression}'");
+            }
+        }
+
+        Assert.Empty(mismatches);
+    }
+
+    [Fact]
+    public void DefaultRules_LabelPatternsNumericallyAndConditionsSeparately()
+    {
+        var ruleSet = RuleSetUtils.GetDefaultRuleSet();
+
+        foreach (var oatRule in ruleSet.GetOatRules())
+        {
+            var patternLabels = oatRule.Clauses.Where(x => x is not WithinClause).Select(x => x.Label);
+            var conditionLabels = oatRule.Clauses.OfType<WithinClause>().Select(x => x.Label).ToList();
+
+            Assert.Equal(Enumerable.Range(0, oatRule.AppInspectorRule.Patterns.Length).Select(x => x.ToString()),
+                patternLabels);
+            Assert.Equal(Enumerable.Range(0, conditionLabels.Count).Select(x => $"c{x}"), conditionLabels);
+        }
+    }
+
+    [Fact]
+    public void AuthorSuppliedExpression_IsPassedThroughVerbatim()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""SA400001"",
+        ""name"": ""Testing.Rules.CustomExpression"",
+        ""tags"": [ ""Testing.Rules.CustomExpression"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""author supplied expression"",
+        ""expression"": ""(curl AND NOT tls13) OR wget"",
+        ""patterns"": [
+            { ""pattern"": ""curl"", ""type"": ""substring"", ""label"": ""curl"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""wget"", ""type"": ""substring"", ""label"": ""wget"", ""scopes"": [ ""code"" ] }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""--tlsv1.3"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                ""search_in"": ""same-line"",
+                ""label"": ""tls13""
+            }
+        ]
+    }
+]";
+        RuleSet rules = new();
+        rules.AddString(ruleJson, "TestRules");
+        var oatRule = rules.GetOatRules().Single();
+
+        Assert.Equal("(curl AND NOT tls13) OR wget", oatRule.Expression);
+        Assert.Equal(new[] { "curl", "wget", "tls13" }, oatRule.Clauses.Select(x => x.Label));
+    }
+
+    [Fact]
+    public void AuthorSuppliedLabels_WithoutExpression_AreUsedInGeneratedExpression()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""SA400002"",
+        ""name"": ""Testing.Rules.LabelsOnly"",
+        ""tags"": [ ""Testing.Rules.LabelsOnly"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""labels but no expression"",
+        ""patterns"": [
+            { ""pattern"": ""curl"", ""type"": ""substring"", ""label"": ""curl"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""wget"", ""type"": ""substring"", ""label"": ""wget"", ""scopes"": [ ""code"" ] }
+        ]
+    }
+]";
+        RuleSet rules = new();
+        rules.AddString(ruleJson, "TestRules");
+
+        Assert.Equal("(curl OR wget)", rules.GetOatRules().Single().Expression);
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/ExpressionNestingLimitTests.cs
+++ b/AppInspector.Tests/RuleProcessor/ExpressionNestingLimitTests.cs
@@ -1,0 +1,119 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.CST.RecursiveExtractor;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+/// <summary>
+///     Expression evaluation recurses once per level of parenthesis nesting, both here and in the
+///     underlying engine, so deeply nested input must be refused before anything tries to evaluate it.
+///     Stack exhaustion cannot be caught and would take the whole process down.
+///     These tests deliberately assert the guards, and never evaluate a deeply nested expression.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class ExpressionNestingLimitTests
+{
+    private const int WellPastTheLimit = 5000;
+
+    private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
+
+    private static string Nested(int depth, string inner = "a")
+    {
+        return new string('(', depth) + inner + new string(')', depth);
+    }
+
+    private static string RuleWithExpression(string expression)
+    {
+        return $@"[
+    {{
+        ""id"": ""SA800001"",
+        ""name"": ""Testing.Rules.Nesting"",
+        ""tags"": [ ""Testing.Rules.Nesting"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""nesting fixture"",
+        ""expression"": ""{expression}"",
+        ""patterns"": [
+            {{ ""pattern"": ""alpha"", ""type"": ""substring"", ""label"": ""a"", ""scopes"": [ ""code"" ] }}
+        ]
+    }}
+]";
+    }
+
+    [Fact]
+    public void ParserRefusesNestingPastTheLimit()
+    {
+        Assert.NotNull(RuleExpression.TryParse(Nested(RuleExpression.MaxNestingDepth)));
+        Assert.Null(RuleExpression.TryParse(Nested(RuleExpression.MaxNestingDepth + 1)));
+        Assert.Null(RuleExpression.TryParse(Nested(WellPastTheLimit)));
+    }
+
+    [Fact]
+    public void MaxNestingOf_CountsTheDeepestGroup()
+    {
+        Assert.Equal(0, RuleExpression.MaxNestingOf("a OR b"));
+        Assert.Equal(1, RuleExpression.MaxNestingOf("(a OR b) AND (c OR d)"));
+        Assert.Equal(2, RuleExpression.MaxNestingOf("((a OR b) AND c)"));
+        Assert.Equal(WellPastTheLimit, RuleExpression.MaxNestingOf(Nested(WellPastTheLimit)));
+    }
+
+    [Fact]
+    public void VerificationRejectsNestingPastTheLimit()
+    {
+        RuleSet rules = new();
+        rules.AddString(RuleWithExpression(Nested(WellPastTheLimit)), "TestRules");
+
+        RulesVerifier verifier = new(new RulesVerifierOptions());
+        var status = verifier.CheckIntegrity(rules).Single();
+
+        Assert.Contains(status.Errors, x => x.Contains("nests parentheses more than"));
+        Assert.False(status.Verified);
+    }
+
+    /// <summary>
+    ///     Conversion is the gate that every load path passes through, verified or not, so a rule nested
+    ///     past the limit must never reach the analyzer with its expression intact.
+    /// </summary>
+    [Fact]
+    public void ConversionRefusesToBuildARuleNestedPastTheLimit()
+    {
+        RuleSet rules = new();
+        rules.AddString(RuleWithExpression(Nested(WellPastTheLimit)), "TestRules");
+
+        var oatRule = rules.GetOatRules().Single();
+
+        Assert.Empty(oatRule.Clauses);
+        Assert.Null(oatRule.Expression);
+    }
+
+    /// <summary>
+    ///     Analyzing with such a rule present must be safe rather than fatal.
+    /// </summary>
+    [Fact]
+    public void AnalyzingWithAnOverNestedRuleIsSafe()
+    {
+        RuleSet rules = new();
+        rules.AddString(RuleWithExpression(Nested(WellPastTheLimit)), "TestRules");
+        Microsoft.ApplicationInspector.RulesEngine.RuleProcessor processor =
+            new(rules, new RuleProcessorOptions { Parallel = false });
+
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        Assert.Empty(processor.AnalyzeFile("alpha", new FileEntry("test.c", new MemoryStream()), info));
+    }
+
+    [Fact]
+    public void NestingWithinTheLimitStillWorks()
+    {
+        RuleSet rules = new();
+        rules.AddString(RuleWithExpression("(((a)))"), "TestRules");
+        Microsoft.ApplicationInspector.RulesEngine.RuleProcessor processor =
+            new(rules, new RuleProcessorOptions { Parallel = false });
+
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        Assert.Single(processor.AnalyzeFile("alpha", new FileEntry("test.c", new MemoryStream()), info));
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/ExpressionValidationTests.cs
+++ b/AppInspector.Tests/RuleProcessor/ExpressionValidationTests.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+/// <summary>
+///     A rule whose expression or labels are malformed must fail verification rather than silently never
+///     matching or throwing mid scan.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class ExpressionValidationTests
+{
+    private static string RuleWith(string extraRuleFields, string patterns, string conditions)
+    {
+        return $@"[
+    {{
+        ""id"": ""SA600001"",
+        ""name"": ""Testing.Rules.Validation"",
+        ""tags"": [ ""Testing.Rules.Validation"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""validation fixture"",
+        {extraRuleFields}
+        ""patterns"": [ {patterns} ],
+        ""conditions"": [ {conditions} ]
+    }}
+]";
+    }
+
+    private const string twoPatterns =
+        @"{ ""pattern"": ""alpha"", ""type"": ""substring"", ""label"": ""a"", ""scopes"": [ ""code"" ] },
+          { ""pattern"": ""beta"",  ""type"": ""substring"", ""label"": ""b"", ""scopes"": [ ""code"" ] }";
+
+    private const string oneCondition =
+        @"{ ""pattern"": { ""pattern"": ""guard"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+            ""search_in"": ""same-line"", ""label"": ""c"" }";
+
+    private static RuleStatus Verify(string ruleJson)
+    {
+        RuleSet rules = new();
+        rules.AddString(ruleJson, "TestRules");
+        RulesVerifier verifier = new(new RulesVerifierOptions());
+        return verifier.CheckIntegrity(rules).Single();
+    }
+
+    [Fact]
+    public void WellFormedExpression_Verifies()
+    {
+        var status = Verify(RuleWith(@"""expression"": ""(a AND NOT c) OR b"",", twoPatterns, oneCondition));
+
+        Assert.Empty(status.Errors);
+        Assert.Empty(status.OatIssues);
+        Assert.True(status.Verified);
+    }
+
+    [Fact]
+    public void UnbalancedParentheses_FailVerification()
+    {
+        var status = Verify(RuleWith(@"""expression"": ""(a OR b"",", twoPatterns, oneCondition));
+
+        Assert.Contains(status.Errors, x => x.Contains("unbalanced parentheses"));
+        Assert.False(status.Verified);
+    }
+
+    [Fact]
+    public void DuplicateLabels_FailVerification()
+    {
+        const string duplicated =
+            @"{ ""pattern"": ""alpha"", ""type"": ""substring"", ""label"": ""a"", ""scopes"": [ ""code"" ] },
+              { ""pattern"": ""beta"",  ""type"": ""substring"", ""label"": ""a"", ""scopes"": [ ""code"" ] }";
+
+        var status = Verify(RuleWith(@"""expression"": ""a"",", duplicated, oneCondition));
+
+        Assert.Contains(status.Errors, x => x.Contains("more than one pattern or condition"));
+        Assert.False(status.Verified);
+    }
+
+    /// <summary>
+    ///     Mixing operators without parentheses is almost always an authoring mistake, because evaluation
+    ///     folds left to right with no precedence.
+    /// </summary>
+    [Fact]
+    public void MixedOperatorsWithoutParentheses_FailVerification()
+    {
+        var status = Verify(RuleWith(@"""expression"": ""a OR b AND c"",", twoPatterns, oneCondition));
+
+        Assert.Contains(status.Errors, x => x.Contains("without parentheses"));
+        Assert.False(status.Verified);
+    }
+
+    [Fact]
+    public void MixedOperatorsInSeparateGroups_Verify()
+    {
+        var status = Verify(RuleWith(@"""expression"": ""(a AND c) OR b"",", twoPatterns, oneCondition));
+
+        Assert.Empty(status.Errors);
+        Assert.True(status.Verified);
+    }
+
+    [Fact]
+    public void ExpressionWithNegateFinding_FailsVerification()
+    {
+        const string negatedCondition =
+            @"{ ""pattern"": { ""pattern"": ""guard"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                ""search_in"": ""same-line"", ""label"": ""c"", ""negate_finding"": true }";
+
+        var status = Verify(RuleWith(@"""expression"": ""(a AND NOT c) OR b"",", twoPatterns, negatedCondition));
+
+        Assert.Contains(status.Errors, x => x.Contains("negate_finding"));
+        Assert.False(status.Verified);
+    }
+
+    [Fact]
+    public void UndefinedLabelInExpression_FailsVerification()
+    {
+        var status = Verify(RuleWith(@"""expression"": ""a OR missing"",", twoPatterns, oneCondition));
+
+        Assert.False(status.Verified);
+    }
+
+    [Fact]
+    public void LabelContainingWhitespace_FailsVerification()
+    {
+        const string spacedLabel =
+            @"{ ""pattern"": ""alpha"", ""type"": ""substring"", ""label"": ""a b"", ""scopes"": [ ""code"" ] }";
+
+        var status = Verify(RuleWith(string.Empty, spacedLabel, oneCondition));
+
+        Assert.Contains(status.Errors, x => x.Contains("whitespace or parentheses"));
+        Assert.False(status.Verified);
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/ExpressionValidationTests.cs
+++ b/AppInspector.Tests/RuleProcessor/ExpressionValidationTests.cs
@@ -197,6 +197,28 @@ public class ExpressionValidationTests
         Assert.False(status.Verified);
     }
 
+    /// <summary>
+    ///     An operator used as a label is read as an operator by the per-finding parser and as an operand
+    ///     by the engine, so the rule would match and then report nothing.
+    /// </summary>
+    [Theory]
+    [InlineData("AND")]
+    [InlineData("or")]
+    [InlineData("Not")]
+    [InlineData("XOR")]
+    [InlineData("nand")]
+    [InlineData("NOR")]
+    public void OperatorShapedLabel_FailsVerification(string label)
+    {
+        var patterns =
+            $@"{{ ""pattern"": ""alpha"", ""type"": ""substring"", ""label"": ""{label}"", ""scopes"": [ ""code"" ] }}";
+
+        var status = Verify(RuleWith(string.Empty, patterns, oneCondition));
+
+        Assert.Contains(status.Errors, x => x.Contains("is an expression operator"));
+        Assert.False(status.Verified);
+    }
+
     [Fact]
     public void LabelContainingWhitespace_FailsVerification()
     {

--- a/AppInspector.Tests/RuleProcessor/ExpressionValidationTests.cs
+++ b/AppInspector.Tests/RuleProcessor/ExpressionValidationTests.cs
@@ -98,6 +98,62 @@ public class ExpressionValidationTests
         Assert.True(status.Verified);
     }
 
+    /// <summary>
+    ///     Sibling groups are independent, so different operators in each are explicitly grouped and must
+    ///     not be treated as mixed.
+    /// </summary>
+    [Fact]
+    public void DifferentOperatorsInSiblingGroups_Verify()
+    {
+        var status = Verify(RuleWith(@"""expression"": ""(a AND c) OR (b XOR c)"",", twoPatterns, oneCondition));
+
+        Assert.Empty(status.Errors);
+        Assert.True(status.Verified);
+    }
+
+    /// <summary>
+    ///     A finding comes from one pattern, so an expression requiring two patterns at once matches at the
+    ///     rule level and then reports nothing. That must fail verification rather than look like a rule
+    ///     that simply never fires.
+    /// </summary>
+    [Fact]
+    public void ExpressionRequiringTwoPatternsAtOnce_FailsVerification()
+    {
+        var status = Verify(RuleWith(@"""expression"": ""a AND b"",", twoPatterns, oneCondition));
+
+        Assert.Contains(status.Errors, x => x.Contains("can never report a finding"));
+        Assert.False(status.Verified);
+    }
+
+    /// <summary>
+    ///     Self-tests execute the rule, and a malformed expression throws rather than simply not matching,
+    ///     so verification must report the problem rather than take the process down with it.
+    /// </summary>
+    [Fact]
+    public void MalformedExpressionWithSelfTest_FailsVerificationWithoutThrowing()
+    {
+        const string withSelfTests = @"[
+    {
+        ""id"": ""SA600002"",
+        ""name"": ""Testing.Rules.SelfTested"",
+        ""tags"": [ ""Testing.Rules.SelfTested"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""unbalanced expression with self tests"",
+        ""expression"": ""(a OR b"",
+        ""patterns"": [
+            { ""pattern"": ""alpha"", ""type"": ""substring"", ""label"": ""a"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""beta"",  ""type"": ""substring"", ""label"": ""b"", ""scopes"": [ ""code"" ] }
+        ],
+        ""must-match"": [ ""alpha"" ],
+        ""must-not-match"": [ ""gamma"" ]
+    }
+]";
+        var status = Verify(withSelfTests);
+
+        Assert.Contains(status.Errors, x => x.Contains("unbalanced parentheses"));
+        Assert.False(status.Verified);
+    }
+
     [Fact]
     public void ExpressionWithNegateFinding_FailsVerification()
     {

--- a/AppInspector.Tests/RuleProcessor/ExpressionValidationTests.cs
+++ b/AppInspector.Tests/RuleProcessor/ExpressionValidationTests.cs
@@ -230,4 +230,33 @@ public class ExpressionValidationTests
         Assert.Contains(status.Errors, x => x.Contains("whitespace or parentheses"));
         Assert.False(status.Verified);
     }
+
+    /// <summary>
+    ///     Counting parentheses to zero is not enough on its own, because a group can be closed before it was
+    ///     ever opened. Such an expression balances on a naive count but still throws when evaluated.
+    /// </summary>
+    [Fact]
+    public void ParenthesisClosedBeforeItOpens_FailsVerification()
+    {
+        var status = Verify(RuleWith(@"""expression"": ""a) AND (b"",", twoPatterns, oneCondition));
+
+        Assert.Contains(status.Errors, x => x.Contains("unbalanced parentheses"));
+        Assert.False(status.Verified);
+    }
+
+    /// <summary>
+    ///     The engine is handed a weaker expression than the authored one, so it never sees these operands and
+    ///     cannot flag them. An unresolved operand is simply false when findings are judged, so verification has
+    ///     to be what catches it.
+    /// </summary>
+    [Theory]
+    [InlineData("a OR nosuchlabel")]
+    [InlineData("a OR 0")]
+    public void ExpressionNamingAnUnknownLabel_FailsVerification(string expression)
+    {
+        var status = Verify(RuleWith($@"""expression"": ""{expression}"",", twoPatterns, oneCondition));
+
+        Assert.Contains(status.Errors, x => x.Contains("is not a pattern or condition label"));
+        Assert.False(status.Verified);
+    }
 }

--- a/AppInspector.Tests/RuleProcessor/ExpressionValidationTests.cs
+++ b/AppInspector.Tests/RuleProcessor/ExpressionValidationTests.cs
@@ -154,6 +154,28 @@ public class ExpressionValidationTests
         Assert.False(status.Verified);
     }
 
+    /// <summary>
+    ///     Captures accumulate in evaluation order, so a condition reached before any pattern has nothing
+    ///     to test and is always false. Such a rule verifies clean today and then never reports.
+    /// </summary>
+    [Fact]
+    public void ConditionBeforeAnyPattern_FailsVerification()
+    {
+        var status = Verify(RuleWith(@"""expression"": ""c AND a"",", twoPatterns, oneCondition));
+
+        Assert.Contains(status.Errors, x => x.Contains("before any pattern"));
+        Assert.False(status.Verified);
+    }
+
+    [Fact]
+    public void ConditionAfterAPattern_Verifies()
+    {
+        var status = Verify(RuleWith(@"""expression"": ""a AND c"",", twoPatterns, oneCondition));
+
+        Assert.Empty(status.Errors);
+        Assert.True(status.Verified);
+    }
+
     [Fact]
     public void ExpressionWithNegateFinding_FailsVerification()
     {

--- a/AppInspector.Tests/RuleProcessor/OatExpressionSemanticsTests.cs
+++ b/AppInspector.Tests/RuleProcessor/OatExpressionSemanticsTests.cs
@@ -1,0 +1,195 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
+using Microsoft.CST.OAT;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+/// <summary>
+///     Characterization tests pinning the <see cref="Analyzer" /> contract that AppInspector's expression
+///     support depends on. These assert OAT behavior, not AppInspector behavior; if they fail after an OAT
+///     upgrade, the expression translation in AbstractRuleSet needs review before the upgrade is taken.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class OatExpressionSemanticsTests
+{
+    private const string threePatternRule = @"[
+    {
+        ""id"": ""SA000001"",
+        ""name"": ""Testing.Rules.ThreePattern"",
+        ""tags"": [ ""Testing.Rules.ThreePattern"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""three independent substring patterns"",
+        ""patterns"": [
+            { ""pattern"": ""alpha"", ""type"": ""substring"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""beta"",  ""type"": ""substring"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""gamma"", ""type"": ""substring"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] }
+        ]
+    }
+]";
+
+    private const string patternWithConditionRule = @"[
+    {
+        ""id"": ""SA000002"",
+        ""name"": ""Testing.Rules.PatternWithCondition"",
+        ""tags"": [ ""Testing.Rules.PatternWithCondition"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""one pattern guarded by a same-line condition"",
+        ""patterns"": [
+            { ""pattern"": ""alpha"", ""type"": ""substring"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""guard"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                ""search_in"": ""same-line""
+            }
+        ]
+    }
+]";
+
+    private const string singleRegexRule = @"[
+    {
+        ""id"": ""SA000003"",
+        ""name"": ""Testing.Rules.SingleRegex"",
+        ""tags"": [ ""Testing.Rules.SingleRegex"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""one regex pattern"",
+        ""patterns"": [
+            { ""pattern"": ""alpha"", ""type"": ""regex"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] }
+        ]
+    }
+]";
+
+    private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
+
+    private ConvertedOatRule RuleFrom(string json)
+    {
+        RuleSet rules = new();
+        rules.AddString(json, "TestRules");
+        return rules.GetOatRules().First();
+    }
+
+    private TextContainer TextFrom(string content)
+    {
+        return new TextContainer(content, "csharp", _languages);
+    }
+
+    private bool Matches(ConvertedOatRule rule, string content)
+    {
+        Analyzer analyzer = new ApplicationInspectorAnalyzer();
+        return analyzer.Analyze(new[] { rule }, TextFrom(content)).Any();
+    }
+
+    /// <summary>
+    ///     OAT folds the expression strictly left to right with no operator precedence, so `0 OR 1 AND 2`
+    ///     means `(0 OR 1) AND 2`. Content matching only pattern 0 discriminates the two readings.
+    /// </summary>
+    [Fact]
+    public void Expression_HasNoOperatorPrecedence()
+    {
+        var leftToRight = RuleFrom(threePatternRule);
+        leftToRight.Expression = "0 OR 1 AND 2";
+
+        // (alpha OR beta) AND gamma => (true OR false) AND false => false
+        Assert.False(Matches(leftToRight, "alpha only"));
+
+        var parenthesised = RuleFrom(threePatternRule);
+        parenthesised.Expression = "0 OR (1 AND 2)";
+
+        // alpha OR (beta AND gamma) => true OR (false AND false) => true
+        Assert.True(Matches(parenthesised, "alpha only"));
+    }
+
+    /// <summary>
+    ///     Parentheses group booleans via recursion. This pins whether that recursion also inherits the
+    ///     captures accumulated by clauses evaluated before it, which decides whether a condition's scope
+    ///     could ever be derived from expression structure.
+    /// </summary>
+    [Fact]
+    public void ParenthesisedSubExpression_InheritsAccumulatedCaptures()
+    {
+        var flat = RuleFrom(patternWithConditionRule);
+        flat.Expression = "0 AND 1";
+        Assert.True(Matches(flat, "alpha guard"));
+
+        var nested = RuleFrom(patternWithConditionRule);
+        nested.Expression = "0 AND (1)";
+
+        // The within clause has no boundaries of its own; it can only pass if it sees clause 0's capture.
+        Assert.True(Matches(nested, "alpha guard"));
+    }
+
+    /// <summary>
+    ///     Duplicate labels make OAT abandon evaluation and report no match, rather than raising. Rule
+    ///     verification must therefore reject duplicate labels as a hard error.
+    /// </summary>
+    [Fact]
+    public void DuplicateLabels_SilentlyEvaluateFalse()
+    {
+        var rule = RuleFrom(threePatternRule);
+        rule.Clauses[1].Label = "0";
+        rule.Expression = "0 OR 2";
+
+        Assert.False(Matches(rule, "alpha beta gamma"));
+    }
+
+    /// <summary>
+    ///     Clause.Label is OAT's expression identifier, so it must be free for authors to name. The pattern
+    ///     index is carried separately on the clause; a non-numeric label must not affect evaluation.
+    /// </summary>
+    [Fact]
+    public void NonNumericLabel_OnRegexClause_IsUsableInExpression()
+    {
+        var rule = RuleFrom(singleRegexRule);
+        rule.Clauses[0].Label = "curl";
+        rule.Expression = "curl";
+
+        Assert.True(Matches(rule, "alpha"));
+    }
+
+    [Theory]
+    [InlineData("0 OR 9")]
+    [InlineData("0 OR")]
+    [InlineData("0 NOT NOT 1")]
+    [InlineData("0 BOGUS 1")]
+    [InlineData("0 OR 1)")]
+    [InlineData("(0 OR 1))")]
+    public void EnumerateRuleIssues_RejectsMalformedExpressions(string expression)
+    {
+        var rule = RuleFrom(threePatternRule);
+        rule.Expression = expression;
+
+        Analyzer analyzer = new ApplicationInspectorAnalyzer();
+
+        Assert.NotEmpty(analyzer.EnumerateRuleIssues(rule));
+    }
+
+    /// <summary>
+    ///     An unclosed group throws during analysis rather than simply failing the rule, which is why
+    ///     AppInspector rejects unbalanced expressions at verification time. OAT 1.2.87 also does not flag
+    ///     these, because its balance check only fires when closing parentheses outnumber opening ones.
+    /// </summary>
+    [Theory]
+    [InlineData("(0 OR 1")]
+    [InlineData("(0 OR (1 AND 2)")]
+    public void UnclosedOpeningParenthesis_ThrowsDuringAnalysis(string expression)
+    {
+        var rule = RuleFrom(threePatternRule);
+        rule.Expression = expression;
+
+        Assert.ThrowsAny<System.Exception>(() => Matches(rule, "alpha beta gamma"));
+    }
+
+    [Fact]
+    public void EnumerateRuleIssues_AcceptsWellFormedExpression()
+    {
+        var rule = RuleFrom(threePatternRule);
+        rule.Expression = "(0 AND NOT 1) OR 2";
+
+        Analyzer analyzer = new ApplicationInspectorAnalyzer();
+
+        Assert.Empty(analyzer.EnumerateRuleIssues(rule));
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/OatExpressionSemanticsTests.cs
+++ b/AppInspector.Tests/RuleProcessor/OatExpressionSemanticsTests.cs
@@ -156,6 +156,8 @@ public class OatExpressionSemanticsTests
     [InlineData("0 BOGUS 1")]
     [InlineData("0 OR 1)")]
     [InlineData("(0 OR 1))")]
+    [InlineData("(0 OR 1")]
+    [InlineData("(0 OR (1 AND 2)")]
     public void EnumerateRuleIssues_RejectsMalformedExpressions(string expression)
     {
         var rule = RuleFrom(threePatternRule);
@@ -167,9 +169,8 @@ public class OatExpressionSemanticsTests
     }
 
     /// <summary>
-    ///     An unclosed group throws during analysis rather than simply failing the rule, which is why
-    ///     AppInspector rejects unbalanced expressions at verification time. OAT 1.2.87 also does not flag
-    ///     these, because its balance check only fires when closing parentheses outnumber opening ones.
+    ///     Validation reports an unclosed group, but evaluating one still throws, so a rule set must be
+    ///     verified before it is run rather than relying on analysis to fail gracefully.
     /// </summary>
     [Theory]
     [InlineData("(0 OR 1")]

--- a/AppInspector.Tests/RuleProcessor/OverrideTests.cs
+++ b/AppInspector.Tests/RuleProcessor/OverrideTests.cs
@@ -1,0 +1,129 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.CST.RecursiveExtractor;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+/// <summary>
+///     A rule listed in another rule's overrides is only suppressed where the overriding finding fully
+///     contains it, and both analysis entry points must agree.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class OverrideTests
+{
+    private const string overridingRules = @"[
+    {
+        ""id"": ""SA700001"",
+        ""name"": ""Testing.Rules.Overridden"",
+        ""tags"": [ ""Testing.Rules.Overridden"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""the general rule"",
+        ""patterns"": [
+            { ""pattern"": ""alphabet"", ""type"": ""substring"", ""scopes"": [ ""code"" ] }
+        ]
+    },
+    {
+        ""id"": ""SA700002"",
+        ""name"": ""Testing.Rules.Overriding"",
+        ""tags"": [ ""Testing.Rules.Overriding"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""the specific rule"",
+        ""overrides"": [ ""SA700001"" ],
+        ""patterns"": [
+            { ""pattern"": ""alphabet soup"", ""type"": ""substring"", ""scopes"": [ ""code"" ] }
+        ]
+    }
+]";
+
+    private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
+
+    private Microsoft.ApplicationInspector.RulesEngine.RuleProcessor Processor()
+    {
+        RuleSet rules = new();
+        rules.AddString(overridingRules, "TestRules");
+        return new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(rules,
+            new RuleProcessorOptions { Parallel = false });
+    }
+
+    private static FileEntry EntryWith(string contents)
+    {
+        return new FileEntry("test.c", new MemoryStream(Encoding.UTF8.GetBytes(contents)));
+    }
+
+    [Fact]
+    public void ContainedMatchIsOverridden()
+    {
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        var matches = Processor().AnalyzeFile("var x = alphabet soup;\n", EntryWith(string.Empty), info);
+
+        var match = Assert.Single(matches);
+        Assert.Equal("SA700002", match.Rule?.Id);
+    }
+
+    /// <summary>
+    ///     The overridden finding starts inside the overriding finding but extends past its end, so it is
+    ///     not contained and must survive.
+    /// </summary>
+    [Fact]
+    public void OverlappingButWiderMatchSurvives()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""SA700003"",
+        ""name"": ""Testing.Rules.Wide"",
+        ""tags"": [ ""Testing.Rules.Wide"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""matches a longer span"",
+        ""patterns"": [
+            { ""pattern"": ""bravo charlie"", ""type"": ""substring"", ""scopes"": [ ""code"" ] }
+        ]
+    },
+    {
+        ""id"": ""SA700004"",
+        ""name"": ""Testing.Rules.Narrow"",
+        ""tags"": [ ""Testing.Rules.Narrow"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""matches a shorter span starting at the same place"",
+        ""overrides"": [ ""SA700003"" ],
+        ""patterns"": [
+            { ""pattern"": ""bravo"", ""type"": ""substring"", ""scopes"": [ ""code"" ] }
+        ]
+    }
+]";
+        RuleSet rules = new();
+        rules.AddString(ruleJson, "TestRules");
+        Microsoft.ApplicationInspector.RulesEngine.RuleProcessor processor =
+            new(rules, new RuleProcessorOptions { Parallel = false });
+
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        var matches = processor.AnalyzeFile("bravo charlie\n", EntryWith(string.Empty), info);
+
+        Assert.Equal(new[] { "SA700003", "SA700004" },
+            matches.Select(x => x.Rule?.Id).OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task BothPathsApplyOverridesIdentically()
+    {
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+        const string content = "var x = alphabet soup;\nvar y = alphabet;\n";
+
+        var processor = Processor();
+        var syncMatches = processor.AnalyzeFile(content, EntryWith(content), info);
+        var asyncMatches = await processor.AnalyzeFileAsync(EntryWith(content), info);
+
+        Assert.Equal(
+            syncMatches.Select(x => $"{x.Rule?.Id}@{x.Boundary.Index}").OrderBy(x => x),
+            asyncMatches.Select(x => $"{x.Rule?.Id}@{x.Boundary.Index}").OrderBy(x => x));
+
+        // The standalone occurrence is untouched by the override.
+        Assert.Contains(syncMatches, x => x.Rule?.Id == "SA700001");
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/PatternConditionsTests.cs
+++ b/AppInspector.Tests/RuleProcessor/PatternConditionsTests.cs
@@ -1,0 +1,610 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.ApplicationInspector.RulesEngine.OatExtensions;
+using Microsoft.CST.RecursiveExtractor;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+[ExcludeFromCodeCoverage]
+public class PatternConditionsTests
+{
+    private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
+    
+    /// <summary>
+    /// Test that pattern-level conditions are parsed correctly
+    /// </summary>
+    [Fact]
+    public void PatternConditions_ParsingTest()
+    {
+        // Rule with two patterns, each with their own condition
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST001"",
+        ""name"": ""Pattern Conditions Test"",
+        ""tags"": [""Test.PatternConditions""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""foo"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": {""pattern"": ""bar"", ""type"": ""regex""},
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            },
+            {
+                ""pattern"": ""baz"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": {""pattern"": ""qux"", ""type"": ""regex""},
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            }
+        ]
+    }
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+        
+        var rules = ruleSet.GetAppInspectorRules().ToList();
+        Assert.Single(rules);
+        
+        var rule = rules.First();
+        Assert.Equal(2, rule.Patterns.Length);
+        
+        // Check that first pattern has a condition
+        Assert.NotNull(rule.Patterns[0].Conditions);
+        Assert.Single(rule.Patterns[0].Conditions);
+        
+        // Check that second pattern has a condition
+        Assert.NotNull(rule.Patterns[1].Conditions);
+        Assert.Single(rule.Patterns[1].Conditions);
+    }
+
+    /// <summary>
+    /// Test that pattern-level conditions match correctly - basic JSON parsing test
+    /// </summary>
+    [Fact]
+    public void PatternConditions_SimpleParsing()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST002"",
+        ""name"": ""Pattern Match Test"",
+        ""tags"": [""Test.PatternMatch""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""foo"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": {""pattern"": ""bar"", ""type"": ""regex""},
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            }
+        ]
+    }
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+
+        var rules = ruleSet.GetAppInspectorRules().ToList();
+        Assert.Single(rules);
+        
+        // Verify the pattern has conditions
+        var rule = rules.First();
+        Assert.NotNull(rule.Patterns[0].Conditions);
+        Assert.Single(rule.Patterns[0].Conditions);
+        Assert.Equal("bar", rule.Patterns[0].Conditions[0].Pattern?.Pattern);
+    }
+
+    /// <summary>
+    /// Test that language filters work on conditions
+    /// </summary>
+    [Fact]
+    public void LanguageFilters_AppliesToTest()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST003"",
+        ""name"": ""Language Filter Test"",
+        ""tags"": [""Test.LanguageFilter""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""test"",
+                ""type"": ""regex""
+            }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": {""pattern"": ""javascript"", ""type"": ""regex""},
+                ""search_in"": ""same-file"",
+                ""applies_to"": [""javascript""]
+            }
+        ]
+    }
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+        
+        var rules = ruleSet.GetAppInspectorRules().ToList();
+        Assert.Single(rules);
+        
+        var rule = rules.First();
+        Assert.NotNull(rule.Conditions);
+        Assert.Single(rule.Conditions);
+        var appliesTo = rule.Conditions[0].AppliesTo;
+        Assert.NotNull(appliesTo);
+        Assert.Contains("javascript", appliesTo);
+    }
+
+    /// <summary>
+    /// Test that language filters work with does_not_apply_to
+    /// </summary>
+    [Fact]
+    public void LanguageFilters_DoesNotApplyToTest()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST004"",
+        ""name"": ""Language Exclusion Test"",
+        ""tags"": [""Test.LanguageExclusion""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""test"",
+                ""type"": ""regex""
+            }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": {""pattern"": ""specific"", ""type"": ""regex""},
+                ""search_in"": ""same-file"",
+                ""does_not_apply_to"": [""python"", ""ruby""]
+            }
+        ]
+    }
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+        
+        var rules = ruleSet.GetAppInspectorRules().ToList();
+        Assert.Single(rules);
+        
+        var rule = rules.First();
+        Assert.NotNull(rule.Conditions);
+        Assert.Single(rule.Conditions);
+        var doesNotApplyTo = rule.Conditions[0].DoesNotApplyTo;
+        Assert.NotNull(doesNotApplyTo);
+        Assert.Contains("python", doesNotApplyTo);
+        Assert.Contains("ruby", doesNotApplyTo);
+    }
+
+    /// <summary>
+    /// Pattern-level conditions should only restrict the pattern they are attached to.
+    /// This test uses RuleProcessor to ensure that a pattern without conditions still matches.
+    /// </summary>
+    [Fact]
+    public void PatternLevelConditions_OnlyAffectAttachedPattern()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST005"",
+        ""name"": ""Pattern-level Condition Runtime Test"",
+        ""tags"": [""Test.PatternLevelCondition.Runtime""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""foo"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": {""pattern"": ""bar"", ""type"": ""regex""},
+                        ""search_in"": ""same-file""
+                    }
+                ]
+            },
+            {
+                ""pattern"": ""baz"",
+                ""type"": ""regex""
+            }
+        ]
+    }
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+
+        // "foo" is present but its condition requires "bar" in the same file, so only "baz" is reported.
+        var processor = new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(ruleSet, new RuleProcessorOptions());
+
+        const string fileName = "test.js";
+        const string fileContent = "this line contains foo and baz but not the other token";
+
+        // Derive a language from the file name; JavaScript is a reasonable choice here.
+        if (_languages.FromFileNameOut(fileName, out var languageInfo))
+        {
+            var matches = processor.AnalyzeFile(fileContent, new FileEntry(fileName, new System.IO.MemoryStream()), languageInfo);
+
+            // We expect exactly one match, corresponding to the second pattern ("baz").
+            Assert.Single(matches);
+            Assert.Contains(matches, m => m.MatchingPattern.Pattern == "baz");
+            Assert.DoesNotContain(matches, m => m.MatchingPattern.Pattern == "foo");
+        }
+        else
+        {
+            Assert.Fail("Failed to get language info");
+        }
+    }
+
+    /// <summary>
+    /// Language filters on conditions should control whether the condition is evaluated
+    /// based on the file language. When the file language is not listed in applies_to,
+    /// the condition should be skipped and not block pattern matches.
+    /// </summary>
+    [Fact]
+    public void LanguageFilters_RuntimeBehavior_AppliesToAndDoesNotApplyTo()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST006"",
+        ""name"": ""Language Filter Runtime Test"",
+        ""tags"": [""Test.LanguageFilter.Runtime""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""test_token"",
+                ""type"": ""regex""
+            }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": {""pattern"": ""javascript_only"", ""type"": ""regex""},
+                ""search_in"": ""same-file"",
+                ""applies_to"": [""javascript""],
+                ""does_not_apply_to"": [""python""]
+            }
+        ]
+    }
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+
+        var processor = new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(ruleSet, new RuleProcessorOptions());
+
+        const string contentWithBothTokens = "test_token javascript_only";
+        const string contentWithPatternOnly = "test_token no_language_marker";
+
+        // Analyze as JavaScript: condition applies (applies_to includes "javascript"),
+        // so the presence of "javascript_only" should be required for a match.
+        const string jsFileName = "file.js";
+        if (_languages.FromFileNameOut(jsFileName, out var jsLanguage))
+        {
+            var jsResultWithBoth = processor.AnalyzeFile(contentWithBothTokens, new FileEntry(jsFileName, new System.IO.MemoryStream()), jsLanguage);
+            var jsResultWithPatternOnly = processor.AnalyzeFile(contentWithPatternOnly, new FileEntry(jsFileName, new System.IO.MemoryStream()), jsLanguage);
+
+            Assert.Single(jsResultWithBoth);
+            Assert.Empty(jsResultWithPatternOnly);
+        }
+        else
+        {
+            Assert.Fail("Failed to get JavaScript language info");
+        }
+
+        // Analyze as Python: condition should be skipped (does_not_apply_to includes "python"),
+        // so the pattern should match even without the "javascript_only" token.
+        const string pyFileName = "file.py";
+        if (_languages.FromFileNameOut(pyFileName, out var pyLanguage))
+        {
+            var pyResultWithPatternOnly = processor.AnalyzeFile(contentWithPatternOnly, new FileEntry(pyFileName, new System.IO.MemoryStream()), pyLanguage);
+
+            Assert.Single(pyResultWithPatternOnly);
+            Assert.Contains(pyResultWithPatternOnly, m => m.MatchingPattern.Pattern == "test_token");
+        }
+        else
+        {
+            Assert.Fail("Failed to get Python language info");
+        }
+    }
+
+    private string[] Analyze(string ruleJson, string fileName, string content)
+    {
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+        var processor = new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(ruleSet,
+            new RuleProcessorOptions { Parallel = false });
+
+        Assert.True(_languages.FromFileNameOut(fileName, out var languageInfo), $"No language for {fileName}");
+
+        return processor
+            .AnalyzeFile(content, new FileEntry(fileName, new System.IO.MemoryStream()), languageInfo)
+            .Select(x => x.MatchingPattern?.Pattern ?? string.Empty)
+            .OrderBy(x => x)
+            .ToArray();
+    }
+
+    /// <summary>
+    ///     A pattern carrying a condition must still match when that condition is satisfied. Without this the
+    ///     negative-direction tests above would pass for the wrong reason, because a conditioned pattern that can
+    ///     never match also never produces a false positive.
+    /// </summary>
+    [Fact]
+    public void PatternLevelCondition_MatchesWhenConditionIsSatisfied()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST100"",
+        ""name"": ""Conditioned pattern positive case"",
+        ""tags"": [""Test.PatternLevelCondition.Positive""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""foo"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""bar"", ""type"": ""regex"" },
+                        ""search_in"": ""same-file""
+                    }
+                ]
+            },
+            { ""pattern"": ""baz"", ""type"": ""regex"" }
+        ]
+    }
+]";
+
+        Assert.Equal(new[] { "baz", "foo" }, Analyze(ruleJson, "test.js", "foo bar baz"));
+        Assert.Equal(new[] { "baz" }, Analyze(ruleJson, "test.js", "foo baz"));
+        Assert.Equal(new[] { "foo" }, Analyze(ruleJson, "test.js", "foo bar"));
+    }
+
+    /// <summary>
+    ///     A condition attached to one pattern must not gate the rule's other patterns.
+    /// </summary>
+    [Fact]
+    public void PatternLevelCondition_DoesNotGateSiblingPatterns()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST101"",
+        ""name"": ""Conditioned middle pattern"",
+        ""tags"": [""Test.PatternLevelCondition.Siblings""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            { ""pattern"": ""alpha"", ""type"": ""regex"" },
+            {
+                ""pattern"": ""beta"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""gate"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            },
+            { ""pattern"": ""gamma"", ""type"": ""regex"" }
+        ]
+    }
+]";
+
+        // The condition is satisfied, so all three patterns report.
+        Assert.Equal(new[] { "alpha", "beta", "gamma" },
+            Analyze(ruleJson, "test.js", "alpha\nbeta gate\ngamma"));
+
+        // The condition is not satisfied, so only the unconditioned siblings report.
+        Assert.Equal(new[] { "alpha", "gamma" },
+            Analyze(ruleJson, "test.js", "alpha\nbeta\ngamma"));
+    }
+
+    /// <summary>
+    ///     A rule level condition gates every pattern, including patterns that carry their own conditions.
+    /// </summary>
+    [Fact]
+    public void RuleLevelAndPatternLevelConditionsCombine()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST102"",
+        ""name"": ""Rule and pattern level conditions"",
+        ""tags"": [""Test.PatternLevelCondition.Combined""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""alpha"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""gate"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            },
+            { ""pattern"": ""beta"", ""type"": ""regex"" }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""enabled"", ""type"": ""regex"" },
+                ""search_in"": ""same-file""
+            }
+        ]
+    }
+]";
+
+        // Rule level condition satisfied, pattern level condition satisfied.
+        Assert.Equal(new[] { "alpha", "beta" }, Analyze(ruleJson, "test.js", "enabled\nalpha gate\nbeta"));
+
+        // Rule level condition satisfied, pattern level condition not; beta is unaffected.
+        Assert.Equal(new[] { "beta" }, Analyze(ruleJson, "test.js", "enabled\nalpha\nbeta"));
+
+        // Rule level condition not satisfied, so nothing reports regardless of the pattern level condition.
+        Assert.Empty(Analyze(ruleJson, "test.js", "alpha gate\nbeta"));
+    }
+
+    /// <summary>
+    ///     When every pattern carries its own condition, each pattern is gated independently: one pattern failing its
+    ///     condition must not suppress another whose condition was satisfied.
+    /// </summary>
+    [Fact]
+    public void PatternLevelConditions_GateEachPatternIndependently()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""TEST105"",
+        ""name"": ""Both patterns conditioned"",
+        ""tags"": [""Test.PatternLevelCondition.Independent""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {
+                ""pattern"": ""alpha"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""gateA"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            },
+            {
+                ""pattern"": ""beta"",
+                ""type"": ""regex"",
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""gateB"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line""
+                    }
+                ]
+            }
+        ]
+    }
+]";
+
+        Assert.Equal(new[] { "alpha", "beta" }, Analyze(ruleJson, "test.js", "alpha gateA\nbeta gateB"));
+        Assert.Equal(new[] { "alpha" }, Analyze(ruleJson, "test.js", "alpha gateA\nbeta"));
+        Assert.Equal(new[] { "beta" }, Analyze(ruleJson, "test.js", "alpha\nbeta gateB"));
+        Assert.Empty(Analyze(ruleJson, "test.js", "alpha\nbeta"));
+
+        // Each pattern is gated by its own condition, not by the other pattern's.
+        Assert.Empty(Analyze(ruleJson, "test.js", "alpha gateB\nbeta gateA"));
+    }
+
+    /// <summary>
+    ///     A condition that is skipped for the file's language must not change the outcome of the conditions
+    ///     declared alongside it, whichever order they appear in.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void LanguageSkippedCondition_IsOrderIndependent(bool skippedConditionFirst)
+    {
+        const string realCondition = @"{
+                        ""pattern"": { ""pattern"": ""gate"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line""
+                    }";
+        const string skippedCondition = @"{
+                        ""pattern"": { ""pattern"": ""never"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line"",
+                        ""applies_to"": [ ""python"" ]
+                    }";
+
+        var conditions = skippedConditionFirst
+            ? $"{skippedCondition}, {realCondition}"
+            : $"{realCondition}, {skippedCondition}";
+
+        var ruleJson = $@"[
+    {{
+        ""id"": ""TEST103"",
+        ""name"": ""Skipped condition ordering"",
+        ""tags"": [""Test.PatternLevelCondition.SkipOrder""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {{
+                ""pattern"": ""alpha"",
+                ""type"": ""regex"",
+                ""conditions"": [ {conditions} ]
+            }}
+        ]
+    }}
+]";
+
+        // The skipped condition filters nothing, so the real condition alone decides the outcome.
+        Assert.Equal(new[] { "alpha" }, Analyze(ruleJson, "test.js", "alpha gate"));
+        Assert.Empty(Analyze(ruleJson, "test.js", "alpha"));
+    }
+
+    /// <summary>
+    ///     The OAT rules generated for conditions must be well formed. OAT silently refuses to evaluate an
+    ///     expression whose label matches more than one clause, so a malformed rule fails by never matching rather
+    ///     than by raising an error.
+    /// </summary>
+    [Theory]
+    [InlineData("first pattern conditioned", true, false, false, "(0 AND c0) OR 1")]
+    [InlineData("second pattern conditioned", false, true, false, "(0 OR (1 AND c0))")]
+    [InlineData("both patterns conditioned", true, true, false, "(0 AND c0) OR (1 AND c1)")]
+    [InlineData("no conditions", false, false, false, "(0 OR 1)")]
+    [InlineData("rule level only", false, false, true, "(0 OR 1) AND c0")]
+    [InlineData("pattern and rule level", true, false, true, "(0 AND c0) OR 1 AND c1")]
+    public void GeneratedOatRulesAreWellFormed(string because, bool conditionOnFirst, bool conditionOnSecond,
+        bool ruleLevelCondition, string expectedExpression)
+    {
+        const string condition = @",
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""gate"", ""type"": ""regex"" },
+                        ""search_in"": ""same-line""
+                    }
+                ]";
+
+        var ruleLevel = ruleLevelCondition
+            ? @",
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""enabled"", ""type"": ""regex"" },
+                ""search_in"": ""same-file""
+            }
+        ]"
+            : string.Empty;
+
+        var ruleJson = $@"[
+    {{
+        ""id"": ""TEST104"",
+        ""name"": ""Well formed generated rule"",
+        ""tags"": [""Test.PatternLevelCondition.WellFormed""],
+        ""severity"": ""Important"",
+        ""patterns"": [
+            {{ ""pattern"": ""alpha"", ""type"": ""regex""{(conditionOnFirst ? condition : string.Empty)} }},
+            {{ ""pattern"": ""beta"", ""type"": ""regex""{(conditionOnSecond ? condition : string.Empty)} }}
+        ]{ruleLevel}
+    }}
+]";
+
+        var ruleSet = new RuleSet(NullLoggerFactory.Instance);
+        ruleSet.AddString(ruleJson, "test");
+        var oatRule = Assert.Single(ruleSet.GetOatRules());
+
+        Assert.Equal(expectedExpression, oatRule.Expression);
+
+        // Clause labels must be unique, and every label in the expression must resolve to a clause.
+        var analyzer = new ApplicationInspectorAnalyzer();
+        var violations = analyzer.EnumerateRuleIssues(oatRule).Select(x => x.Description).ToList();
+        Assert.True(violations.Count == 0, $"{because}: {string.Join("; ", violations)}");
+
+        // Pattern clauses keep the bare numeric labels the pattern index is recovered from.
+        var patternLabels = oatRule.Clauses.Where(x => x is not WithinClause).Select(x => x.Label).ToArray();
+        Assert.Equal(new[] { "0", "1" }, patternLabels);
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/PatternIndexReportingTests.cs
+++ b/AppInspector.Tests/RuleProcessor/PatternIndexReportingTests.cs
@@ -1,0 +1,86 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.CST.RecursiveExtractor;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+/// <summary>
+///     Regression tests for reporting the pattern that actually matched. String and substring patterns
+///     each become their own single-element clause, so the reported index must come from the clause's
+///     pattern index rather than the position within the clause's data.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class PatternIndexReportingTests
+{
+    private const string twoSubstringPatternsDifferentConfidence = @"[
+    {
+        ""id"": ""SA100001"",
+        ""name"": ""Testing.Rules.TwoSubstrings"",
+        ""tags"": [ ""Testing.Rules.TwoSubstrings"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""first pattern is high confidence, second is low"",
+        ""patterns"": [
+            { ""pattern"": ""alpha"", ""type"": ""substring"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""beta"",  ""type"": ""substring"", ""confidence"": ""Low"",  ""scopes"": [ ""code"" ] }
+        ]
+    }
+]";
+
+    private const string twoRegexPatternsDifferentConfidence = @"[
+    {
+        ""id"": ""SA100002"",
+        ""name"": ""Testing.Rules.TwoRegexes"",
+        ""tags"": [ ""Testing.Rules.TwoRegexes"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""first pattern is high confidence, second is low"",
+        ""patterns"": [
+            { ""pattern"": ""alpha"", ""type"": ""regex"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""beta"",  ""type"": ""regex"", ""confidence"": ""Low"",  ""scopes"": [ ""code"" ] }
+        ]
+    }
+]";
+
+    private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
+
+    private Microsoft.ApplicationInspector.RulesEngine.RuleProcessor ProcessorFor(string json,
+        RuleProcessorOptions? options = null)
+    {
+        RuleSet rules = new();
+        rules.AddString(json, "TestRules");
+        return new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(rules, options ?? new RuleProcessorOptions());
+    }
+
+    [Theory]
+    [InlineData(twoSubstringPatternsDifferentConfidence)]
+    [InlineData(twoRegexPatternsDifferentConfidence)]
+    public void SecondPatternMatch_ReportsSecondPattern(string ruleJson)
+    {
+        var processor = ProcessorFor(ruleJson);
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        var matches = processor.AnalyzeFile("beta only", new FileEntry("test.c", new MemoryStream()), info);
+
+        var match = Assert.Single(matches);
+        Assert.Equal("beta", match.MatchingPattern?.Pattern);
+        Assert.Equal(Confidence.Low, match.MatchingPattern?.Confidence);
+    }
+
+    /// <summary>
+    ///     Confidence filtering reads the confidence off the reported pattern, so misreporting the index
+    ///     would let a low confidence match through a high confidence only filter.
+    /// </summary>
+    [Theory]
+    [InlineData(twoSubstringPatternsDifferentConfidence)]
+    [InlineData(twoRegexPatternsDifferentConfidence)]
+    public void ConfidenceFilter_AppliesToTheMatchedPattern(string ruleJson)
+    {
+        var processor = ProcessorFor(ruleJson, new RuleProcessorOptions { ConfidenceFilter = Confidence.High });
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        Assert.Empty(processor.AnalyzeFile("beta only", new FileEntry("test.c", new MemoryStream()), info));
+        Assert.Single(processor.AnalyzeFile("alpha only", new FileEntry("test.c", new MemoryStream()), info));
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/RuleExpressionBehaviourTests.cs
+++ b/AppInspector.Tests/RuleProcessor/RuleExpressionBehaviourTests.cs
@@ -274,6 +274,73 @@ public class RuleExpressionBehaviourTests
     }
 
     /// <summary>
+    ///     A NOT judged across the whole file is satisfied by any one compliant finding, which would let a single
+    ///     hardened call site hide every vulnerable one beside it. The negation has to be judged per finding.
+    /// </summary>
+    private const string negatedCondition = @"[
+    {
+        ""id"": ""SA500005"",
+        ""name"": ""Testing.Rules.NegatedCondition"",
+        ""tags"": [ ""Testing.Rules.NegatedCondition"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""a cookie without the Secure flag"",
+        ""expression"": ""cookie AND NOT secure"",
+        ""patterns"": [
+            { ""pattern"": ""setcookie"", ""type"": ""substring"", ""label"": ""cookie"", ""scopes"": [ ""code"" ] }
+        ],
+        ""conditions"": [
+            { ""pattern"": { ""pattern"": ""Secure"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+              ""search_in"": ""same-line"", ""label"": ""secure"" }
+        ]
+    }
+]";
+
+    [Theory]
+    [InlineData("setcookie a\n", 1)]
+    [InlineData("setcookie a Secure\n", 0)]
+    [InlineData("setcookie a Secure\nsetcookie b\n", 1)]
+    [InlineData("setcookie a\nsetcookie b\n", 2)]
+    public void NegationIsJudgedPerFinding_NotAcrossTheFile(string content, int expected)
+    {
+        Assert.Equal(expected, MatchedPatterns(negatedCondition, content).Length);
+    }
+
+    /// <summary>
+    ///     The worked example from the rule authoring documentation: fire when either flag is missing, including
+    ///     on a file that also contains a fully hardened cookie.
+    /// </summary>
+    private const string partiallyHardened = @"[
+    {
+        ""id"": ""SA500008"",
+        ""name"": ""Testing.Rules.PartiallyHardened"",
+        ""tags"": [ ""Testing.Rules.PartiallyHardened"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""a cookie missing either hardening flag"",
+        ""expression"": ""cookie AND NOT (secure AND httponly)"",
+        ""patterns"": [
+            { ""pattern"": ""setcookie"", ""type"": ""substring"", ""label"": ""cookie"", ""scopes"": [ ""code"" ] }
+        ],
+        ""conditions"": [
+            { ""pattern"": { ""pattern"": ""Secure"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+              ""search_in"": ""same-line"", ""label"": ""secure"" },
+            { ""pattern"": { ""pattern"": ""HttpOnly"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+              ""search_in"": ""same-line"", ""label"": ""httponly"" }
+        ]
+    }
+]";
+
+    [Theory]
+    [InlineData("setcookie a Secure HttpOnly\n", 0)]
+    [InlineData("setcookie a Secure\n", 1)]
+    [InlineData("setcookie a HttpOnly\n", 1)]
+    [InlineData("setcookie a\n", 1)]
+    [InlineData("setcookie a Secure HttpOnly\nsetcookie b Secure\n", 1)]
+    public void PartiallyHardenedFinding_IsReportedBesideAHardenedOne(string content, int expected)
+    {
+        Assert.Equal(expected, MatchedPatterns(partiallyHardened, content).Length);
+    }
+
+    /// <summary>
     ///     Regex patterns carry the pattern they belong to on the clause rather than in the label, so an author
     ///     supplied label must survive on them exactly as it does on string patterns.
     /// </summary>

--- a/AppInspector.Tests/RuleProcessor/RuleExpressionBehaviourTests.cs
+++ b/AppInspector.Tests/RuleProcessor/RuleExpressionBehaviourTests.cs
@@ -1,0 +1,229 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.CST.RecursiveExtractor;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+/// <summary>
+///     The detections that the fixed pattern-OR-conditions-AND shape could not express.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class RuleExpressionBehaviourTests
+{
+    /// <summary>
+    ///     One condition guards one pattern: `(curl AND NOT tls13) OR wget`.
+    /// </summary>
+    private const string perPatternCondition = @"[
+    {
+        ""id"": ""SA500001"",
+        ""name"": ""Testing.Rules.PerPatternCondition"",
+        ""tags"": [ ""Testing.Rules.PerPatternCondition"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""curl is excused by an explicit tls1.3 flag, wget is not"",
+        ""expression"": ""(curl AND NOT tls13) OR wget"",
+        ""patterns"": [
+            { ""pattern"": ""curl"", ""type"": ""substring"", ""label"": ""curl"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""wget"", ""type"": ""substring"", ""label"": ""wget"", ""scopes"": [ ""code"" ] }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""--tlsv1.3"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                ""search_in"": ""same-line"",
+                ""label"": ""tls13""
+            }
+        ]
+    }
+]";
+
+    /// <summary>
+    ///     Condition disjunction: `p AND (near OR sameline)`.
+    /// </summary>
+    private const string conditionDisjunction = @"[
+    {
+        ""id"": ""SA500002"",
+        ""name"": ""Testing.Rules.ConditionDisjunction"",
+        ""tags"": [ ""Testing.Rules.ConditionDisjunction"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""either context is enough"",
+        ""expression"": ""p AND (near OR sameline)"",
+        ""patterns"": [
+            { ""pattern"": ""deserialize"", ""type"": ""substring"", ""label"": ""p"", ""scopes"": [ ""code"" ] }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""TypeNameHandling"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                ""search_in"": ""finding-region(-3, 0)"",
+                ""label"": ""near""
+            },
+            {
+                ""pattern"": { ""pattern"": ""JsonSerializerSettings"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                ""search_in"": ""same-line"",
+                ""label"": ""sameline""
+            }
+        ]
+    }
+]";
+
+    /// <summary>
+    ///     Negated conjunction: `p AND NOT (secure AND httponly)` fires when any required flag is missing.
+    /// </summary>
+    private const string negatedConjunction = @"[
+    {
+        ""id"": ""SA500003"",
+        ""name"": ""Testing.Rules.NegatedConjunction"",
+        ""tags"": [ ""Testing.Rules.NegatedConjunction"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""cookie must set both flags"",
+        ""expression"": ""p AND NOT (secure AND httponly)"",
+        ""patterns"": [
+            { ""pattern"": ""Set-Cookie"", ""type"": ""substring"", ""label"": ""p"", ""scopes"": [ ""code"" ] }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""Secure"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                ""search_in"": ""same-line"",
+                ""label"": ""secure""
+            },
+            {
+                ""pattern"": { ""pattern"": ""HttpOnly"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                ""search_in"": ""same-line"",
+                ""label"": ""httponly""
+            }
+        ]
+    }
+]";
+
+    /// <summary>
+    ///     Exactly one of two mutually exclusive settings: `p AND (a XOR b)`.
+    /// </summary>
+    private const string exclusiveOr = @"[
+    {
+        ""id"": ""SA500004"",
+        ""name"": ""Testing.Rules.ExclusiveOr"",
+        ""tags"": [ ""Testing.Rules.ExclusiveOr"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""exactly one mode may be set"",
+        ""expression"": ""p AND (a XOR b)"",
+        ""patterns"": [
+            { ""pattern"": ""configure"", ""type"": ""substring"", ""label"": ""p"", ""scopes"": [ ""code"" ] }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""modeA"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                ""search_in"": ""same-line"",
+                ""label"": ""a""
+            },
+            {
+                ""pattern"": { ""pattern"": ""modeB"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                ""search_in"": ""same-line"",
+                ""label"": ""b""
+            }
+        ]
+    }
+]";
+
+    /// <summary>
+    ///     The same per-pattern scoping without an expression, by declaring the condition on the pattern it
+    ///     guards.
+    /// </summary>
+    private const string scopedConditionNoExpression = @"[
+    {
+        ""id"": ""SA500005"",
+        ""name"": ""Testing.Rules.ScopedCondition"",
+        ""tags"": [ ""Testing.Rules.ScopedCondition"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""condition guards only the curl pattern"",
+        ""patterns"": [
+            {
+                ""pattern"": ""curl"", ""type"": ""substring"", ""label"": ""curl"", ""scopes"": [ ""code"" ],
+                ""conditions"": [
+                    {
+                        ""pattern"": { ""pattern"": ""--tlsv1.3"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                        ""search_in"": ""same-line"",
+                        ""negate_finding"": true
+                    }
+                ]
+            },
+            { ""pattern"": ""wget"", ""type"": ""substring"", ""label"": ""wget"", ""scopes"": [ ""code"" ] }
+        ]
+    }
+]";
+
+    private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
+
+    private string[] MatchedPatterns(string ruleJson, string content)
+    {
+        RuleSet rules = new();
+        rules.AddString(ruleJson, "TestRules");
+        Microsoft.ApplicationInspector.RulesEngine.RuleProcessor processor =
+            new(rules, new RuleProcessorOptions { Parallel = false });
+
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        return processor.AnalyzeFile(content, new FileEntry("test.c", new MemoryStream()), info)
+            .Select(x => x.MatchingPattern?.Pattern ?? string.Empty).OrderBy(x => x).ToArray();
+    }
+
+    [Fact]
+    public void PerPatternCondition_GuardedPatternIsExcused()
+    {
+        Assert.Equal(new[] { "curl" }, MatchedPatterns(perPatternCondition, "curl http://x\n"));
+        Assert.Empty(MatchedPatterns(perPatternCondition, "curl --tlsv1.3 http://x\n"));
+    }
+
+    /// <summary>
+    ///     The case the historical shape could not express: the unguarded pattern must still report even
+    ///     though the guarded pattern was excused on the same file.
+    /// </summary>
+    [Fact]
+    public void PerPatternCondition_UnguardedPatternStillReports()
+    {
+        Assert.Equal(new[] { "wget" }, MatchedPatterns(perPatternCondition, "curl --tlsv1.3 http://x\nwget http://y\n"));
+    }
+
+    [Fact]
+    public void ConditionDisjunction_EitherContextSuffices()
+    {
+        Assert.Equal(new[] { "deserialize" },
+            MatchedPatterns(conditionDisjunction, "TypeNameHandling.All\nvar x = deserialize(y)\n"));
+        Assert.Equal(new[] { "deserialize" },
+            MatchedPatterns(conditionDisjunction, "var x = deserialize(new JsonSerializerSettings())\n"));
+        Assert.Empty(MatchedPatterns(conditionDisjunction, "var x = deserialize(y)\n"));
+    }
+
+    /// <summary>
+    ///     Partially hardened code is the common real world defect and is exactly what a conjunction of
+    ///     negated conditions cannot detect.
+    /// </summary>
+    [Fact]
+    public void NegatedConjunction_FiresWhenOnlyOneRequirementIsMet()
+    {
+        Assert.Equal(new[] { "Set-Cookie" }, MatchedPatterns(negatedConjunction, "Set-Cookie: a=b; Secure\n"));
+        Assert.Equal(new[] { "Set-Cookie" }, MatchedPatterns(negatedConjunction, "Set-Cookie: a=b; HttpOnly\n"));
+        Assert.Equal(new[] { "Set-Cookie" }, MatchedPatterns(negatedConjunction, "Set-Cookie: a=b\n"));
+        Assert.Empty(MatchedPatterns(negatedConjunction, "Set-Cookie: a=b; Secure; HttpOnly\n"));
+    }
+
+    [Fact]
+    public void ExclusiveOr_RequiresExactlyOne()
+    {
+        Assert.Equal(new[] { "configure" }, MatchedPatterns(exclusiveOr, "configure modeA\n"));
+        Assert.Equal(new[] { "configure" }, MatchedPatterns(exclusiveOr, "configure modeB\n"));
+        Assert.Empty(MatchedPatterns(exclusiveOr, "configure modeA modeB\n"));
+        Assert.Empty(MatchedPatterns(exclusiveOr, "configure\n"));
+    }
+
+    [Fact]
+    public void PatternLevelCondition_ScopesConditionWithoutAnExpression()
+    {
+        Assert.Equal(new[] { "curl" }, MatchedPatterns(scopedConditionNoExpression, "curl http://x\n"));
+        Assert.Empty(MatchedPatterns(scopedConditionNoExpression, "curl --tlsv1.3 http://x\n"));
+
+        // wget is not guarded by the condition, so it reports even on a line the condition would exclude.
+        Assert.Equal(new[] { "wget" },
+            MatchedPatterns(scopedConditionNoExpression, "curl --tlsv1.3 http://x\nwget http://y\n"));
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/RuleExpressionBehaviourTests.cs
+++ b/AppInspector.Tests/RuleProcessor/RuleExpressionBehaviourTests.cs
@@ -152,6 +152,32 @@ public class RuleExpressionBehaviourTests
     }
 ]";
 
+    /// <summary>
+    ///     Two conditions guarded by an OR, each satisfied by a different finding. Both sub-expressions
+    ///     succeed, so the engine propagates both condition captures, and intersecting them would demand a
+    ///     finding that passed both and report nothing. This is the case that per-finding evaluation of the
+    ///     expression exists for.
+    /// </summary>
+    private const string conditionsSatisfiedByDifferentFindings = @"[
+    {
+        ""id"": ""SA500006"",
+        ""name"": ""Testing.Rules.SplitDisjunction"",
+        ""tags"": [ ""Testing.Rules.SplitDisjunction"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""either guard is enough, and each is met by a different finding"",
+        ""expression"": ""p AND (g1 OR g2)"",
+        ""patterns"": [
+            { ""pattern"": ""deserialize"", ""type"": ""substring"", ""label"": ""p"", ""scopes"": [ ""code"" ] }
+        ],
+        ""conditions"": [
+            { ""pattern"": { ""pattern"": ""GUARD1"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+              ""search_in"": ""same-line"", ""label"": ""g1"" },
+            { ""pattern"": { ""pattern"": ""GUARD2"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+              ""search_in"": ""same-line"", ""label"": ""g2"" }
+        ]
+    }
+]";
+
     private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
 
     private string[] MatchedPatterns(string ruleJson, string content)
@@ -225,5 +251,25 @@ public class RuleExpressionBehaviourTests
         // wget is not guarded by the condition, so it reports even on a line the condition would exclude.
         Assert.Equal(new[] { "wget" },
             MatchedPatterns(scopedConditionNoExpression, "curl --tlsv1.3 http://x\nwget http://y\n"));
+    }
+
+    /// <summary>
+    ///     Both findings satisfy the expression, each through a different half of the disjunction, so both
+    ///     must be reported. Intersecting the condition captures instead reports neither.
+    /// </summary>
+    [Fact]
+    public void ConditionsSatisfiedByDifferentFindings_ReportBoth()
+    {
+        RuleSet rules = new();
+        rules.AddString(conditionsSatisfiedByDifferentFindings, "TestRules");
+        Microsoft.ApplicationInspector.RulesEngine.RuleProcessor processor =
+            new(rules, new RuleProcessorOptions { Parallel = false });
+
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        var matches = processor.AnalyzeFile("deserialize GUARD1\ndeserialize GUARD2\n",
+            new FileEntry("test.c", new MemoryStream()), info);
+
+        Assert.Equal(new[] { 1, 2 }, matches.Select(x => x.StartLocationLine).OrderBy(x => x));
     }
 }

--- a/AppInspector.Tests/RuleProcessor/RuleExpressionBehaviourTests.cs
+++ b/AppInspector.Tests/RuleProcessor/RuleExpressionBehaviourTests.cs
@@ -272,4 +272,60 @@ public class RuleExpressionBehaviourTests
 
         Assert.Equal(new[] { 1, 2 }, matches.Select(x => x.StartLocationLine).OrderBy(x => x));
     }
+
+    /// <summary>
+    ///     Regex patterns carry the pattern they belong to on the clause rather than in the label, so an author
+    ///     supplied label must survive on them exactly as it does on string patterns.
+    /// </summary>
+    [Theory]
+    [InlineData("regex")]
+    [InlineData("regexword")]
+    public void AuthorSuppliedLabel_IsHonouredOnRegexPatterns(string patternType)
+    {
+        var ruleJson = $@"[
+    {{
+        ""id"": ""SA500006"",
+        ""name"": ""Testing.Rules.RegexLabel"",
+        ""tags"": [ ""Testing.Rules.RegexLabel"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""labelled regex patterns"",
+        ""expression"": ""alpha OR beta"",
+        ""patterns"": [
+            {{ ""pattern"": ""alpha"", ""type"": ""{patternType}"", ""label"": ""alpha"", ""scopes"": [ ""code"" ] }},
+            {{ ""pattern"": ""beta"", ""type"": ""{patternType}"", ""label"": ""beta"", ""scopes"": [ ""code"" ] }}
+        ]
+    }}
+]";
+
+        Assert.Equal(new[] { "alpha", "beta" }, MatchedPatterns(ruleJson, "alpha here\nbeta there\n"));
+    }
+
+    /// <summary>
+    ///     A condition declared on a pattern is labelled in the same namespace as a rule level one, so naming it
+    ///     must work the same way in an expression.
+    /// </summary>
+    [Fact]
+    public void AuthorSuppliedLabel_IsHonouredOnPatternLevelConditions()
+    {
+        const string ruleJson = @"[
+    {
+        ""id"": ""SA500007"",
+        ""name"": ""Testing.Rules.PatternConditionLabel"",
+        ""tags"": [ ""Testing.Rules.PatternConditionLabel"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""labelled pattern level condition"",
+        ""expression"": ""p AND NOT g"",
+        ""patterns"": [
+            { ""pattern"": ""curl"", ""type"": ""substring"", ""label"": ""p"", ""scopes"": [ ""code"" ],
+              ""conditions"": [
+                { ""pattern"": { ""pattern"": ""--tlsv1.3"", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                  ""search_in"": ""same-line"", ""label"": ""g"" }
+              ] }
+        ]
+    }
+]";
+
+        Assert.Equal(new[] { "curl" }, MatchedPatterns(ruleJson, "curl http://x\n"));
+        Assert.Empty(MatchedPatterns(ruleJson, "curl --tlsv1.3 http://x\n"));
+    }
 }

--- a/AppInspector.Tests/RuleProcessor/RuleExpressionParserTests.cs
+++ b/AppInspector.Tests/RuleProcessor/RuleExpressionParserTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.ApplicationInspector.RulesEngine;
 using Xunit;
 
@@ -90,5 +91,37 @@ public class RuleExpressionParserTests
     public void MalformedExpressionsDoNotParse(string expression)
     {
         Assert.Null(RuleExpression.TryParse(expression));
+    }
+
+    /// <summary>
+    ///     Operands are folded iteratively rather than through a left leaning tree, so a long flat
+    ///     expression must evaluate without recursing once per operator and exhausting the stack.
+    ///     A left leaning tree survives 50,000 operands here but dies at 1,000,000, so the count is chosen
+    ///     to actually catch a reversion.
+    /// </summary>
+    [Fact]
+    public void LongFlatExpressionEvaluatesWithoutRecursingPerOperator()
+    {
+        const int operands = 1000000;
+
+        var expression = string.Join(" OR ", Enumerable.Repeat("b", operands - 1).Prepend("a"));
+        var parsed = RuleExpression.TryParse(expression);
+
+        Assert.NotNull(parsed);
+        Assert.True(parsed!.Evaluate(label => label == "a"));
+        Assert.False(parsed.Evaluate(label => label == "z"));
+    }
+
+    [Fact]
+    public void LongFlatConjunctionEvaluatesWithoutRecursingPerOperator()
+    {
+        const int operands = 1000000;
+
+        var expression = string.Join(" AND ", Enumerable.Repeat("a", operands));
+        var parsed = RuleExpression.TryParse(expression);
+
+        Assert.NotNull(parsed);
+        Assert.True(parsed!.Evaluate(label => label == "a"));
+        Assert.False(parsed.Evaluate(_ => false));
     }
 }

--- a/AppInspector.Tests/RuleProcessor/RuleExpressionParserTests.cs
+++ b/AppInspector.Tests/RuleProcessor/RuleExpressionParserTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+/// <summary>
+///     The per finding evaluator must agree with the rule engine's own folding rules, otherwise a rule
+///     could match while none of its findings are reported, or the reverse.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class RuleExpressionParserTests
+{
+    private static bool Eval(string expression, params string[] trueLabels)
+    {
+        var parsed = RuleExpression.TryParse(expression);
+        Assert.NotNull(parsed);
+
+        var set = new HashSet<string>(trueLabels, StringComparer.Ordinal);
+        return parsed!.Evaluate(label => set.Contains(label));
+    }
+
+    [Theory]
+    [InlineData("a", "a", true)]
+    [InlineData("a", "b", false)]
+    [InlineData("NOT a", "b", true)]
+    [InlineData("NOT a", "a", false)]
+    public void SingleTerms(string expression, string trueLabel, bool expected)
+    {
+        Assert.Equal(expected, Eval(expression, trueLabel));
+    }
+
+    /// <summary>
+    ///     `a OR b AND c` folds as `(a OR b) AND c`, so a alone is not enough.
+    /// </summary>
+    [Fact]
+    public void OperatorsFoldLeftToRightWithoutPrecedence()
+    {
+        Assert.False(Eval("a OR b AND c", "a"));
+        Assert.True(Eval("a OR b AND c", "a", "c"));
+
+        Assert.True(Eval("a OR (b AND c)", "a"));
+        Assert.False(Eval("a OR (b AND c)", "b"));
+    }
+
+    [Fact]
+    public void ParenthesesGroup()
+    {
+        Assert.True(Eval("(a AND NOT c) OR b", "a"));
+        Assert.False(Eval("(a AND NOT c) OR b", "a", "c"));
+        Assert.True(Eval("(a AND NOT c) OR b", "b", "c"));
+    }
+
+    [Fact]
+    public void NegatedConjunctionFiresOnPartialSatisfaction()
+    {
+        Assert.True(Eval("p AND NOT (a AND b)", "p", "a"));
+        Assert.True(Eval("p AND NOT (a AND b)", "p", "b"));
+        Assert.True(Eval("p AND NOT (a AND b)", "p"));
+        Assert.False(Eval("p AND NOT (a AND b)", "p", "a", "b"));
+    }
+
+    [Theory]
+    [InlineData("a XOR b", new[] { "a" }, true)]
+    [InlineData("a XOR b", new[] { "a", "b" }, false)]
+    [InlineData("a NAND b", new[] { "a", "b" }, false)]
+    [InlineData("a NAND b", new[] { "a" }, true)]
+    [InlineData("a NOR b", new string[0], true)]
+    [InlineData("a NOR b", new[] { "a" }, false)]
+    public void BooleanOperators(string expression, string[] trueLabels, bool expected)
+    {
+        Assert.Equal(expected, Eval(expression, trueLabels));
+    }
+
+    [Fact]
+    public void NestedParenthesesGroup()
+    {
+        Assert.True(Eval("((a OR b) AND c)", "a", "c"));
+        Assert.False(Eval("((a OR b) AND c)", "a"));
+    }
+
+    [Theory]
+    [InlineData("(a OR b")]
+    [InlineData("a OR")]
+    [InlineData("a b")]
+    [InlineData("")]
+    [InlineData("AND a")]
+    public void MalformedExpressionsDoNotParse(string expression)
+    {
+        Assert.Null(RuleExpression.TryParse(expression));
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/SchemaValidationTests.cs
+++ b/AppInspector.Tests/RuleProcessor/SchemaValidationTests.cs
@@ -146,17 +146,20 @@ namespace Microsoft.ApplicationInspector.Tests.RuleProcessor
 
         /// <summary>
         ///     The schema's search_in pattern must agree with what the engine accepts, otherwise a rule can
-        ///     pass schema validation and still fail verification. Lines before may be negative, lines after
-        ///     may not.
+        ///     pass schema validation and still fail verification. For finding-region the engine requires
+        ///     lines before to be 0 or negative, lines after to be 0 or positive, and rejects both being 0.
         /// </summary>
         [Theory]
         [InlineData("finding-region(-1,0)", true)]
         [InlineData("finding-region(-1, 0)", true)]
         [InlineData("finding-region(0,5)", true)]
+        [InlineData("finding-region(-3,3)", true)]
         [InlineData("only-before", true)]
         [InlineData("only-after", true)]
         [InlineData("finding-region(-1,-2)", false)]
         [InlineData("finding-region(-1, -2)", false)]
+        [InlineData("finding-region(1,5)", false)]
+        [InlineData("finding-region(0,0)", false)]
         [InlineData("nonsense", false)]
         public void SearchInValues_MatchWhatTheEngineAccepts(string searchIn, bool expectedValid)
         {

--- a/AppInspector.Tests/RuleProcessor/SchemaValidationTests.cs
+++ b/AppInspector.Tests/RuleProcessor/SchemaValidationTests.cs
@@ -144,11 +144,56 @@ namespace Microsoft.ApplicationInspector.Tests.RuleProcessor
             }
         }
 
-        [Fact]
-        public void RuleWithoutRequiredFields_FailsSchemaValidation()
+        /// <summary>
+        ///     The schema's search_in pattern must agree with what the engine accepts, otherwise a rule can
+        ///     pass schema validation and still fail verification. Lines before may be negative, lines after
+        ///     may not.
+        /// </summary>
+        [Theory]
+        [InlineData("finding-region(-1,0)", true)]
+        [InlineData("finding-region(-1, 0)", true)]
+        [InlineData("finding-region(0,5)", true)]
+        [InlineData("only-before", true)]
+        [InlineData("only-after", true)]
+        [InlineData("finding-region(-1,-2)", false)]
+        [InlineData("finding-region(-1, -2)", false)]
+        [InlineData("nonsense", false)]
+        public void SearchInValues_MatchWhatTheEngineAccepts(string searchIn, bool expectedValid)
         {
             var provider = new RuleSchemaProvider();
             var rule = new Rule
+            {
+                Id = "TEST002",
+                Name = "Test Rule",
+                Description = "A test rule",
+                Tags = new[] { "Test.Tag" },
+                Patterns = new[]
+                {
+                    new SearchPattern
+                    {
+                        Pattern = "test",
+                        PatternType = PatternType.String,
+                        Scopes = new[] { PatternScope.Code },
+                        Confidence = Confidence.High
+                    }
+                },
+                Conditions = new[]
+                {
+                    new SearchCondition
+                    {
+                        Pattern = new SearchPattern { Pattern = "guard", PatternType = PatternType.String },
+                        SearchIn = searchIn
+                    }
+                }
+            };
+
+            Assert.Equal(expectedValid, provider.ValidateRule(rule).IsValid);
+        }
+
+        [Fact]
+        public void RuleWithoutRequiredFields_FailsSchemaValidation()
+        {
+            var provider = new RuleSchemaProvider();            var rule = new Rule
             {
                 // Missing required fields: id, name, tags, patterns
                 Description = "A test rule"

--- a/AppInspector.Tests/RuleProcessor/SyncAsyncParityTests.cs
+++ b/AppInspector.Tests/RuleProcessor/SyncAsyncParityTests.cs
@@ -1,0 +1,97 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.CST.RecursiveExtractor;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+/// <summary>
+///     The synchronous and asynchronous analysis entry points are conveniences over the same engine and
+///     must agree, including for rules whose conditions filter findings.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class SyncAsyncParityTests
+{
+    private const string multipleNegatedConditions = @"[
+    {
+        ""id"": ""SA300001"",
+        ""name"": ""Testing.Rules.MultipleNegatedConditions"",
+        ""tags"": [ ""Testing.Rules.MultipleNegatedConditions"" ],
+        ""severity"": ""moderate"",
+        ""description"": ""insecure url with several exclusions"",
+        ""patterns"": [
+            { ""pattern"": ""http://"", ""type"": ""substring"", ""scopes"": [ ""code"" ] }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""xmlns="", ""type"": ""substring"", ""scopes"": [ ""code"" ] },
+                ""negate_finding"": true,
+                ""search_in"": ""finding-region(-1, 0)""
+            },
+            {
+                ""pattern"": { ""pattern"": ""http://localhost"", ""type"": ""regex"", ""scopes"": [ ""code"" ] },
+                ""negate_finding"": true,
+                ""search_in"": ""same-line""
+            }
+        ]
+    }
+]";
+
+    private const string testData = @"
+http://
+http://localhost
+xmlns=
+http://
+http://
+";
+
+    private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
+
+    private Microsoft.ApplicationInspector.RulesEngine.RuleProcessor ProcessorFor(string json)
+    {
+        RuleSet rules = new();
+        rules.AddString(json, "TestRules");
+        return new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(rules,
+            new RuleProcessorOptions { Parallel = false });
+    }
+
+    private static FileEntry EntryWith(string contents)
+    {
+        return new FileEntry("test.c", new MemoryStream(Encoding.UTF8.GetBytes(contents)));
+    }
+
+    [Fact]
+    public async Task AnalyzeFileAsync_AgreesWithAnalyzeFile()
+    {
+        var processor = ProcessorFor(multipleNegatedConditions);
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        var syncMatches = processor.AnalyzeFile(testData, EntryWith(testData), info);
+        var asyncMatches = await processor.AnalyzeFileAsync(EntryWith(testData), info);
+
+        Assert.Equal(
+            syncMatches.Select(x => x.Boundary.Index).OrderBy(x => x),
+            asyncMatches.Select(x => x.Boundary.Index).OrderBy(x => x));
+    }
+
+    /// <summary>
+    ///     Only the findings that satisfy every condition are reported. Lines 3 and 5 are each excluded by
+    ///     one of the two conditions.
+    /// </summary>
+    [Fact]
+    public async Task BothPaths_ReportOnlyFindingsPassingEveryCondition()
+    {
+        var processor = ProcessorFor(multipleNegatedConditions);
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        var syncMatches = processor.AnalyzeFile(testData, EntryWith(testData), info);
+        var asyncMatches = await processor.AnalyzeFileAsync(EntryWith(testData), info);
+
+        Assert.Equal(new[] { 2, 6 }, syncMatches.Select(x => x.StartLocationLine).OrderBy(x => x));
+        Assert.Equal(new[] { 2, 6 }, asyncMatches.Select(x => x.StartLocationLine).OrderBy(x => x));
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/SyncAsyncParityTests.cs
+++ b/AppInspector.Tests/RuleProcessor/SyncAsyncParityTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInspector.RulesEngine;
 using Microsoft.CST.RecursiveExtractor;
@@ -93,5 +94,17 @@ http://
 
         Assert.Equal(new[] { 2, 6 }, syncMatches.Select(x => x.StartLocationLine).OrderBy(x => x));
         Assert.Equal(new[] { 2, 6 }, asyncMatches.Select(x => x.StartLocationLine).OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task CancelledAnalysis_ReturnsWithoutThrowing()
+    {
+        var processor = ProcessorFor(multipleNegatedConditions);
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        Assert.Empty(await processor.AnalyzeFileAsync(EntryWith(testData), info, cts.Token));
     }
 }

--- a/AppInspector.Tests/RuleProcessor/WithinClauseMultiPatternTests.cs
+++ b/AppInspector.Tests/RuleProcessor/WithinClauseMultiPatternTests.cs
@@ -1,0 +1,101 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.CST.RecursiveExtractor;
+using Xunit;
+
+namespace AppInspector.Tests.RuleProcessor;
+
+/// <summary>
+///     Each matching pattern clause contributes its own capture, so a condition must consider all of them
+///     rather than only the first.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class WithinClauseMultiPatternTests
+{
+    private const string twoPatternsOneCondition = @"[
+    {
+        ""id"": ""SA200001"",
+        ""name"": ""Testing.Rules.TwoPatternsOneCondition"",
+        ""tags"": [ ""Testing.Rules.TwoPatternsOneCondition"" ],
+        ""severity"": ""Critical"",
+        ""description"": ""two patterns guarded by a single same-line condition"",
+        ""patterns"": [
+            { ""pattern"": ""alpha"", ""type"": ""regex"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""beta"",  ""type"": ""regex"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""guard"", ""type"": ""regex"", ""scopes"": [ ""code"" ] },
+                ""search_in"": ""same-line""
+            }
+        ]
+    }
+]";
+
+    private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
+
+    private Microsoft.ApplicationInspector.RulesEngine.RuleProcessor ProcessorFor(string json)
+    {
+        RuleSet rules = new();
+        rules.AddString(json, "TestRules");
+        return new Microsoft.ApplicationInspector.RulesEngine.RuleProcessor(rules, new RuleProcessorOptions());
+    }
+
+    /// <summary>
+    ///     The first pattern's capture fails the condition and the second pattern's capture passes it.
+    ///     The passing match must still be reported.
+    /// </summary>
+    [Fact]
+    public void ConditionSatisfiedOnlyBySecondPattern_StillReports()
+    {
+        var processor = ProcessorFor(twoPatternsOneCondition);
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        var matches = processor.AnalyzeFile("alpha\nbeta guard\n",
+            new FileEntry("test.c", new MemoryStream()), info);
+
+        var match = Assert.Single(matches);
+        Assert.Equal("beta", match.MatchingPattern?.Pattern);
+        Assert.Equal(2, match.StartLocationLine);
+    }
+
+    [Fact]
+    public void ConditionSatisfiedOnlyByFirstPattern_StillReports()
+    {
+        var processor = ProcessorFor(twoPatternsOneCondition);
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        var matches = processor.AnalyzeFile("alpha guard\nbeta\n",
+            new FileEntry("test.c", new MemoryStream()), info);
+
+        var match = Assert.Single(matches);
+        Assert.Equal("alpha", match.MatchingPattern?.Pattern);
+        Assert.Equal(1, match.StartLocationLine);
+    }
+
+    [Fact]
+    public void ConditionSatisfiedByBothPatterns_ReportsBoth()
+    {
+        var processor = ProcessorFor(twoPatternsOneCondition);
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        var matches = processor.AnalyzeFile("alpha guard\nbeta guard\n",
+            new FileEntry("test.c", new MemoryStream()), info);
+
+        Assert.Equal(2, matches.Count);
+        Assert.Contains(matches, m => m.MatchingPattern?.Pattern == "alpha");
+        Assert.Contains(matches, m => m.MatchingPattern?.Pattern == "beta");
+    }
+
+    [Fact]
+    public void ConditionSatisfiedByNeitherPattern_ReportsNothing()
+    {
+        var processor = ProcessorFor(twoPatternsOneCondition);
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        Assert.Empty(processor.AnalyzeFile("alpha\nbeta\n",
+            new FileEntry("test.c", new MemoryStream()), info));
+    }
+}

--- a/AppInspector.Tests/RuleProcessor/WithinClauseTests.cs
+++ b/AppInspector.Tests/RuleProcessor/WithinClauseTests.cs
@@ -602,6 +602,102 @@ http://
         }
     }
 
+    /// <summary>
+    ///     A rule with several patterns and a rule level condition must report the findings of every
+    ///     pattern that satisfies the condition, not just those of the first pattern.
+    /// </summary>
+    [Fact]
+    public void MultiplePatternsWithConditionReportAllMatchingPatterns()
+    {
+        const string multiPatternRule = @"[
+    {
+        ""id"": ""SA000010"",
+        ""name"": ""Testing.Rules.MultiPatternWithin"",
+        ""description"": ""multiple patterns gated by a single same-line condition"",
+        ""tags"": [ ""Testing.Rules.MultiPatternWithin"" ],
+        ""severity"": ""Critical"",
+        ""patterns"": [
+            { ""pattern"": ""alpha"", ""type"": ""regex"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""beta"", ""type"": ""regex"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] },
+            { ""pattern"": ""gamma"", ""type"": ""regex"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] }
+        ],
+        ""conditions"": [
+            {
+                ""pattern"": { ""pattern"": ""gate"", ""type"": ""regex"", ""scopes"": [ ""code"" ] },
+                ""search_in"": ""same-line""
+            }
+        ]
+    }
+]";
+
+        RuleSet rules = new(_loggerFactory);
+        rules.AddString(multiPatternRule, "multi-pattern-tests");
+        Microsoft.ApplicationInspector.RulesEngine.RuleProcessor processor = new(rules,
+            new RuleProcessorOptions { Parallel = false });
+
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        // Every pattern is on a line that satisfies the condition, so all three must be reported.
+        var allGated = processor.AnalyzeFile("alpha gate\nbeta gate\ngamma gate",
+            new FileEntry("test.c", new MemoryStream()), info);
+        Assert.Equal(new[] { "alpha", "beta", "gamma" },
+            allGated.Select(x => x.MatchingPattern?.Pattern).OrderBy(x => x));
+
+        // Only the patterns on a gated line are reported; the others are filtered out.
+        var partiallyGated = processor.AnalyzeFile("alpha gate\nbeta\ngamma gate",
+            new FileEntry("test.c", new MemoryStream()), info);
+        Assert.Equal(new[] { "alpha", "gamma" },
+            partiallyGated.Select(x => x.MatchingPattern?.Pattern).OrderBy(x => x));
+
+        // The condition is not satisfied anywhere, so nothing is reported.
+        var ungated = processor.AnalyzeFile("alpha\nbeta\ngamma",
+            new FileEntry("test.c", new MemoryStream()), info);
+        Assert.Empty(ungated);
+    }
+
+    /// <summary>
+    ///     Pattern ordering must not change which findings a multi-pattern rule reports.
+    /// </summary>
+    [Fact]
+    public void MultiplePatternsWithConditionAreOrderIndependent()
+    {
+        const string ruleTemplate = @"[
+    {{
+        ""id"": ""SA000011"",
+        ""name"": ""Testing.Rules.MultiPatternWithinOrder"",
+        ""description"": ""pattern order must not affect reported findings"",
+        ""tags"": [ ""Testing.Rules.MultiPatternWithinOrder"" ],
+        ""severity"": ""Critical"",
+        ""patterns"": [
+            {{ ""pattern"": ""{0}"", ""type"": ""regex"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] }},
+            {{ ""pattern"": ""{1}"", ""type"": ""regex"", ""confidence"": ""High"", ""scopes"": [ ""code"" ] }}
+        ],
+        ""conditions"": [
+            {{
+                ""pattern"": {{ ""pattern"": ""gate"", ""type"": ""regex"", ""scopes"": [ ""code"" ] }},
+                ""search_in"": ""same-file""
+            }}
+        ]
+    }}
+]";
+
+        Assert.True(_languages.FromFileNameOut("test.c", out var info));
+
+        string[] MatchesFor(string firstPattern, string secondPattern)
+        {
+            RuleSet rules = new(_loggerFactory);
+            rules.AddString(string.Format(ruleTemplate, firstPattern, secondPattern), "order-tests");
+            Microsoft.ApplicationInspector.RulesEngine.RuleProcessor processor = new(rules,
+                new RuleProcessorOptions { Parallel = false });
+            return processor
+                .AnalyzeFile("alpha beta gate", new FileEntry("test.c", new MemoryStream()), info)
+                .Select(x => x.MatchingPattern?.Pattern ?? string.Empty).OrderBy(x => x).ToArray();
+        }
+
+        Assert.Equal(new[] { "alpha", "beta" }, MatchesFor("alpha", "beta"));
+        Assert.Equal(new[] { "alpha", "beta" }, MatchesFor("beta", "alpha"));
+    }
+
     public WithinClauseTests()
     {
         _logger = _loggerFactory.CreateLogger<WithinClauseTests>();

--- a/AppInspector/AppInspector.Commands.csproj
+++ b/AppInspector/AppInspector.Commands.csproj
@@ -55,7 +55,7 @@
         <PackageReference Include="DotLiquid" Version="2.3.197" />
         <PackageReference Include="Glob" Version="1.1.9" />
         <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
-        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.87" />
+        <PackageReference Include="Microsoft.CST.OAT" Version="1.2.95" />
         <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.45" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
         <PackageReference Include="ShellProgressBar" Version="5.2.0" />

--- a/AppInspector/Commands/AnalyzeCommand.cs
+++ b/AppInspector/Commands/AnalyzeCommand.cs
@@ -500,8 +500,17 @@ public class AnalyzeCommand
                     }
                     else
                     {
-                        ProcessLambda();
-                        fileRecord.Status = ScanState.Analyzed;
+                        try
+                        {
+                            ProcessLambda();
+                            fileRecord.Status = ScanState.Analyzed;
+                        }
+                        catch (Exception e)
+                        {
+                            _logger.LogError("Failed to analyze {Path}. {Type}:{Message}", file.FullPath,
+                                e.GetType(), e.Message);
+                            fileRecord.Status = ScanState.Error;
+                        }
                     }
 
                     if (results.Any())
@@ -697,36 +706,47 @@ public class AnalyzeCommand
                         var ignoredTags = _options.TagsOnly ? _metaDataHelper.UniqueTags.Keys :
                             _options.MaxNumMatchesPerTag > 0 ? _metaDataHelper.UniqueTags
                                 .Where(x => x.Value < _options.MaxNumMatchesPerTag).Select(x => x.Key) : null;
-                        var results = await _rulesProcessor.AnalyzeFileAsync(file, languageInfo, cancellationToken,
-                            ignoredTags, contextLines);
-                        fileRecord.Status = ScanState.Analyzed;
 
-                        if (results.Any())
+                        // One file failing must not abandon the rest of the scan.
+                        try
                         {
-                            fileRecord.Status = ScanState.Affected;
-                            fileRecord.NumFindings = results.Count;
-                        }
+                            var results = await _rulesProcessor.AnalyzeFileAsync(file, languageInfo, cancellationToken,
+                                ignoredTags, contextLines);
+                            fileRecord.Status = ScanState.Analyzed;
 
-                        foreach (var matchRecord in results)
-                        {
-                            if (_options.TagsOnly)
+                            if (results.Any())
                             {
-                                _metaDataHelper.AddTagsFromMatchRecord(matchRecord);
+                                fileRecord.Status = ScanState.Affected;
+                                fileRecord.NumFindings = results.Count;
                             }
-                            else if (_options.MaxNumMatchesPerTag > 0)
+
+                            foreach (var matchRecord in results)
                             {
-                                if (matchRecord.Tags?.Any(x =>
-                                        _metaDataHelper.UniqueTags.TryGetValue(x, out var value) is bool foundValue &&
-                                        (!foundValue || (foundValue && value < _options.MaxNumMatchesPerTag))) ??
-                                    true)
+                                if (_options.TagsOnly)
+                                {
+                                    _metaDataHelper.AddTagsFromMatchRecord(matchRecord);
+                                }
+                                else if (_options.MaxNumMatchesPerTag > 0)
+                                {
+                                    if (matchRecord.Tags?.Any(x =>
+                                            _metaDataHelper.UniqueTags.TryGetValue(x, out var value) is bool foundValue &&
+                                            (!foundValue || (foundValue && value < _options.MaxNumMatchesPerTag))) ??
+                                        true)
+                                    {
+                                        _metaDataHelper.AddMatchRecord(matchRecord);
+                                    }
+                                }
+                                else
                                 {
                                     _metaDataHelper.AddMatchRecord(matchRecord);
                                 }
                             }
-                            else
-                            {
-                                _metaDataHelper.AddMatchRecord(matchRecord);
-                            }
+                        }
+                        catch (Exception e)
+                        {
+                            _logger.LogError("Failed to analyze {Path}. {Type}:{Message}", file.FullPath,
+                                e.GetType(), e.Message);
+                            fileRecord.Status = ScanState.Error;
                         }
                     }
                 }

--- a/AppInspector/rules/samples/README.md
+++ b/AppInspector/rules/samples/README.md
@@ -48,6 +48,7 @@ To use these samples:
 - `depends_on_tags`: Array of tags that must be present for this rule to apply
 - `overrides`: Array of rule IDs that this rule supersedes
 - `conditions`: Array of additional matching conditions
+- `expression`: Boolean expression combining pattern and condition labels (see [Expressions](#expressions))
 - `must-match`: Array of test strings that should match (for validation)
 - `must-not-match`: Array of test strings that should not match (for validation)
 - `_comment`: Optional comment for documentation
@@ -56,6 +57,7 @@ To use these samples:
 
 - `pattern`: The regex/string pattern to search for (required)
 - `type`: One of: regex (default), regexword, string, substring
+- `label`: Name for this pattern, for use in `expression` (default: the pattern's index)
 - `scopes`: Array of: code, comment, all, html
 - `confidence`: One of: high, medium, low, unspecified
 - `modifiers`: Array of regex modifiers: i, m, s, x (or full names)
@@ -67,9 +69,68 @@ To use these samples:
 ### Condition Fields
 
 - `pattern`: A pattern object (same structure as patterns array)
-- `search_in`: Where to search - "file", "finding-region(-offset,length)", "finding-only", "same-line", "same-file"
+- `search_in`: Where to search - "file", "finding-region(-offset,length)", "finding-only", "same-line", "same-file", "only-before", "only-after"
 - `negate_finding`: Boolean - if true, the finding is invalid if this condition matches
+- `label`: Name for this condition, for use in `expression` (default: the condition's clause index)
+- `applies_to_patterns`: Array of pattern labels this condition guards (default: every pattern)
 - `_comment`: Optional comment for documentation
+
+## Expressions
+
+By default a rule matches when **any** pattern matches and **every** condition holds:
+
+```text
+(pattern0 OR pattern1 OR ...) AND condition0 AND condition1 ...
+```
+
+Two optional fields let you go beyond that shape.
+
+### Scoping a condition to some patterns
+
+Give the patterns labels and list them in the condition's `applies_to_patterns`. Patterns that are not
+listed are unaffected by the condition, so they still report even when the condition excludes another
+pattern's finding.
+
+```json
+"patterns": [
+  { "pattern": "curl", "type": "substring", "label": "curl" },
+  { "pattern": "wget", "type": "substring", "label": "wget" }
+],
+"conditions": [
+  {
+    "pattern": { "pattern": "--tlsv1.3", "type": "substring" },
+    "search_in": "same-line",
+    "negate_finding": true,
+    "applies_to_patterns": [ "curl" ]
+  }
+]
+```
+
+### Writing the expression yourself
+
+Set `expression` to combine labels with `AND`, `OR`, `XOR`, `NAND`, `NOR` and `NOT`. This makes
+otherwise inexpressible rules possible, such as a disjunction of conditions or a negated conjunction:
+
+```json
+"expression": "cookie AND NOT (secure AND httponly)"
+```
+
+That rule fires when *either* required flag is missing. Writing it as two negated conditions would
+instead mean "neither flag is present", which stays silent on partially hardened code.
+
+> **Expressions have no operator precedence.** They are evaluated strictly left to right, so
+> `a OR b AND c` means `(a OR b) AND c`, **not** `a OR (b AND c)`. Always use parentheses to make
+> grouping explicit; rule verification rejects an expression that mixes operators at the same level
+> without them.
+
+Other rules for expressions:
+
+- Labels may not contain spaces or parentheses, and must be unique within the rule.
+- Attach parentheses to labels: `(a OR b)` is valid, `( a OR b )` is not.
+- Parentheses must be balanced.
+- A rule that sets `expression` must express negation with `NOT` rather than `negate_finding`.
+- A condition can only test findings produced by patterns evaluated before it, so place at least one
+  pattern label ahead of any condition label.
 
 ## Best Practices
 
@@ -79,6 +140,7 @@ To use these samples:
 4. **Use appropriate severity**: Choose severity levels that reflect the actual impact
 5. **Use specific patterns**: Make patterns as specific as possible to reduce false positives
 6. **Document with comments**: Use `_comment` fields to explain complex patterns or conditions
+7. **Parenthesise expressions**: Expressions fold left to right with no precedence, so group explicitly
 
 ## Related Documentation
 

--- a/AppInspector/rules/samples/README.md
+++ b/AppInspector/rules/samples/README.md
@@ -120,6 +120,10 @@ otherwise inexpressible rules possible, such as a disjunction of conditions or a
 That rule fires when *either* required flag is missing. Writing it as two negated conditions would
 instead mean "neither flag is present", which stays silent on partially hardened code.
 
+Every finding is judged against the expression on its own. A file containing one correctly hardened
+cookie and one missing a flag reports the second, because the first satisfying `secure AND httponly`
+says nothing about the second.
+
 > **Expressions have no operator precedence.** They are evaluated strictly left to right, so
 > `a OR b AND c` means `(a OR b) AND c`, **not** `a OR (b AND c)`. Always use parentheses to make
 > grouping explicit; rule verification rejects an expression that mixes operators at the same level
@@ -128,6 +132,7 @@ instead mean "neither flag is present", which stays silent on partially hardened
 Other rules for expressions:
 
 - Labels may not contain spaces or parentheses, and must be unique within the rule.
+- Every label named in the expression must belong to a pattern or condition in the same rule.
 - Attach parentheses to labels: `(a OR b)` is valid, `( a OR b )` is not.
 - Parentheses must be balanced.
 - A rule that sets `expression` must express negation with `NOT` rather than `negate_finding`.

--- a/AppInspector/rules/samples/README.md
+++ b/AppInspector/rules/samples/README.md
@@ -58,6 +58,7 @@ To use these samples:
 - `pattern`: The regex/string pattern to search for (required)
 - `type`: One of: regex (default), regexword, string, substring
 - `label`: Name for this pattern, for use in `expression` (default: the pattern's index)
+- `conditions`: Array of conditions that gate only this pattern's findings
 - `scopes`: Array of: code, comment, all, html
 - `confidence`: One of: high, medium, low, unspecified
 - `modifiers`: Array of regex modifiers: i, m, s, x (or full names)
@@ -69,40 +70,41 @@ To use these samples:
 ### Condition Fields
 
 - `pattern`: A pattern object (same structure as patterns array)
-- `search_in`: Where to search - "file", "finding-region(-offset,length)", "finding-only", "same-line", "same-file", "only-before", "only-after"
+- `search_in`: Where to search - "finding-region(-offset,length)", "finding-only", "same-line", "same-file", "only-before", "only-after"
 - `negate_finding`: Boolean - if true, the finding is invalid if this condition matches
 - `label`: Name for this condition, for use in `expression` (default: the condition's clause index)
-- `applies_to_patterns`: Array of pattern labels this condition guards (default: every pattern)
+- `applies_to`: Array of languages this condition applies to (default: all)
+- `does_not_apply_to`: Array of languages this condition does not apply to
 - `_comment`: Optional comment for documentation
 
 ## Expressions
 
-By default a rule matches when **any** pattern matches and **every** condition holds:
+By default a rule matches when **any** pattern matches and **every** rule level condition holds:
 
 ```text
 (pattern0 OR pattern1 OR ...) AND condition0 AND condition1 ...
 ```
 
-Two optional fields let you go beyond that shape.
+Two optional features let you go beyond that shape.
 
-### Scoping a condition to some patterns
+### Scoping a condition to one pattern
 
-Give the patterns labels and list them in the condition's `applies_to_patterns`. Patterns that are not
-listed are unaffected by the condition, so they still report even when the condition excludes another
-pattern's finding.
+Declare the condition on the pattern it guards rather than at rule level. Other patterns are unaffected,
+so they still report even when the condition excludes this pattern's finding.
 
 ```json
 "patterns": [
-  { "pattern": "curl", "type": "substring", "label": "curl" },
-  { "pattern": "wget", "type": "substring", "label": "wget" }
-],
-"conditions": [
   {
-    "pattern": { "pattern": "--tlsv1.3", "type": "substring" },
-    "search_in": "same-line",
-    "negate_finding": true,
-    "applies_to_patterns": [ "curl" ]
-  }
+    "pattern": "curl", "type": "substring", "label": "curl",
+    "conditions": [
+      {
+        "pattern": { "pattern": "--tlsv1.3", "type": "substring" },
+        "search_in": "same-line",
+        "negate_finding": true
+      }
+    ]
+  },
+  { "pattern": "wget", "type": "substring", "label": "wget" }
 ]
 ```
 

--- a/rule-schema-v1.json
+++ b/rule-schema-v1.json
@@ -240,6 +240,16 @@
             { "type": "null" }
           ],
           "description": "YAMLPath expressions for YAML matching"
+        },
+        "conditions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": { "$ref": "#/definitions/searchCondition" }
+            },
+            { "type": "null" }
+          ],
+          "description": "Pattern-specific conditions that must be met when this pattern matches"
         }
       }
     },
@@ -253,13 +263,33 @@
         },
         "search_in": {
           "type": "string",
-          "pattern": "^(file|finding-region\\(-?\\d+,\\d+\\)|finding-only|same-line|same-file)$",
+          "pattern": "^(finding-region\\(-?\\d+,\\d+\\)|finding-only|same-line|same-file|only-before|only-after)$",
           "description": "Where to search for the condition"
         },
         "negate_finding": {
           "type": "boolean",
           "default": false,
           "description": "Whether to negate the condition"
+        },
+        "applies_to": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            { "type": "null" }
+          ],
+          "description": "Languages this condition applies to"
+        },
+        "does_not_apply_to": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            { "type": "null" }
+          ],
+          "description": "Languages this condition does not apply to"
         }
       }
     }

--- a/rule-schema-v1.json
+++ b/rule-schema-v1.json
@@ -281,7 +281,7 @@
         },
         "search_in": {
           "type": "string",
-          "pattern": "^(finding-region\\(-?\\d+,\\d+\\)|finding-only|same-line|same-file|only-before|only-after)$",
+          "pattern": "^(finding-region\\(-?\\d+,\\s*\\d+\\)|finding-only|same-line|same-file|only-before|only-after)$",
           "description": "Where to search for the condition"
         },
         "negate_finding": {

--- a/rule-schema-v1.json
+++ b/rule-schema-v1.json
@@ -63,10 +63,13 @@
         },
         "expression": {
           "oneOf": [
-            { "type": "string" },
+            {
+              "type": "string",
+              "maxLength": 4096
+            },
             { "type": "null" }
           ],
-          "description": "Boolean expression over pattern and condition labels, for example '(curl AND NOT tls13) OR wget'. When omitted, any pattern may match and all conditions must hold. Evaluated left to right with no operator precedence, so grouping requires parentheses."
+          "description": "Boolean expression over pattern and condition labels, for example '(curl AND NOT tls13) OR wget'. When omitted, any pattern may match and all conditions must hold. Evaluated left to right with no operator precedence, so grouping requires parentheses. Parentheses may not nest more than 64 deep."
         },
         "applies_to": {
           "oneOf": [

--- a/rule-schema-v1.json
+++ b/rule-schema-v1.json
@@ -281,8 +281,8 @@
         },
         "search_in": {
           "type": "string",
-          "pattern": "^(finding-region\\(-?\\d+,\\s*\\d+\\)|finding-only|same-line|same-file|only-before|only-after)$",
-          "description": "Where to search for the condition"
+          "pattern": "^(finding-region\\((0,\\s*[1-9]\\d*|-\\d+,\\s*\\d+)\\)|finding-only|same-line|same-file|only-before|only-after)$",
+          "description": "Where to search for the condition. For finding-region, lines before must be 0 or negative, lines after must be 0 or positive, and they may not both be 0 (use same-line instead)."
         },
         "negate_finding": {
           "type": "boolean",

--- a/rule-schema-v1.json
+++ b/rule-schema-v1.json
@@ -3,6 +3,7 @@
   "$id": "https://raw.githubusercontent.com/microsoft/applicationinspector/main/rule-schema-v1.json",
   "title": "Application Inspector Rule Schema",
   "description": "Schema for Application Inspector rule definitions",
+  "version": "1.1.0",
   "type": "array",
   "items": {
     "$ref": "#/definitions/rule"
@@ -59,6 +60,13 @@
             { "type": "null" }
           ],
           "description": "Additional conditions that must be met"
+        },
+        "expression": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Boolean expression over pattern and condition labels, for example '(curl AND NOT tls13) OR wget'. When omitted, any pattern may match and all conditions must hold. Evaluated left to right with no operator precedence, so grouping requires parentheses."
         },
         "applies_to": {
           "oneOf": [
@@ -153,6 +161,16 @@
         "pattern": {
           "type": "string",
           "description": "The pattern to search for"
+        },
+        "label": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[^\\s()]+$"
+            },
+            { "type": "null" }
+          ],
+          "description": "Name for this pattern for use in the rule's expression. Defaults to the pattern index. May not contain spaces or parentheses."
         },
         "type": {
           "oneOf": [
@@ -270,6 +288,16 @@
           "type": "boolean",
           "default": false,
           "description": "Whether to negate the condition"
+        },
+        "label": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[^\\s()]+$"
+            },
+            { "type": "null" }
+          ],
+          "description": "Name for this condition for use in the rule's expression. Defaults to the condition's clause index. May not contain spaces or parentheses."
         },
         "applies_to": {
           "oneOf": [

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.9",
+  "version": "1.10",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Adds boolean expression support to the rules engine, so a rule can be described as an explicit expression over named patterns and conditions instead of the single hardcoded `(P0 OR P1 ...) AND C0 AND C1 ...` shape. Along the way it fixes several bugs in the surrounding code.

Closes #524.
**Supersedes #650** — that branch is now the base of this one, so #650 can be closed unmerged. #652 was merged into #650 and comes along with it.

## Relationship to #650

#650 fixed `WithinOperation` returning after its first capture, and added pattern level conditions. This branch needed the same code, and the two fixes overlapped enough that landing them separately would have meant resolving the same conflicts twice. So #650's two commits are replayed onto `main` first and this work is rebased on top, giving one reviewable history.

Where the two designs collided, the rule was: **#650 wins on condition mechanics, this PR wins on expressions.**

- #650's `GovernedMatches` fix is kept over the deduplication approach originally used here; that commit is now tests only.
- #650's `pattern.conditions` is kept for scoping a condition to one pattern. The `applies_to_patterns` field originally proposed here is **dropped entirely** — the two solved the same problem and `pattern.conditions` needs no new label resolution. Its tests were rewritten against nested conditions, so the capability stays covered.
- `FilterCaptures` combines both: #650's gate semantics inside the sync/async unification from this branch.
- The schema's `search_in` combines both: #650 correctly removed `file` (never handled by `GenerateCondition`), and the finding-region constraints from this branch sit on top.

## Reviewing this

It is a big diff, so the commits are ordered to be read in sequence and each one builds and passes on its own.

**Commits 1, 2, 4, 7 and 12 are standalone bug fixes** with no dependency on the feature.

| # | Commit | Kind |
|---|---|---|
| 1 | Fix conditions dropping all but the first pattern's findings | **bug fix** (#650) |
| 2 | Make pattern-level conditions actually gate their pattern (#652) | **bug fix** (#650) |
| 3 | Add expression and label to the rule model | model + schema |
| 4 | Report the pattern that actually matched for string patterns | **bug fix** |
| 5 | Pin the expression semantics the rules engine depends on | tests only |
| 6 | Add regression tests for conditions across multiple pattern captures | tests only |
| 7 | Unify the synchronous and asynchronous analysis paths | **bug fix** |
| 8 | Translate author supplied labels and expressions | feature |
| 9 | Validate rule expressions and labels | feature |
| 10 | Report the findings that satisfy the rule expression | feature |
| 11 | Document rule expressions | docs |
| 12 | Apply rule overrides consistently in both analysis paths | **bug fix** |
| 13 | Share one implementation between the sync and async analysis paths | refactor |
| 14 | Take OAT 1.2.95 for the parenthesis balance fix | dependency |
| 15 | Bump minor version for the rules engine work | release |
| 16–26 | Review response: schema alignment, nesting bounds, defect fixes, hardening, docs | review |

The highest risk commit is **10**, because it changes which findings get reported. The legacy path is untouched when a rule has no `expression`.

## What rule authors get

Two independent additions, either usable alone.

**`conditions` on a pattern** (from #650) scopes a condition to the pattern it guards, so guarding one pattern no longer requires splitting the rule in two:

```json
"patterns": [
  {
    "pattern": "curl", "type": "substring", "label": "curl",
    "conditions": [
      { "pattern": { "pattern": "--tlsv1.3", "type": "substring" },
        "search_in": "same-line", "negate_finding": true }
    ]
  },
  { "pattern": "wget", "type": "substring", "label": "wget" }
]
```

**`expression`** combines labels with `AND`, `OR`, `XOR`, `NAND`, `NOR`, `NOT`:

```json
"expression": "cookie AND NOT (secure AND httponly)"
```

That one fires when *either* required flag is missing. Expressed as two negated conditions it would instead mean "neither flag is present", which stays silent on partially hardened code, the common real world defect.

## Bugs fixed

From #650:

1. **Multi pattern rules with a condition reported only the first pattern's findings.** `WithinOperation` returned from inside its loop over captures. Seven shipped rules are under reporting today: `AI016300`, `AI036000`, `AI036622`, `AI038210`, `AI038500`, `AI080001`, `AI084000`.
2. **Pattern level conditions did not gate their pattern** (#652).

From this branch:

3. **String and substring patterns always reported pattern index 0.** Each becomes its own clause holding a single element of `Data`, so deriving the index from the position in that list always gave 0. `MatchingPattern` and confidence filtering resolved against the wrong pattern.
4. **The async path over reported.** `AnalyzeFileAsync` took the union of within clause captures instead of intersecting them, so it emitted duplicates and findings the conditions should have excluded. It also never populated `StartLocationColumn`/`EndLocationColumn` and had an off by one bounds check.
5. **Overrides used different overlap rules per path.** Sync required only that the overridden finding *start* inside the overriding one; async required containment. Settled on containment, which is what the sync code's own comment described.
6. **One unreadable file abandoned the entire scan.** Two per file paths had no exception handling, so a single failure propagated out of the scan loop. Each file now fails to its own `ScanState.Error` record and the scan continues.

Commit 13 then removes the duplicated scan loop that allowed 4 and 5 to happen, so both entry points share one implementation.

## Behaviour changes to be aware of

Existing rule JSON is unchanged and continues to validate, but **results are not bit identical**, because the bug fixes correct which findings are reported:

- multi pattern rules with conditions no longer drop findings, affecting the seven default rules listed above (more results)
- string pattern matches now resolve to the pattern that actually matched
- the async path no longer over reports (fewer results)
- overrides now require containment (previously suppressed findings may return)

No rule shipped with Application Inspector uses `overrides`, so default scan output is unaffected by that last one. Anyone baselining scan output should expect a diff. This is why the version goes to 1.10 rather than a patch; the new public API on the rules engine is additive and independently forces a minor.

Schema stays `rule-schema-v1.json` since every addition is backward compatible; it carries a `"version": "1.1.0"` annotation.

## Verification

- 491 tests pass on net9.0 and net10.0; full solution builds clean including netstandard2.1
- `verifyrules` reports zero failures across the shipped rule set
- every one of the 26 commits was independently built and tested in a clean worktree, growing 354 to 491 tests
- each bug fix was confirmed by reverting the fix and watching the new test fail
- a golden test asserts the generated expression string is byte for byte unchanged for every shipped rule
- `OatExpressionSemanticsTests` pins the engine behaviour the translation relies on: no operator precedence, parentheses group and inherit accumulated captures, duplicate labels evaluate false

## Notes for the reviewer

- Expressions have **no operator precedence** and fold strictly left to right, so `a OR b AND c` means `(a OR b) AND c`. Verification rejects an expression that mixes operators at one level without parentheses, which should stop that being a footgun in practice.
- Evaluating an unbalanced expression still throws even on OAT 1.2.95, which only fixed the *validation* gap (microsoft/OAT#393). Verification is therefore the gate that keeps a malformed rule away from the analyzer, and `RulesVerifier` keeps its own balance check.
- Per-finding expression evaluation earns its place on one case: sibling conditions each satisfied by a *different* finding, e.g. `p AND (g1 OR g2)` where `g1` and `g2` match on separate lines. OAT's accumulated captures report nothing there. `ConditionsSatisfiedByDifferentFindings_ReportBoth` is the single test that fails if that filtering is removed.
- **A rule carries two expressions.** The engine gets a plain disjunction of every clause, which only decides whether a file is worth examining; the authored expression stays on the rule and decides, per finding, what is reported. Handing the authored expression to the engine instead evaluates `NOT` across the whole file, so one compliant finding suppresses vulnerable siblings — `NegationIsJudgedPerFinding_NotAcrossTheFile` covers this. A consequence is that the engine never sees the authored operands, so verification checks them against the rule's own labels rather than relying on OAT.
- **Still outstanding:** DevSkim has not been built against this. Worth checking its rule set verifies unchanged, and whether any of its rules use `overrides`.

