### PR TITLE
Address API review findings and update expression generation

### DIFF
--- a/AppInspector.RulesEngine/RuleProcessor.cs
+++ b/AppInspector.RulesEngine/RuleProcessor.cs
@@ -163,16 +163,8 @@ public class RuleProcessor
         {
             if (cancellationToken?.IsCancellationRequested is true)
             {
-                var patternIndex = match.Item1;
-                var boundary = match.Item2;
-                // Universal rules can reach build files incidentally, so suppress their non-Metadata tags by default.
-                if (!_opts.AllowAllTagsInBuildFiles &&
-                    languageInfo.Type == LanguageInfo.LangFileType.Build &&
-                    oatRule.AppInspectorRule.IsUniversal &&
-                    (oatRule.AppInspectorRule.Tags?.Any(v => !v.Contains("Metadata")) ?? false))
-                {
-                    continue;
-                }
+                return resultsList;
+            }
 
             if (ruleCapture.Rule is not ConvertedOatRule oatRule)
             {
@@ -376,90 +368,7 @@ public class RuleProcessor
         var contents = string.Empty;
         try
         {
-            // If we had a WithinClause we only want the captures that passed the within filter.
-            var filteredCaptures = ruleCapture.Captures.Any(x => x.Clause is WithinClause)
-                ? ruleCapture.Captures.Where(x => x.Clause is WithinClause)
-                : ruleCapture.Captures;
-            if (cancellationToken?.IsCancellationRequested is true)
-            {
-                return resultsList;
-            }
-
-            foreach (var cap in filteredCaptures) resultsList.AddRange(ProcessBoundary(cap));
-
-            List<MatchRecord> ProcessBoundary(ClauseCapture cap)
-            {
-                List<MatchRecord> newMatches = new(); //matches for this rule clause only
-
-                if (cap is TypedClauseCapture<List<(int, Boundary)>> tcc)
-                {
-                    if (ruleCapture.Rule is ConvertedOatRule oatRule)
-                    {
-                        if (tcc.Result is { } captureResults)
-                        {
-                            foreach (var match in captureResults)
-                            {
-                                var patternIndex = match.Item1;
-                                var boundary = match.Item2;
-
-                                // Universal rules can reach build files incidentally, so suppress their non-Metadata tags by default.
-                                if (!_opts.AllowAllTagsInBuildFiles &&
-                                    languageInfo.Type == LanguageInfo.LangFileType.Build &&
-                                    oatRule.AppInspectorRule.IsUniversal &&
-                                    (oatRule.AppInspectorRule.Tags?.Any(v => !v.Contains("Metadata")) ?? false))
-                                {
-                                    continue;
-                                }
-
-                                if (patternIndex < 0 || patternIndex > oatRule.AppInspectorRule.Patterns.Length)
-                                {
-                                    _logger.LogError("Index out of range for patterns for rule: {ruleName}",
-                                        oatRule.AppInspectorRule.Name);
-                                    continue;
-                                }
-
-                                if (!_opts.ConfidenceFilter.HasFlag(oatRule.AppInspectorRule.Patterns[patternIndex]
-                                        .Confidence))
-                                {
-                                    continue;
-                                }
-
-                                var startLocation = textContainer.GetLocation(boundary.Index);
-                                var endLocation = textContainer.GetLocation(boundary.Index + boundary.Length);
-                                MatchRecord newMatch = new(oatRule.AppInspectorRule)
-                                {
-                                    FileName = fileEntry.FullPath,
-                                    FullTextContainer = textContainer,
-                                    LanguageInfo = languageInfo,
-                                    Boundary = boundary,
-                                    StartLocationLine = startLocation.Line,
-                                    EndLocationLine =
-                                        endLocation.Line != 0
-                                            ? endLocation.Line
-                                            : startLocation.Line + 1, //match is on last line
-                                    MatchingPattern = oatRule.AppInspectorRule.Patterns[patternIndex],
-                                    Excerpt = numLinesContext > 0
-                                        ? ExtractExcerpt(textContainer, startLocation, endLocation, boundary, numLinesContext)
-                                        : string.Empty,
-                                    Sample = numLinesContext > -1
-                                        ? ExtractTextSample(textContainer.FullContent, boundary.Index, boundary.Length)
-                                        : string.Empty
-                                };
-
-                                if (oatRule.AppInspectorRule.Tags?.Contains("Dependency.SourceInclude") ?? false)
-                                {
-                                    newMatch.Sample = ExtractDependency(newMatch.FullTextContainer,
-                                        newMatch.Boundary.Index, newMatch.Pattern, newMatch.LanguageInfo.Name);
-                                }
-
-                                newMatches.Add(newMatch);
-                            }
-                        }
-                    }
-                }
-
-                return newMatches;
-            }
+            contents = await sr.ReadToEndAsync().ConfigureAwait(false);
         }
         catch (Exception e)
         {

--- a/AppInspector.Tests/Languages/LanguagesTests.cs
+++ b/AppInspector.Tests/Languages/LanguagesTests.cs
@@ -63,6 +63,16 @@ public class LanguagesTests
         Assert.Equal("package.json", language.Name);
     }
 
+    [Theory]
+    [InlineData("Application.kt")]
+    [InlineData("build.gradle.kts")]
+    public void DetectKotlinExtensions(string filename)
+    {
+        Microsoft.ApplicationInspector.RulesEngine.Languages languages = new(_factory);
+        Assert.True(languages.FromFileNameOut(filename, out var language));
+        Assert.Equal("kotlin", language.Name);
+    }
+
     [InlineData(null, false)] // No way to determine language
     [InlineData("", false)] // No way to determine language
     [InlineData("validfilename.json", false)] //This test uses the .z test comments and languages from this file.

--- a/AppInspector.Tests/RuleProcessor/ExpressionGenerationTests.cs
+++ b/AppInspector.Tests/RuleProcessor/ExpressionGenerationTests.cs
@@ -16,10 +16,28 @@ public class ExpressionGenerationTests
 {
     private readonly Microsoft.ApplicationInspector.RulesEngine.Languages _languages = new();
 
-    private static string GeneratedExpression(int patternClauses, int conditionClauses)
+    private static string GeneratedExpression(ConvertedOatRule oatRule)
     {
-        var expression = "(" + string.Join(" OR ", Enumerable.Range(0, patternClauses)) + ")";
-        for (var i = 0; i < conditionClauses; i++) expression += $" AND c{i}";
+        var patternClauses = oatRule.Clauses.Count(x => x is not WithinClause);
+        var conditions = oatRule.Clauses.OfType<WithinClause>().ToList();
+        var patternExpressions = Enumerable.Range(0, patternClauses)
+            .Select(i =>
+            {
+                var expression = i.ToString();
+                var patternConditions = conditions.Where(x => x.OwnerPatternIndex == i).Select(x => x.Label);
+                foreach (var label in patternConditions) expression += $" AND {label}";
+                return expression.Contains(" AND ") ? $"({expression})" : expression;
+            })
+            .ToList();
+
+        var patternBody = string.Join(" OR ", patternExpressions);
+        var expression = patternBody.StartsWith('(') ? patternBody : $"({patternBody})";
+
+        foreach (var label in conditions.Where(x => x.OwnerPatternIndex is null).Select(x => x.Label))
+        {
+            expression += $" AND {label}";
+        }
+
         return expression;
     }
 
@@ -47,7 +65,7 @@ public class ExpressionGenerationTests
             // Every shipped pattern must produce a clause, otherwise indices and labels would shift.
             Assert.Equal(oatRule.AppInspectorRule.Patterns.Length, patternClauses);
 
-            var expected = GeneratedExpression(patternClauses, conditionClauses);
+            var expected = GeneratedExpression(oatRule);
 
             if (oatRule.Expression != expected)
             {

--- a/AppInspector/rules/default/webapp/api.json
+++ b/AppInspector/rules/default/webapp/api.json
@@ -203,15 +203,6 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "rest_framework",
-        "type": "regexword",
-        "scopes": [
-          "code"
-        ],
-        "confidence": "high",
-        "_comment": "Django REST Framework import"
-      },
-      {
         "pattern": "@api_view(",
         "type": "substring",
         "scopes": [
@@ -219,14 +210,25 @@
         ],
         "confidence": "high",
         "_comment": "Django REST Framework function view decorator"
+      },
+      {
+        "pattern": "from\\s+rest_framework(?:\\.\\w+)*\\s+import\\s+[^\\r\\n]*(APIView|ViewSet|ModelViewSet|ReadOnlyModelViewSet|GenericViewSet|DefaultRouter|SimpleRouter)\\b|class\\s+\\w+\\([^\\r\\n)]*(APIView|ViewSet|ModelViewSet|ReadOnlyModelViewSet|GenericViewSet)[^\\r\\n)]*\\)",
+        "type": "regex",
+        "scopes": [
+          "code"
+        ],
+        "confidence": "high",
+        "_comment": "Django REST Framework API views, viewsets, and router registrations"
       }
     ],
     "must-match": [
-      "from rest_framework import serializers",
-      "@api_view(['GET', 'POST'])"
+      "@api_view(['GET', 'POST'])",
+      "from rest_framework.views import APIView\n\nclass UserView(APIView):\n    pass",
+      "from rest_framework.routers import DefaultRouter\n\nrouter = DefaultRouter()\nrouter.register(r'users', UserViewSet)"
     ],
     "must-not-match": [
-      "from django.db import models"
+      "from django.db import models",
+      "from rest_framework import serializers\n\nclass UserSerializer(serializers.Serializer):\n    name = serializers.CharField()"
     ]
   },
   {
@@ -483,17 +485,8 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "@nestjs/common",
-        "type": "substring",
-        "scopes": [
-          "code"
-        ],
-        "confidence": "high",
-        "_comment": "NestJS import"
-      },
-      {
-        "pattern": "@Controller(",
-        "type": "substring",
+        "pattern": "@Controller\\b",
+        "type": "regex",
         "scopes": [
           "code"
         ],
@@ -502,11 +495,12 @@
       }
     ],
     "must-match": [
-      "import { Controller, Get } from '@nestjs/common';",
-      "@Controller('cats')"
+      "import { Controller, Get } from '@nestjs/common';\n\n@Controller('cats')\nexport class CatsController {\n  @Get()\n  findAll() { return []; }\n}",
+      "@Controller()\nexport class HealthController {}"
     ],
     "must-not-match": [
-      "const controller = new AbortController();"
+      "const controller = new AbortController();",
+      "import { Injectable, OnModuleInit } from '@nestjs/common';\n\n@Injectable()\nexport class CatsService implements OnModuleInit {\n  onModuleInit() {}\n}"
     ]
   },
   {
@@ -896,16 +890,31 @@
           "code"
         ],
         "confidence": "high",
-        "_comment": "Spring request mapping annotation"
+        "_comment": "Spring request mapping annotation",
+        "conditions": [
+          {
+            "pattern": {
+              "pattern": "@(RestController|Controller)\\b",
+              "type": "regex",
+              "scopes": [
+                "code"
+              ]
+            },
+            "search_in": "same-file",
+            "negate_finding": false
+          }
+        ]
       }
     ],
     "must-match": [
       "@RestController",
-      "@GetMapping(\"/users\")"
+      "@RestController\nclass UserController {\n    @GetMapping(\"/users\")\n    List<User> users() { return List.of(); }\n}",
+      "@Controller\nclass PageController {\n    @RequestMapping(\"/home\")\n    String home() { return \"home\"; }\n}"
     ],
     "must-not-match": [
       "import java.util.Map;",
-      "@Component"
+      "@Component",
+      "import org.springframework.cloud.openfeign.FeignClient;\n\n@FeignClient(name = \"users\")\ninterface UserClient {\n    @GetMapping(\"/users\")\n    List<User> users();\n}"
     ]
   },
   {
@@ -922,22 +931,25 @@
     "severity": "moderate",
     "patterns": [
       {
-        "pattern": "(javax|jakarta)\\.ws\\.rs\\.(ApplicationPath|Path|GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|Produces|Consumes|BeanParam|PathParam|QueryParam|FormParam|HeaderParam|Context)\\b|ResourceConfig\\s*\\(",
+        "pattern": "@(ApplicationPath|Path)\\s*\\([^\\r\\n)]*\\)(?:\\s*@[A-Za-z_][\\w.]*\\s*(?:\\([^\\r\\n)]*\\))?){0,8}\\s*(?:(?:public|final|abstract|open|data)\\s+)*class\\s+\\w+|ResourceConfig\\s*\\(",
         "type": "regex",
         "scopes": [
           "code"
         ],
         "confidence": "high",
-        "_comment": "JAX-RS import"
+        "_comment": "JAX-RS resource classes or server resource registration"
       }
     ],
     "must-match": [
-      "import javax.ws.rs.GET;",
-      "import jakarta.ws.rs.Path;"
+      "import javax.ws.rs.GET;\nimport javax.ws.rs.Path;\n\n@Path(\"/users\")\npublic class UsersResource {\n    @GET\n    public String users() { return \"[]\"; }\n}",
+      "import jakarta.ws.rs.ApplicationPath;\n\n@ApplicationPath(\"/api\")\npublic class ApiApplication extends Application {}",
+      "import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;\nimport jakarta.ws.rs.GET;\nimport jakarta.ws.rs.Path;\n\n@RegisterRestClient\n@Path(\"/remote\")\npublic interface RemoteClient {\n    @GET\n    String get();\n}\n\n@Path(\"/local\")\npublic class LocalResource {\n    @GET\n    public String get() { return \"ok\"; }\n}"
     ],
     "must-not-match": [
       "import java.nio.file.Path;",
-      "import jakarta.ws.rs.client.Client;"
+      "import jakarta.ws.rs.client.Client;",
+      "import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;\nimport jakarta.ws.rs.GET;\nimport jakarta.ws.rs.Path;\n\n@RegisterRestClient\n@Path(\"/remote\")\npublic interface RemoteClient {\n    @GET\n    String get();\n}",
+      "import org.eclipse.microprofile.rest.client.RestClientBuilder;\nimport jakarta.ws.rs.GET;\nimport jakarta.ws.rs.Path;\n\n@Path(\"/remote\")\npublic interface RemoteClient {\n    @GET\n    String get();\n}\n\nclass Caller {\n    RemoteClient client = RestClientBuilder.newBuilder().build(RemoteClient.class);\n}"
     ]
   },
   {


### PR DESCRIPTION
This pull request includes significant improvements to language detection, rule processing, and the accuracy of API detection rules for several web frameworks. The changes enhance test coverage, refine rule logic, and update detection patterns and test cases to reduce false positives and improve precision.

**Language Detection and Testing Enhancements:**

* Added tests to ensure Kotlin files with `.kt` and `.kts` extensions are correctly detected as Kotlin, improving language identification reliability.

**Rule Processing and Expression Generation Improvements:**

* Refactored the rule expression generation logic in `ExpressionGenerationTests` to more accurately reflect clause relationships, especially for complex rules with conditions like `WithinClause`. This ensures generated expressions match the actual rule structure. [[1]](diffhunk://#diff-63113a983f07e62d3d4d910b2c2c8638d0560c6037e8ef642c8771f660bd76feL19-R40) [[2]](diffhunk://#diff-63113a983f07e62d3d4d910b2c2c8638d0560c6037e8ef642c8771f660bd76feL50-R68)
* Simplified and corrected logic in `RuleProcessor.cs` by removing redundant or unreachable code paths related to cancellation and tag filtering, making the codebase cleaner and more maintainable. [[1]](diffhunk://#diff-6cd0b3866d439401ed54f62916e1bd36b03d951bc6085302db215a38eb0d7b5bL166-R166) [[2]](diffhunk://#diff-6cd0b3866d439401ed54f62916e1bd36b03d951bc6085302db215a38eb0d7b5bL379-R371)

**API Detection Rule Updates (webapp/api.json):**

* **Django REST Framework:** Updated patterns to more accurately detect API views, viewsets, and router registrations, and expanded test cases to reduce false positives from unrelated imports.
* **NestJS:** Improved detection by replacing substring patterns with a regex for `@Controller` and refined test cases to distinguish between actual controllers and unrelated uses. [[1]](diffhunk://#diff-578dcf2bdaac79a2af6dea395a5a9fdb1184c265d5d4b661bf2d0162158a84a8L486-R489) [[2]](diffhunk://#diff-578dcf2bdaac79a2af6dea395a5a9fdb1184c265d5d4b661bf2d0162158a84a8L505-R503)
* **Spring:** Added a condition to require the presence of `@RestController` or `@Controller` for request mapping detection, and expanded test cases to avoid false positives with Feign clients.
* **JAX-RS:** Refined the detection pattern to target resource classes and server resource registration, with improved test coverage to distinguish between API resources and unrelated code.